### PR TITLE
[feat] Move コントラクトのコアモデルを実装

### DIFF
--- a/contracts/sources/events.move
+++ b/contracts/sources/events.move
@@ -1,0 +1,26 @@
+#[allow(unused_field)]
+module one_portrait::events;
+
+public struct SubmittedEvent has copy, drop {
+    unit_id: ID,
+    athlete_id: u16,
+    submitter: address,
+    walrus_blob_id: vector<u8>,
+    submission_no: u64,
+    submitted_count: u64,
+    max_slots: u64,
+}
+
+public struct UnitFilledEvent has copy, drop {
+    unit_id: ID,
+    athlete_id: u16,
+    filled_count: u64,
+    max_slots: u64,
+}
+
+public struct MosaicReadyEvent has copy, drop {
+    unit_id: ID,
+    athlete_id: u16,
+    master_id: ID,
+    mosaic_walrus_blob_id: vector<u8>,
+}

--- a/contracts/sources/events.move
+++ b/contracts/sources/events.move
@@ -47,6 +47,20 @@ public(package) fun emit_submitted(
     });
 }
 
+public(package) fun emit_unit_filled(
+    unit_id: ID,
+    athlete_id: u16,
+    filled_count: u64,
+    max_slots: u64,
+) {
+    event::emit(UnitFilledEvent {
+        unit_id,
+        athlete_id,
+        filled_count,
+        max_slots,
+    });
+}
+
 #[test_only]
 public fun submitted_event_unit_id_for_testing(event: &SubmittedEvent): ID {
     event.unit_id
@@ -79,5 +93,25 @@ public fun submitted_event_submitted_count_for_testing(event: &SubmittedEvent): 
 
 #[test_only]
 public fun submitted_event_max_slots_for_testing(event: &SubmittedEvent): u64 {
+    event.max_slots
+}
+
+#[test_only]
+public fun unit_filled_event_unit_id_for_testing(event: &UnitFilledEvent): ID {
+    event.unit_id
+}
+
+#[test_only]
+public fun unit_filled_event_athlete_id_for_testing(event: &UnitFilledEvent): u16 {
+    event.athlete_id
+}
+
+#[test_only]
+public fun unit_filled_event_filled_count_for_testing(event: &UnitFilledEvent): u64 {
+    event.filled_count
+}
+
+#[test_only]
+public fun unit_filled_event_max_slots_for_testing(event: &UnitFilledEvent): u64 {
     event.max_slots
 }

--- a/contracts/sources/events.move
+++ b/contracts/sources/events.move
@@ -1,6 +1,8 @@
 #[allow(unused_field)]
 module one_portrait::events;
 
+use sui::event;
+
 public struct SubmittedEvent has copy, drop {
     unit_id: ID,
     athlete_id: u16,
@@ -23,4 +25,59 @@ public struct MosaicReadyEvent has copy, drop {
     athlete_id: u16,
     master_id: ID,
     mosaic_walrus_blob_id: vector<u8>,
+}
+
+public(package) fun emit_submitted(
+    unit_id: ID,
+    athlete_id: u16,
+    submitter: address,
+    walrus_blob_id: vector<u8>,
+    submission_no: u64,
+    submitted_count: u64,
+    max_slots: u64,
+) {
+    event::emit(SubmittedEvent {
+        unit_id,
+        athlete_id,
+        submitter,
+        walrus_blob_id,
+        submission_no,
+        submitted_count,
+        max_slots,
+    });
+}
+
+#[test_only]
+public fun submitted_event_unit_id_for_testing(event: &SubmittedEvent): ID {
+    event.unit_id
+}
+
+#[test_only]
+public fun submitted_event_athlete_id_for_testing(event: &SubmittedEvent): u16 {
+    event.athlete_id
+}
+
+#[test_only]
+public fun submitted_event_submitter_for_testing(event: &SubmittedEvent): address {
+    event.submitter
+}
+
+#[test_only]
+public fun submitted_event_walrus_blob_id_for_testing(event: &SubmittedEvent): vector<u8> {
+    copy event.walrus_blob_id
+}
+
+#[test_only]
+public fun submitted_event_submission_no_for_testing(event: &SubmittedEvent): u64 {
+    event.submission_no
+}
+
+#[test_only]
+public fun submitted_event_submitted_count_for_testing(event: &SubmittedEvent): u64 {
+    event.submitted_count
+}
+
+#[test_only]
+public fun submitted_event_max_slots_for_testing(event: &SubmittedEvent): u64 {
+    event.max_slots
 }

--- a/contracts/sources/events.move
+++ b/contracts/sources/events.move
@@ -61,6 +61,20 @@ public(package) fun emit_unit_filled(
     });
 }
 
+public(package) fun emit_mosaic_ready(
+    unit_id: ID,
+    athlete_id: u16,
+    master_id: ID,
+    mosaic_walrus_blob_id: vector<u8>,
+) {
+    event::emit(MosaicReadyEvent {
+        unit_id,
+        athlete_id,
+        master_id,
+        mosaic_walrus_blob_id,
+    });
+}
+
 #[test_only]
 public fun submitted_event_unit_id_for_testing(event: &SubmittedEvent): ID {
     event.unit_id
@@ -114,4 +128,26 @@ public fun unit_filled_event_filled_count_for_testing(event: &UnitFilledEvent): 
 #[test_only]
 public fun unit_filled_event_max_slots_for_testing(event: &UnitFilledEvent): u64 {
     event.max_slots
+}
+
+#[test_only]
+public fun mosaic_ready_event_unit_id_for_testing(event: &MosaicReadyEvent): ID {
+    event.unit_id
+}
+
+#[test_only]
+public fun mosaic_ready_event_athlete_id_for_testing(event: &MosaicReadyEvent): u16 {
+    event.athlete_id
+}
+
+#[test_only]
+public fun mosaic_ready_event_master_id_for_testing(event: &MosaicReadyEvent): ID {
+    event.master_id
+}
+
+#[test_only]
+public fun mosaic_ready_event_mosaic_walrus_blob_id_for_testing(
+    event: &MosaicReadyEvent,
+): vector<u8> {
+    copy event.mosaic_walrus_blob_id
 }

--- a/contracts/sources/kakera.move
+++ b/contracts/sources/kakera.move
@@ -1,0 +1,12 @@
+#[allow(unused_field)]
+module one_portrait::kakera;
+
+public struct Kakera has key {
+    id: UID,
+    unit_id: ID,
+    athlete_id: u16,
+    submitter: address,
+    walrus_blob_id: vector<u8>,
+    submission_no: u64,
+    minted_at_ms: u64,
+}

--- a/contracts/sources/kakera.move
+++ b/contracts/sources/kakera.move
@@ -10,3 +10,56 @@ public struct Kakera has key {
     submission_no: u64,
     minted_at_ms: u64,
 }
+
+public(package) fun mint_and_transfer(
+    unit_id: ID,
+    athlete_id: u16,
+    submitter: address,
+    walrus_blob_id: vector<u8>,
+    submission_no: u64,
+    minted_at_ms: u64,
+    ctx: &mut TxContext,
+) {
+    transfer::transfer(
+        Kakera {
+            id: object::new(ctx),
+            unit_id,
+            athlete_id,
+            submitter,
+            walrus_blob_id,
+            submission_no,
+            minted_at_ms,
+        },
+        submitter,
+    );
+}
+
+#[test_only]
+public fun unit_id_for_testing(kakera: &Kakera): ID {
+    kakera.unit_id
+}
+
+#[test_only]
+public fun athlete_id_for_testing(kakera: &Kakera): u16 {
+    kakera.athlete_id
+}
+
+#[test_only]
+public fun submitter_for_testing(kakera: &Kakera): address {
+    kakera.submitter
+}
+
+#[test_only]
+public fun walrus_blob_id_for_testing(kakera: &Kakera): vector<u8> {
+    copy kakera.walrus_blob_id
+}
+
+#[test_only]
+public fun submission_no_for_testing(kakera: &Kakera): u64 {
+    kakera.submission_no
+}
+
+#[test_only]
+public fun minted_at_ms_for_testing(kakera: &Kakera): u64 {
+    kakera.minted_at_ms
+}

--- a/contracts/sources/master_portrait.move
+++ b/contracts/sources/master_portrait.move
@@ -1,7 +1,7 @@
 #[allow(unused_field)]
 module one_portrait::master_portrait;
 
-use sui::table::Table;
+use sui::table::{Self as table, Table};
 
 public struct MasterPortrait has key, store {
     id: UID,
@@ -16,4 +16,125 @@ public struct Placement has copy, drop, store {
     y: u16,
     submitter: address,
     submission_no: u64,
+}
+
+public struct PlacementInput has copy, drop, store {
+    blob_id: vector<u8>,
+    x: u16,
+    y: u16,
+    submitter: address,
+    submission_no: u64,
+}
+
+public fun new_placement_input(
+    blob_id: vector<u8>,
+    x: u16,
+    y: u16,
+    submitter: address,
+    submission_no: u64,
+): PlacementInput {
+    PlacementInput {
+        blob_id,
+        x,
+        y,
+        submitter,
+        submission_no,
+    }
+}
+
+public(package) fun create(
+    unit_id: ID,
+    athlete_id: u16,
+    mosaic_walrus_blob_id: vector<u8>,
+    mut placement_inputs: vector<PlacementInput>,
+    ctx: &mut TxContext,
+): MasterPortrait {
+    let mut placements = table::new(ctx);
+    while (!vector::is_empty(&placement_inputs)) {
+        let PlacementInput {
+            blob_id,
+            x,
+            y,
+            submitter,
+            submission_no,
+        } = vector::pop_back(&mut placement_inputs);
+        table::add(
+            &mut placements,
+            blob_id,
+            Placement {
+                x,
+                y,
+                submitter,
+                submission_no,
+            },
+        );
+    };
+
+    MasterPortrait {
+        id: object::new(ctx),
+        unit_id,
+        athlete_id,
+        mosaic_walrus_blob_id,
+        placements,
+    }
+}
+
+public(package) fun create_and_transfer(
+    unit_id: ID,
+    athlete_id: u16,
+    mosaic_walrus_blob_id: vector<u8>,
+    placement_inputs: vector<PlacementInput>,
+    recipient: address,
+    ctx: &mut TxContext,
+): ID {
+    let master = create(
+        unit_id,
+        athlete_id,
+        mosaic_walrus_blob_id,
+        placement_inputs,
+        ctx,
+    );
+    let master_id = object::id(&master);
+    transfer::transfer(master, recipient);
+    master_id
+}
+
+#[test_only]
+public fun unit_id_for_testing(master: &MasterPortrait): ID {
+    master.unit_id
+}
+
+#[test_only]
+public fun athlete_id_for_testing(master: &MasterPortrait): u16 {
+    master.athlete_id
+}
+
+#[test_only]
+public fun mosaic_walrus_blob_id_for_testing(master: &MasterPortrait): vector<u8> {
+    copy master.mosaic_walrus_blob_id
+}
+
+#[test_only]
+public fun placement_for_testing(master: &MasterPortrait, blob_id: vector<u8>): Placement {
+    *table::borrow(&master.placements, blob_id)
+}
+
+#[test_only]
+public fun placement_x_for_testing(placement: &Placement): u16 {
+    placement.x
+}
+
+#[test_only]
+public fun placement_y_for_testing(placement: &Placement): u16 {
+    placement.y
+}
+
+#[test_only]
+public fun placement_submitter_for_testing(placement: &Placement): address {
+    placement.submitter
+}
+
+#[test_only]
+public fun placement_submission_no_for_testing(placement: &Placement): u64 {
+    placement.submission_no
 }

--- a/contracts/sources/master_portrait.move
+++ b/contracts/sources/master_portrait.move
@@ -1,0 +1,19 @@
+#[allow(unused_field)]
+module one_portrait::master_portrait;
+
+use sui::table::Table;
+
+public struct MasterPortrait has key, store {
+    id: UID,
+    unit_id: ID,
+    athlete_id: u16,
+    mosaic_walrus_blob_id: vector<u8>,
+    placements: Table<vector<u8>, Placement>,
+}
+
+public struct Placement has copy, drop, store {
+    x: u16,
+    y: u16,
+    submitter: address,
+    submission_no: u64,
+}

--- a/contracts/sources/master_portrait.move
+++ b/contracts/sources/master_portrait.move
@@ -42,6 +42,18 @@ public fun new_placement_input(
     }
 }
 
+public(package) fun placement_input_blob_id(input: &PlacementInput): vector<u8> {
+    copy input.blob_id
+}
+
+public(package) fun placement_input_submitter(input: &PlacementInput): address {
+    input.submitter
+}
+
+public(package) fun placement_input_submission_no(input: &PlacementInput): u64 {
+    input.submission_no
+}
+
 public(package) fun create(
     unit_id: ID,
     athlete_id: u16,

--- a/contracts/sources/one_portrait.move
+++ b/contracts/sources/one_portrait.move
@@ -1,5 +1,0 @@
-module one_portrait::bootstrap {
-    public fun version(): u64 {
-        1
-    }
-}

--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -1,0 +1,35 @@
+module one_portrait::registry;
+
+use sui::table::Table;
+
+public struct REGISTRY has drop {}
+
+public struct AdminCap has key, store {
+    id: UID,
+}
+
+public struct Registry has key {
+    id: UID,
+    current_units: Table<u16, ID>,
+}
+
+fun init(_witness: REGISTRY, ctx: &mut TxContext) {
+    let admin_cap = AdminCap { id: object::new(ctx) };
+    let registry = Registry {
+        id: object::new(ctx),
+        current_units: sui::table::new(ctx),
+    };
+
+    transfer::transfer(admin_cap, tx_context::sender(ctx));
+    transfer::share_object(registry);
+}
+
+#[test_only]
+public fun init_for_testing(ctx: &mut TxContext) {
+    init(REGISTRY {}, ctx);
+}
+
+#[test_only]
+public fun current_unit_count_for_testing(registry: &Registry): u64 {
+    sui::table::length(&registry.current_units)
+}

--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -1,6 +1,6 @@
 module one_portrait::registry;
 
-use sui::table::Table;
+use sui::table::{Self as table, Table};
 
 public struct REGISTRY has drop {}
 
@@ -24,6 +24,35 @@ fun init(_witness: REGISTRY, ctx: &mut TxContext) {
     transfer::share_object(registry);
 }
 
+public fun current_unit_id(registry: &Registry, athlete_id: u16): Option<ID> {
+    if (table::contains(&registry.current_units, athlete_id)) {
+        option::some(*table::borrow(&registry.current_units, athlete_id))
+    } else {
+        option::none()
+    }
+}
+
+public(package) fun set_current_unit_if_missing(
+    registry: &mut Registry,
+    athlete_id: u16,
+    unit_id: ID,
+): bool {
+    if (table::contains(&registry.current_units, athlete_id)) {
+        false
+    } else {
+        table::add(&mut registry.current_units, athlete_id, unit_id);
+        true
+    }
+}
+
+public(package) fun set_current_unit(registry: &mut Registry, athlete_id: u16, unit_id: ID) {
+    if (table::contains(&registry.current_units, athlete_id)) {
+        *table::borrow_mut(&mut registry.current_units, athlete_id) = unit_id;
+    } else {
+        table::add(&mut registry.current_units, athlete_id, unit_id);
+    }
+}
+
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext) {
     init(REGISTRY {}, ctx);
@@ -31,5 +60,5 @@ public fun init_for_testing(ctx: &mut TxContext) {
 
 #[test_only]
 public fun current_unit_count_for_testing(registry: &Registry): u64 {
-    sui::table::length(&registry.current_units)
+    table::length(&registry.current_units)
 }

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -727,8 +727,8 @@ fun finalize_rejects_double_finalize() {
     scenario.end();
 }
 
-#[test, expected_failure(abort_code = unit::EBLOB_ALREADY_SUBMITTED)]
-fun submit_photo_rejects_duplicate_blob_id_from_different_sender() {
+#[test, expected_failure(abort_code = unit::EDUPLICATE_BLOB_ID)]
+fun submit_photo_rejects_duplicate_blob_id_from_different_submitter() {
     let publisher = @0xA11CE;
     let first_submitter = @0xF41;
     let second_submitter = @0xF42;

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -726,3 +726,112 @@ fun finalize_rejects_double_finalize() {
     test_scenario::return_shared(unit);
     scenario.end();
 }
+
+#[test, expected_failure(abort_code = unit::EBLOB_ALREADY_SUBMITTED)]
+fun submit_photo_rejects_duplicate_blob_id_from_different_sender() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF41;
+    let second_submitter = @0xF42;
+    let blob_id = b"shared-blob";
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        18,
+        b"target-blob",
+        3,
+        scenario.ctx(),
+    );
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, blob_id, &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+    let first_effects = scenario.next_tx(first_submitter);
+    assert_eq!(first_effects.num_user_events(), 1);
+    let first_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(first_kakera);
+
+    scenario.next_tx(second_submitter);
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, blob_id, &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = unit::EINVALID_PLACEMENTS)]
+fun finalize_rejects_mismatched_placements() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF51;
+    let second_submitter = @0xF52;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        19,
+        b"target-blob",
+        2,
+        scenario.ctx(),
+    );
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+    let first_effects = scenario.next_tx(first_submitter);
+    assert_eq!(first_effects.num_user_events(), 1);
+    let first_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(first_kakera);
+
+    scenario.next_tx(second_submitter);
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+    let second_effects = scenario.next_tx(second_submitter);
+    assert_eq!(second_effects.num_user_events(), 2);
+    let second_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(second_kakera);
+
+    scenario.next_tx(publisher);
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    unit::finalize(
+        &admin_cap,
+        &mut unit,
+        b"mosaic-blob",
+        vector[
+            master_portrait::new_placement_input(b"photo-1", 10, 20, second_submitter, 1),
+            master_portrait::new_placement_input(b"photo-2", 30, 40, second_submitter, 2),
+        ],
+        scenario.ctx(),
+    );
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
+    scenario.end();
+}

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -2,8 +2,12 @@
 module one_portrait::registry_tests;
 
 use std::unit_test::assert_eq;
+use one_portrait::events::{Self as portrait_events};
+use one_portrait::kakera::{Self as kakera, Kakera};
 use one_portrait::registry::{Self, AdminCap, Registry};
 use one_portrait::unit::{Self, Unit};
+use sui::clock::{Self as clock, Clock};
+use sui::event;
 use sui::test_scenario;
 
 #[test]
@@ -140,6 +144,167 @@ fun admin_cap_is_only_held_by_initializer() {
 
     assert!(test_scenario::has_most_recent_for_address<AdminCap>(publisher));
     assert!(!test_scenario::has_most_recent_for_address<AdminCap>(other));
+
+    scenario.end();
+}
+
+#[test]
+fun submit_photo_mints_kakera_records_submission_and_emits_event() {
+    let publisher = @0xA11CE;
+    let submitter = @0xF0A;
+    let athlete_id = 11;
+    let max_slots = 500;
+    let target_blob = b"target-blob";
+    let walrus_blob_id = b"photo-blob";
+    let now_ms = 1_717_071_568_899;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        target_blob,
+        max_slots,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let mut clock = scenario.take_shared<Clock>();
+    clock::set_for_testing(&mut clock, now_ms);
+    test_scenario::return_shared(clock);
+
+    scenario.next_tx(submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+
+    unit::submit_photo(&mut unit, walrus_blob_id, &clock, scenario.ctx());
+
+    assert!(unit::is_pending_for_testing(&unit));
+    assert_eq!(unit::submitter_count_for_testing(&unit), 1);
+    assert_eq!(unit::submission_count_for_testing(&unit), 1);
+
+    let submission = unit::submission_ref_for_testing(&unit, 0);
+    assert_eq!(unit::submission_ref_submission_no_for_testing(&submission), 1);
+    assert_eq!(unit::submission_ref_submitter_for_testing(&submission), submitter);
+    assert_eq!(
+        unit::submission_ref_walrus_blob_id_for_testing(&submission),
+        walrus_blob_id
+    );
+    assert_eq!(unit::submission_ref_submitted_at_ms_for_testing(&submission), now_ms);
+
+    assert_eq!(event::num_events(), 1);
+    let submitted_events = event::events_by_type<portrait_events::SubmittedEvent>();
+    assert_eq!(submitted_events.length(), 1);
+    let submitted_event = submitted_events[0];
+    assert_eq!(portrait_events::submitted_event_unit_id_for_testing(&submitted_event), unit_id);
+    assert_eq!(
+        portrait_events::submitted_event_athlete_id_for_testing(&submitted_event),
+        athlete_id
+    );
+    assert_eq!(
+        portrait_events::submitted_event_submitter_for_testing(&submitted_event),
+        submitter
+    );
+    assert_eq!(
+        portrait_events::submitted_event_walrus_blob_id_for_testing(&submitted_event),
+        walrus_blob_id
+    );
+    assert_eq!(
+        portrait_events::submitted_event_submission_no_for_testing(&submitted_event),
+        1
+    );
+    assert_eq!(
+        portrait_events::submitted_event_submitted_count_for_testing(&submitted_event),
+        1
+    );
+    assert_eq!(
+        portrait_events::submitted_event_max_slots_for_testing(&submitted_event),
+        max_slots
+    );
+
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let effects = scenario.next_tx(submitter);
+    assert_eq!(effects.num_user_events(), 1);
+
+    let kakera = scenario.take_from_sender<Kakera>();
+    assert_eq!(kakera::unit_id_for_testing(&kakera), unit_id);
+    assert_eq!(kakera::athlete_id_for_testing(&kakera), athlete_id);
+    assert_eq!(kakera::submitter_for_testing(&kakera), submitter);
+    assert_eq!(kakera::walrus_blob_id_for_testing(&kakera), walrus_blob_id);
+    assert_eq!(kakera::submission_no_for_testing(&kakera), 1);
+    assert_eq!(kakera::minted_at_ms_for_testing(&kakera), now_ms);
+    scenario.return_to_sender(kakera);
+
+    let unit = scenario.take_shared_by_id<Unit>(unit_id);
+    assert!(unit::is_pending_for_testing(&unit));
+    assert_eq!(unit::submitter_count_for_testing(&unit), 1);
+    assert_eq!(unit::submission_count_for_testing(&unit), 1);
+    test_scenario::return_shared(unit);
+
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = unit::EALREADY_SUBMITTED)]
+fun submit_photo_rejects_duplicate_submission_from_same_sender() {
+    let publisher = @0xA11CE;
+    let submitter = @0xF0A;
+    let athlete_id = 12;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-blob",
+        500,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let mut clock = scenario.take_shared<Clock>();
+    clock::set_for_testing(&mut clock, 42);
+    test_scenario::return_shared(clock);
+
+    scenario.next_tx(submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    scenario.next_tx(submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
 
     scenario.end();
 }

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -308,3 +308,148 @@ fun submit_photo_rejects_duplicate_submission_from_same_sender() {
 
     scenario.end();
 }
+
+#[test]
+fun submit_photo_marks_unit_filled_and_emits_unit_filled_event_on_last_slot() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF01;
+    let second_submitter = @0xF02;
+    let athlete_id = 13;
+    let max_slots = 2;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-blob",
+        max_slots,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+
+    assert!(unit::is_pending_for_testing(&unit));
+    assert_eq!(event::events_by_type<portrait_events::UnitFilledEvent>().length(), 0);
+
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let first_effects = scenario.next_tx(first_submitter);
+    assert_eq!(first_effects.num_user_events(), 1);
+    let first_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(first_kakera);
+
+    scenario.next_tx(second_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+
+    assert!(unit::is_filled_for_testing(&unit));
+    assert_eq!(unit::submission_count_for_testing(&unit), max_slots);
+    assert_eq!(event::num_events(), 2);
+
+    let filled_events = event::events_by_type<portrait_events::UnitFilledEvent>();
+    assert_eq!(filled_events.length(), 1);
+    let filled_event = filled_events[0];
+    assert_eq!(portrait_events::unit_filled_event_unit_id_for_testing(&filled_event), unit_id);
+    assert_eq!(
+        portrait_events::unit_filled_event_athlete_id_for_testing(&filled_event),
+        athlete_id
+    );
+    assert_eq!(
+        portrait_events::unit_filled_event_filled_count_for_testing(&filled_event),
+        max_slots
+    );
+    assert_eq!(
+        portrait_events::unit_filled_event_max_slots_for_testing(&filled_event),
+        max_slots
+    );
+
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let second_effects = scenario.next_tx(second_submitter);
+    assert_eq!(second_effects.num_user_events(), 2);
+    let second_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(second_kakera);
+
+    scenario.next_tx(publisher);
+
+    let unit = scenario.take_shared_by_id<Unit>(unit_id);
+    assert!(unit::is_filled_for_testing(&unit));
+    assert_eq!(unit::submission_count_for_testing(&unit), max_slots);
+    test_scenario::return_shared(unit);
+
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = unit::EUNIT_NOT_PENDING)]
+fun submit_photo_rejects_submission_after_unit_is_filled() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF11;
+    let second_submitter = @0xF12;
+    let third_submitter = @0xF13;
+    let athlete_id = 14;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-blob",
+        2,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    scenario.next_tx(second_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    scenario.next_tx(third_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-3", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    scenario.end();
+}

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -4,6 +4,7 @@ module one_portrait::registry_tests;
 use std::unit_test::assert_eq;
 use one_portrait::events::{Self as portrait_events};
 use one_portrait::kakera::{Self as kakera, Kakera};
+use one_portrait::master_portrait::{Self as master_portrait, MasterPortrait};
 use one_portrait::registry::{Self, AdminCap, Registry};
 use one_portrait::unit::{Self, Unit};
 use sui::clock::{Self as clock, Clock};
@@ -451,5 +452,277 @@ fun submit_photo_rejects_submission_after_unit_is_filled() {
     test_scenario::return_shared(clock);
     test_scenario::return_shared(unit);
 
+    scenario.end();
+}
+
+#[test]
+fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF21;
+    let second_submitter = @0xF22;
+    let athlete_id = 15;
+    let mosaic_blob_id = b"mosaic-blob";
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-blob",
+        2,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let first_effects = scenario.next_tx(first_submitter);
+    assert_eq!(first_effects.num_user_events(), 1);
+    let first_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(first_kakera);
+
+    scenario.next_tx(second_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let second_effects = scenario.next_tx(second_submitter);
+    assert_eq!(second_effects.num_user_events(), 2);
+    let second_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(second_kakera);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let placements = vector[
+        master_portrait::new_placement_input(b"photo-1", 10, 20, first_submitter, 1),
+        master_portrait::new_placement_input(b"photo-2", 30, 40, second_submitter, 2),
+    ];
+
+    unit::finalize(&admin_cap, &mut unit, mosaic_blob_id, placements, scenario.ctx());
+
+    assert!(unit::is_finalized_for_testing(&unit));
+    let master_id = unit::master_id_for_testing(&unit);
+    assert_eq!(event::num_events(), 1);
+
+    let mosaic_ready_events = event::events_by_type<portrait_events::MosaicReadyEvent>();
+    assert_eq!(mosaic_ready_events.length(), 1);
+    let mosaic_ready_event = mosaic_ready_events[0];
+    assert_eq!(
+        portrait_events::mosaic_ready_event_unit_id_for_testing(&mosaic_ready_event),
+        unit_id
+    );
+    assert_eq!(
+        portrait_events::mosaic_ready_event_athlete_id_for_testing(&mosaic_ready_event),
+        athlete_id
+    );
+    assert_eq!(
+        portrait_events::mosaic_ready_event_master_id_for_testing(&mosaic_ready_event),
+        master_id
+    );
+    assert_eq!(
+        portrait_events::mosaic_ready_event_mosaic_walrus_blob_id_for_testing(
+            &mosaic_ready_event
+        ),
+        mosaic_blob_id
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
+
+    let finalize_effects = scenario.next_tx(publisher);
+    assert_eq!(finalize_effects.num_user_events(), 1);
+
+    let master = scenario.take_from_sender<MasterPortrait>();
+    assert_eq!(object::id(&master), master_id);
+    assert_eq!(master_portrait::unit_id_for_testing(&master), unit_id);
+    assert_eq!(master_portrait::athlete_id_for_testing(&master), athlete_id);
+    assert_eq!(
+        master_portrait::mosaic_walrus_blob_id_for_testing(&master),
+        mosaic_blob_id
+    );
+
+    let first_placement = master_portrait::placement_for_testing(&master, b"photo-1");
+    assert_eq!(master_portrait::placement_x_for_testing(&first_placement), 10);
+    assert_eq!(master_portrait::placement_y_for_testing(&first_placement), 20);
+    assert_eq!(
+        master_portrait::placement_submitter_for_testing(&first_placement),
+        first_submitter
+    );
+    assert_eq!(
+        master_portrait::placement_submission_no_for_testing(&first_placement),
+        1
+    );
+
+    let second_placement = master_portrait::placement_for_testing(&master, b"photo-2");
+    assert_eq!(master_portrait::placement_x_for_testing(&second_placement), 30);
+    assert_eq!(master_portrait::placement_y_for_testing(&second_placement), 40);
+    assert_eq!(
+        master_portrait::placement_submitter_for_testing(&second_placement),
+        second_submitter
+    );
+    assert_eq!(
+        master_portrait::placement_submission_no_for_testing(&second_placement),
+        2
+    );
+    scenario.return_to_sender(master);
+
+    scenario.next_tx(publisher);
+
+    let unit = scenario.take_shared_by_id<Unit>(unit_id);
+    assert!(unit::is_finalized_for_testing(&unit));
+    assert_eq!(unit::master_id_for_testing(&unit), master_id);
+    test_scenario::return_shared(unit);
+
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = unit::EUNIT_NOT_FILLED)]
+fun finalize_rejects_pending_unit() {
+    let publisher = @0xA11CE;
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        16,
+        b"target-blob",
+        2,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    unit::finalize(
+        &admin_cap,
+        &mut unit,
+        b"mosaic-blob",
+        vector[],
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = unit::EUNIT_NOT_FILLED)]
+fun finalize_rejects_double_finalize() {
+    let publisher = @0xA11CE;
+    let first_submitter = @0xF31;
+    let second_submitter = @0xF32;
+
+    let mut scenario = test_scenario::begin(publisher);
+    test_scenario::create_system_objects(&mut scenario);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        17,
+        b"target-blob",
+        2,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(first_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-1", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let first_effects = scenario.next_tx(first_submitter);
+    assert_eq!(first_effects.num_user_events(), 1);
+    let first_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(first_kakera);
+
+    scenario.next_tx(second_submitter);
+
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    let clock = scenario.take_shared<Clock>();
+    unit::submit_photo(&mut unit, b"photo-2", &clock, scenario.ctx());
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(unit);
+
+    let second_effects = scenario.next_tx(second_submitter);
+    assert_eq!(second_effects.num_user_events(), 2);
+    let second_kakera = scenario.take_from_sender<Kakera>();
+    scenario.return_to_sender(second_kakera);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    unit::finalize(
+        &admin_cap,
+        &mut unit,
+        b"mosaic-blob",
+        vector[
+            master_portrait::new_placement_input(b"photo-1", 10, 20, first_submitter, 1),
+            master_portrait::new_placement_input(b"photo-2", 30, 40, second_submitter, 2),
+        ],
+        scenario.ctx(),
+    );
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
+
+    let finalize_effects = scenario.next_tx(publisher);
+    assert_eq!(finalize_effects.num_user_events(), 1);
+    let master = scenario.take_from_sender<MasterPortrait>();
+    scenario.return_to_sender(master);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    unit::finalize(
+        &admin_cap,
+        &mut unit,
+        b"mosaic-blob-2",
+        vector[],
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
     scenario.end();
 }

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -1,0 +1,25 @@
+#[test_only]
+module one_portrait::registry_tests;
+
+use std::unit_test::assert_eq;
+use one_portrait::registry::{Self, AdminCap, Registry};
+use sui::test_scenario;
+
+#[test]
+fun init_creates_admin_cap_and_shared_registry() {
+    let publisher = @0xA11CE;
+    let mut scenario = test_scenario::begin(publisher);
+
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let registry = scenario.take_shared<Registry>();
+
+    assert_eq!(registry::current_unit_count_for_testing(&registry), 0);
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+    scenario.end();
+}

--- a/contracts/sources/registry_tests.move
+++ b/contracts/sources/registry_tests.move
@@ -3,6 +3,7 @@ module one_portrait::registry_tests;
 
 use std::unit_test::assert_eq;
 use one_portrait::registry::{Self, AdminCap, Registry};
+use one_portrait::unit::{Self, Unit};
 use sui::test_scenario;
 
 #[test]
@@ -21,5 +22,124 @@ fun init_creates_admin_cap_and_shared_registry() {
 
     scenario.return_to_sender(admin_cap);
     test_scenario::return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun create_unit_sets_initial_state_and_current_registry_entry() {
+    let publisher = @0xA11CE;
+    let athlete_id = 7;
+    let max_slots = 500;
+    let target_blob = b"target-blob";
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        target_blob,
+        max_slots,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let registry = scenario.take_shared<Registry>();
+    let unit = scenario.take_shared_by_id<Unit>(unit_id);
+
+    assert_eq!(object::id(&unit), unit_id);
+    assert_eq!(unit::athlete_id_for_testing(&unit), athlete_id);
+    assert_eq!(unit::max_slots_for_testing(&unit), max_slots);
+    assert!(unit::is_pending_for_testing(&unit));
+    assert!(!unit::has_master_for_testing(&unit));
+    assert_eq!(unit::submitter_count_for_testing(&unit), 0);
+    assert_eq!(unit::submission_count_for_testing(&unit), 0);
+    assert_eq!(registry::current_unit_id(&registry, athlete_id).destroy_some(), unit_id);
+
+    test_scenario::return_shared(unit);
+    test_scenario::return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun rotate_current_unit_switches_registry_pointer_without_auto_rotating() {
+    let publisher = @0xA11CE;
+    let athlete_id = 9;
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let first_unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-1",
+        500,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let second_unit_id = unit::create_unit(
+        &admin_cap,
+        &mut registry,
+        athlete_id,
+        b"target-2",
+        500,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let second_unit = scenario.take_shared_by_id<Unit>(second_unit_id);
+
+    assert_eq!(registry::current_unit_id(&registry, athlete_id).destroy_some(), first_unit_id);
+
+    unit::rotate_current_unit(&admin_cap, &mut registry, athlete_id, &second_unit);
+
+    assert_eq!(registry::current_unit_id(&registry, athlete_id).destroy_some(), second_unit_id);
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(second_unit);
+    test_scenario::return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun admin_cap_is_only_held_by_initializer() {
+    let publisher = @0xA11CE;
+    let other = @0xB0B;
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(other);
+
+    assert!(test_scenario::has_most_recent_for_address<AdminCap>(publisher));
+    assert!(!test_scenario::has_most_recent_for_address<AdminCap>(other));
+
     scenario.end();
 }

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -17,7 +17,7 @@ const EUNIT_NOT_PENDING: u64 = 3;
 const EALREADY_SUBMITTED: u64 = 4;
 const EUNIT_NOT_FILLED: u64 = 5;
 const EMASTER_ALREADY_SET: u64 = 6;
-const EBLOB_ALREADY_SUBMITTED: u64 = 7;
+const EDUPLICATE_BLOB_ID: u64 = 7;
 const EINVALID_PLACEMENTS: u64 = 8;
 
 public struct Unit has key {
@@ -85,7 +85,7 @@ public fun submit_photo(
 
     let submitter = tx_context::sender(ctx);
     assert!(!table::contains(&unit.submitters, submitter), EALREADY_SUBMITTED);
-    assert!(!has_blob_id(&unit.submissions, &walrus_blob_id), EBLOB_ALREADY_SUBMITTED);
+    assert!(!has_blob_id(&unit.submissions, &walrus_blob_id), EDUPLICATE_BLOB_ID);
 
     let submission_no = vector::length(&unit.submissions) + 1;
     let submitted_at_ms = clock::timestamp_ms(clock);

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -3,6 +3,7 @@ module one_portrait::unit;
 
 use one_portrait::events;
 use one_portrait::kakera;
+use one_portrait::master_portrait::{Self as master_portrait, PlacementInput};
 use one_portrait::registry::{Self as registry, AdminCap, Registry};
 use sui::clock::{Self as clock, Clock};
 use sui::table::{Self as table, Table};
@@ -10,11 +11,12 @@ use sui::table::{Self as table, Table};
 const STATUS_PENDING: u8 = 0;
 const STATUS_FILLED: u8 = 1;
 const STATUS_FINALIZED: u8 = 2;
-const ENOT_IMPLEMENTED: u64 = 0;
 const EINVALID_MAX_SLOTS: u64 = 1;
 const ENEXT_UNIT_ATHLETE_MISMATCH: u64 = 2;
 const EUNIT_NOT_PENDING: u64 = 3;
 const EALREADY_SUBMITTED: u64 = 4;
+const EUNIT_NOT_FILLED: u64 = 5;
+const EMASTER_ALREADY_SET: u64 = 6;
 
 public struct Unit has key {
     id: UID,
@@ -150,8 +152,18 @@ public fun is_filled_for_testing(unit: &Unit): bool {
 }
 
 #[test_only]
+public fun is_finalized_for_testing(unit: &Unit): bool {
+    unit.status == STATUS_FINALIZED
+}
+
+#[test_only]
 public fun has_master_for_testing(unit: &Unit): bool {
     option::is_some(&unit.master_id)
+}
+
+#[test_only]
+public fun master_id_for_testing(unit: &Unit): ID {
+    *option::borrow(&unit.master_id)
 }
 
 #[test_only]
@@ -189,11 +201,33 @@ public fun submission_ref_submitted_at_ms_for_testing(submission: &SubmissionRef
     submission.submitted_at_ms
 }
 
+#[allow(lint(self_transfer))]
 public fun finalize(
     _admin_cap: &AdminCap,
-    _unit: &mut Unit,
-    _mosaic_blob_id: vector<u8>,
-    _ctx: &mut TxContext,
+    unit: &mut Unit,
+    mosaic_blob_id: vector<u8>,
+    placements: vector<PlacementInput>,
+    ctx: &mut TxContext,
 ) {
-    abort ENOT_IMPLEMENTED
+    assert!(unit.status == STATUS_FILLED, EUNIT_NOT_FILLED);
+    assert!(option::is_none(&unit.master_id), EMASTER_ALREADY_SET);
+
+    let master_id = master_portrait::create_and_transfer(
+        object::id(unit),
+        unit.athlete_id,
+        copy mosaic_blob_id,
+        placements,
+        tx_context::sender(ctx),
+        ctx,
+    );
+
+    unit.master_id = option::some(master_id);
+    unit.status = STATUS_FINALIZED;
+
+    events::emit_mosaic_ready(
+        object::id(unit),
+        unit.athlete_id,
+        master_id,
+        mosaic_blob_id,
+    );
 }

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -1,0 +1,65 @@
+#[allow(unused_const, unused_field)]
+module one_portrait::unit;
+
+use one_portrait::registry::{AdminCap, Registry};
+use sui::table::Table;
+
+const STATUS_PENDING: u8 = 0;
+const STATUS_FILLED: u8 = 1;
+const STATUS_FINALIZED: u8 = 2;
+const ENOT_IMPLEMENTED: u64 = 0;
+
+public struct Unit has key {
+    id: UID,
+    athlete_id: u16,
+    target_walrus_blob: vector<u8>,
+    max_slots: u64,
+    status: u8,
+    master_id: Option<ID>,
+    submitters: Table<address, bool>,
+    submissions: vector<SubmissionRef>,
+}
+
+public struct SubmissionRef has copy, drop, store {
+    submission_no: u64,
+    submitter: address,
+    walrus_blob_id: vector<u8>,
+    submitted_at_ms: u64,
+}
+
+public fun create_unit(
+    _admin_cap: &AdminCap,
+    _registry: &mut Registry,
+    _athlete_id: u16,
+    _target_walrus_blob: vector<u8>,
+    _max_slots: u64,
+    _ctx: &mut TxContext,
+) {
+    abort ENOT_IMPLEMENTED
+}
+
+public fun rotate_current_unit(
+    _admin_cap: &AdminCap,
+    _registry: &mut Registry,
+    _athlete_id: u16,
+    _next_unit_id: ID,
+) {
+    abort ENOT_IMPLEMENTED
+}
+
+public fun submit_photo(
+    _unit: &mut Unit,
+    _walrus_blob_id: vector<u8>,
+    _ctx: &mut TxContext,
+) {
+    abort ENOT_IMPLEMENTED
+}
+
+public fun finalize(
+    _admin_cap: &AdminCap,
+    _unit: &mut Unit,
+    _mosaic_blob_id: vector<u8>,
+    _ctx: &mut TxContext,
+) {
+    abort ENOT_IMPLEMENTED
+}

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -95,6 +95,11 @@ public fun submit_photo(
             submitted_at_ms,
         },
     );
+    let submitted_count = vector::length(&unit.submissions);
+    let filled_now = submitted_count == unit.max_slots;
+    if (filled_now) {
+        unit.status = STATUS_FILLED;
+    };
 
     kakera::mint_and_transfer(
         object::id(unit),
@@ -111,9 +116,17 @@ public fun submit_photo(
         submitter,
         walrus_blob_id,
         submission_no,
-        vector::length(&unit.submissions),
+        submitted_count,
         unit.max_slots,
     );
+    if (filled_now) {
+        events::emit_unit_filled(
+            object::id(unit),
+            unit.athlete_id,
+            submitted_count,
+            unit.max_slots,
+        );
+    };
 }
 
 #[test_only]
@@ -129,6 +142,11 @@ public fun max_slots_for_testing(unit: &Unit): u64 {
 #[test_only]
 public fun is_pending_for_testing(unit: &Unit): bool {
     unit.status == STATUS_PENDING
+}
+
+#[test_only]
+public fun is_filled_for_testing(unit: &Unit): bool {
+    unit.status == STATUS_FILLED
 }
 
 #[test_only]

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -17,6 +17,8 @@ const EUNIT_NOT_PENDING: u64 = 3;
 const EALREADY_SUBMITTED: u64 = 4;
 const EUNIT_NOT_FILLED: u64 = 5;
 const EMASTER_ALREADY_SET: u64 = 6;
+const EBLOB_ALREADY_SUBMITTED: u64 = 7;
+const EINVALID_PLACEMENTS: u64 = 8;
 
 public struct Unit has key {
     id: UID,
@@ -83,6 +85,7 @@ public fun submit_photo(
 
     let submitter = tx_context::sender(ctx);
     assert!(!table::contains(&unit.submitters, submitter), EALREADY_SUBMITTED);
+    assert!(!has_blob_id(&unit.submissions, &walrus_blob_id), EBLOB_ALREADY_SUBMITTED);
 
     let submission_no = vector::length(&unit.submissions) + 1;
     let submitted_at_ms = clock::timestamp_ms(clock);
@@ -201,6 +204,49 @@ public fun submission_ref_submitted_at_ms_for_testing(submission: &SubmissionRef
     submission.submitted_at_ms
 }
 
+fun validate_placements(unit: &Unit, placements: &vector<PlacementInput>) {
+    let submission_count = vector::length(&unit.submissions);
+    assert!(vector::length(placements) == submission_count, EINVALID_PLACEMENTS);
+
+    let mut placement_index = 0;
+    while (placement_index < vector::length(placements)) {
+        let placement = vector::borrow(placements, placement_index);
+        let placement_blob_id = master_portrait::placement_input_blob_id(placement);
+
+        let mut duplicate_index = 0;
+        while (duplicate_index < placement_index) {
+            let previous = vector::borrow(placements, duplicate_index);
+            assert!(
+                master_portrait::placement_input_blob_id(previous) != placement_blob_id,
+                EINVALID_PLACEMENTS,
+            );
+            duplicate_index = duplicate_index + 1;
+        };
+
+        let mut matched = false;
+        let mut submission_index = 0;
+        while (submission_index < submission_count) {
+            let submission = vector::borrow(&unit.submissions, submission_index);
+            if (copy submission.walrus_blob_id == placement_blob_id) {
+                assert!(
+                    submission.submitter == master_portrait::placement_input_submitter(placement),
+                    EINVALID_PLACEMENTS,
+                );
+                assert!(
+                    submission.submission_no
+                        == master_portrait::placement_input_submission_no(placement),
+                    EINVALID_PLACEMENTS,
+                );
+                matched = true;
+            };
+            submission_index = submission_index + 1;
+        };
+
+        assert!(matched, EINVALID_PLACEMENTS);
+        placement_index = placement_index + 1;
+    };
+}
+
 #[allow(lint(self_transfer))]
 public fun finalize(
     _admin_cap: &AdminCap,
@@ -211,6 +257,7 @@ public fun finalize(
 ) {
     assert!(unit.status == STATUS_FILLED, EUNIT_NOT_FILLED);
     assert!(option::is_none(&unit.master_id), EMASTER_ALREADY_SET);
+    validate_placements(unit, &placements);
 
     let master_id = master_portrait::create_and_transfer(
         object::id(unit),
@@ -230,4 +277,15 @@ public fun finalize(
         master_id,
         mosaic_blob_id,
     );
+}
+
+fun has_blob_id(submissions: &vector<SubmissionRef>, walrus_blob_id: &vector<u8>): bool {
+    let mut i = 0;
+    while (i < vector::length(submissions)) {
+        if (vector::borrow(submissions, i).walrus_blob_id == *walrus_blob_id) {
+            return true
+        };
+        i = i + 1;
+    };
+    false
 }

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -1,13 +1,15 @@
 #[allow(unused_const, unused_field)]
 module one_portrait::unit;
 
-use one_portrait::registry::{AdminCap, Registry};
-use sui::table::Table;
+use one_portrait::registry::{Self as registry, AdminCap, Registry};
+use sui::table::{Self as table, Table};
 
 const STATUS_PENDING: u8 = 0;
 const STATUS_FILLED: u8 = 1;
 const STATUS_FINALIZED: u8 = 2;
 const ENOT_IMPLEMENTED: u64 = 0;
+const EINVALID_MAX_SLOTS: u64 = 1;
+const ENEXT_UNIT_ATHLETE_MISMATCH: u64 = 2;
 
 public struct Unit has key {
     id: UID,
@@ -29,22 +31,39 @@ public struct SubmissionRef has copy, drop, store {
 
 public fun create_unit(
     _admin_cap: &AdminCap,
-    _registry: &mut Registry,
-    _athlete_id: u16,
-    _target_walrus_blob: vector<u8>,
-    _max_slots: u64,
-    _ctx: &mut TxContext,
-) {
-    abort ENOT_IMPLEMENTED
+    registry: &mut Registry,
+    athlete_id: u16,
+    target_walrus_blob: vector<u8>,
+    max_slots: u64,
+    ctx: &mut TxContext,
+): ID {
+    assert!(max_slots > 0, EINVALID_MAX_SLOTS);
+
+    let unit = Unit {
+        id: object::new(ctx),
+        athlete_id,
+        target_walrus_blob,
+        max_slots,
+        status: STATUS_PENDING,
+        master_id: option::none(),
+        submitters: table::new(ctx),
+        submissions: vector[],
+    };
+    let unit_id = object::id(&unit);
+
+    registry::set_current_unit_if_missing(registry, athlete_id, unit_id);
+    transfer::share_object(unit);
+    unit_id
 }
 
 public fun rotate_current_unit(
     _admin_cap: &AdminCap,
-    _registry: &mut Registry,
-    _athlete_id: u16,
-    _next_unit_id: ID,
+    registry: &mut Registry,
+    athlete_id: u16,
+    next_unit: &Unit,
 ) {
-    abort ENOT_IMPLEMENTED
+    assert!(next_unit.athlete_id == athlete_id, ENEXT_UNIT_ATHLETE_MISMATCH);
+    registry::set_current_unit(registry, athlete_id, object::id(next_unit));
 }
 
 public fun submit_photo(
@@ -53,6 +72,36 @@ public fun submit_photo(
     _ctx: &mut TxContext,
 ) {
     abort ENOT_IMPLEMENTED
+}
+
+#[test_only]
+public fun athlete_id_for_testing(unit: &Unit): u16 {
+    unit.athlete_id
+}
+
+#[test_only]
+public fun max_slots_for_testing(unit: &Unit): u64 {
+    unit.max_slots
+}
+
+#[test_only]
+public fun is_pending_for_testing(unit: &Unit): bool {
+    unit.status == STATUS_PENDING
+}
+
+#[test_only]
+public fun has_master_for_testing(unit: &Unit): bool {
+    option::is_some(&unit.master_id)
+}
+
+#[test_only]
+public fun submitter_count_for_testing(unit: &Unit): u64 {
+    table::length(&unit.submitters)
+}
+
+#[test_only]
+public fun submission_count_for_testing(unit: &Unit): u64 {
+    vector::length(&unit.submissions)
 }
 
 public fun finalize(

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -1,7 +1,10 @@
 #[allow(unused_const, unused_field)]
 module one_portrait::unit;
 
+use one_portrait::events;
+use one_portrait::kakera;
 use one_portrait::registry::{Self as registry, AdminCap, Registry};
+use sui::clock::{Self as clock, Clock};
 use sui::table::{Self as table, Table};
 
 const STATUS_PENDING: u8 = 0;
@@ -10,6 +13,8 @@ const STATUS_FINALIZED: u8 = 2;
 const ENOT_IMPLEMENTED: u64 = 0;
 const EINVALID_MAX_SLOTS: u64 = 1;
 const ENEXT_UNIT_ATHLETE_MISMATCH: u64 = 2;
+const EUNIT_NOT_PENDING: u64 = 3;
+const EALREADY_SUBMITTED: u64 = 4;
 
 public struct Unit has key {
     id: UID,
@@ -67,11 +72,48 @@ public fun rotate_current_unit(
 }
 
 public fun submit_photo(
-    _unit: &mut Unit,
-    _walrus_blob_id: vector<u8>,
-    _ctx: &mut TxContext,
+    unit: &mut Unit,
+    walrus_blob_id: vector<u8>,
+    clock: &Clock,
+    ctx: &mut TxContext,
 ) {
-    abort ENOT_IMPLEMENTED
+    assert!(unit.status == STATUS_PENDING, EUNIT_NOT_PENDING);
+
+    let submitter = tx_context::sender(ctx);
+    assert!(!table::contains(&unit.submitters, submitter), EALREADY_SUBMITTED);
+
+    let submission_no = vector::length(&unit.submissions) + 1;
+    let submitted_at_ms = clock::timestamp_ms(clock);
+
+    table::add(&mut unit.submitters, submitter, true);
+    vector::push_back(
+        &mut unit.submissions,
+        SubmissionRef {
+            submission_no,
+            submitter,
+            walrus_blob_id: copy walrus_blob_id,
+            submitted_at_ms,
+        },
+    );
+
+    kakera::mint_and_transfer(
+        object::id(unit),
+        unit.athlete_id,
+        submitter,
+        copy walrus_blob_id,
+        submission_no,
+        submitted_at_ms,
+        ctx,
+    );
+    events::emit_submitted(
+        object::id(unit),
+        unit.athlete_id,
+        submitter,
+        walrus_blob_id,
+        submission_no,
+        vector::length(&unit.submissions),
+        unit.max_slots,
+    );
 }
 
 #[test_only]
@@ -102,6 +144,31 @@ public fun submitter_count_for_testing(unit: &Unit): u64 {
 #[test_only]
 public fun submission_count_for_testing(unit: &Unit): u64 {
     vector::length(&unit.submissions)
+}
+
+#[test_only]
+public fun submission_ref_for_testing(unit: &Unit, index: u64): SubmissionRef {
+    *vector::borrow(&unit.submissions, index)
+}
+
+#[test_only]
+public fun submission_ref_submission_no_for_testing(submission: &SubmissionRef): u64 {
+    submission.submission_no
+}
+
+#[test_only]
+public fun submission_ref_submitter_for_testing(submission: &SubmissionRef): address {
+    submission.submitter
+}
+
+#[test_only]
+public fun submission_ref_walrus_blob_id_for_testing(submission: &SubmissionRef): vector<u8> {
+    copy submission.walrus_blob_id
+}
+
+#[test_only]
+public fun submission_ref_submitted_at_ms_for_testing(submission: &SubmissionRef): u64 {
+    submission.submitted_at_ms
 }
 
 public fun finalize(


### PR DESCRIPTION
## 概要
ONE Portrait の投稿と確定の正本を Sui Move で実装しました。
`Registry` `Unit` `Kakera` `MasterPortrait` `events` を分割し、投稿から確定までの最小契約を固めています。

## 変更内容
- `contracts/sources/registry.move`
  - `AdminCap` と shared `Registry` を実装し、`athlete_id -> current_unit_id` を管理できるようにしました。
- `contracts/sources/unit.move`
  - `create_unit` `rotate_current_unit` `submit_photo` `finalize` を実装しました。
  - 同一 unit 内の重複投稿と重複 blob_id を拒否し、`Filled` と `Finalized` の状態遷移を追加しました。
- `contracts/sources/kakera.move`
  - `key` only の Soulbound Kakera を実装し、`submit_photo` と同一 Tx で mint する形にしました。
- `contracts/sources/master_portrait.move`
  - `placements: Table<blob_id, Placement>` を持つ `MasterPortrait` を実装しました。
- `contracts/sources/events.move`
  - `SubmittedEvent` `UnitFilledEvent` `MosaicReadyEvent` を実装しました。
- `contracts/sources/registry_tests.move`
  - 初期化、投稿、Filled 遷移、finalize、重複拒否、placement 整合性の Move テストを追加しました。
- `contracts/sources/one_portrait.move`
  - 旧集約モジュールを削除しました。

## 関連する Issue やチケット
Close #2

## 動作確認
- `cd contracts && sui move build`
- `cd contracts && sui move test`
- Claude 最終監査: blocking なし
