### PR TITLE
[feat] 写真投稿フローと Kakera 即時受領を実装する

### DIFF
--- a/apps/web/src/app/units/[unitId]/live-progress.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.tsx
@@ -7,10 +7,16 @@
  * from Sui at request time; from there `useUnitEvents` keeps the number
  * ticking in real time via `SubmittedEvent`s. `UnitFilledEvent` and
  * `MosaicReadyEvent` are logged as hooks for the later finalize / reveal
- * flows but intentionally do not drive UI yet (out of scope for STEP 5/5).
+ * flows but intentionally do not drive UI yet.
+ *
+ * Invariant (see CLAUDE.md / docs/tech.md §10, §11):
+ *   `SubmittedEvent` is the ONLY source of truth for `submittedCount`.
+ *   The submit flow (`ParticipationAccess`) must NOT optimistically bump this
+ *   counter — the participant sees the number advance only after the chain
+ *   event is observed. This keeps the waiting-room narrative ("観測できる
+ *   まで待ち、駄目なら案内付きで再試行") honest.
  *
  * Follow-up issues can plug:
- *   - submit button (zkLogin + Enoki Sponsored Tx)
  *   - reveal animation (listen for MosaicReadyEvent here and fan out)
  */
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -281,4 +281,288 @@ describe("ParticipationAccess", () => {
       );
     });
   });
+
+  describe("submission flow (Walrus PUT + Sponsored Tx)", () => {
+    const SUBMIT_BUTTON_NAME = /投稿を確定/;
+
+    type PreprocessedLike = {
+      readonly blob: Blob;
+      readonly width: number;
+      readonly height: number;
+      readonly contentType: "image/jpeg";
+      readonly sha256: string;
+      readonly previewUrl: string;
+    };
+    type PreprocessMock = (file: File) => Promise<PreprocessedLike>;
+    type SubmitMock = (
+      blobId: string,
+    ) => Promise<{ readonly digest: string; readonly sender: string }>;
+    type PutMock = (
+      photo: PreprocessedLike,
+      deps: {
+        readonly env: {
+          readonly NEXT_PUBLIC_WALRUS_PUBLISHER: string | undefined;
+          readonly NEXT_PUBLIC_WALRUS_AGGREGATOR: string | undefined;
+        };
+      },
+    ) => Promise<{ readonly blobId: string; readonly aggregatorUrl: string }>;
+
+    function setupPreviewingEnv(): {
+      readonly preprocessPhoto: ReturnType<typeof vi.fn<PreprocessMock>>;
+      readonly submitPhoto: ReturnType<typeof vi.fn<SubmitMock>>;
+    } {
+      setupSignedInEnv();
+      const preprocessPhoto = vi.fn<PreprocessMock>().mockResolvedValue({
+        blob: new Blob(["encoded"], { type: "image/jpeg" }),
+        width: 1024,
+        height: 768,
+        contentType: "image/jpeg",
+        sha256: "deadbeef",
+        previewUrl: "blob:preview-xyz",
+      });
+      const submitPhoto = vi.fn<SubmitMock>();
+      useSubmitPhotoMock.mockReturnValue({
+        isSubmitting: false,
+        submitPhoto,
+      });
+      return { preprocessPhoto, submitPhoto };
+    }
+
+    async function advanceToPreview(
+      preprocessPhoto: ReturnType<typeof vi.fn<PreprocessMock>>,
+    ): Promise<void> {
+      fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+      fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
+        target: { files: [makeFile()] },
+      });
+      await waitFor(() => {
+        expect(preprocessPhoto).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+      });
+    }
+
+    it("shows a submit button on the preview step", async () => {
+      const { preprocessPhoto } = setupPreviewingEnv();
+      const putBlob = vi.fn<PutMock>();
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      expect(
+        screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }),
+      ).toBeTruthy();
+    });
+
+    it("calls putBlob first, then submitPhoto with the returned blobId", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const callOrder: string[] = [];
+      const putBlob = vi.fn<PutMock>(async () => {
+        callOrder.push("put");
+        return {
+          blobId: "walrus-blob-123",
+          aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-123",
+        };
+      });
+      submitPhoto.mockImplementation(async (_blobId: string) => {
+        callOrder.push("submit");
+        return { digest: "tx-digest", sender: "0xabc123" };
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(submitPhoto).toHaveBeenCalledWith("walrus-blob-123");
+      });
+
+      expect(callOrder).toEqual(["put", "submit"]);
+      expect(putBlob).toHaveBeenCalledTimes(1);
+      const firstArg = putBlob.mock.calls[0][0];
+      expect(firstArg.previewUrl).toBe("blob:preview-xyz");
+    });
+
+    it("does not call submitPhoto while putBlob is pending", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      let resolvePut: (value: {
+        readonly blobId: string;
+        readonly aggregatorUrl: string;
+      }) => void = () => {};
+      const putBlob = vi.fn<PutMock>(
+        () =>
+          new Promise((resolve) => {
+            resolvePut = resolve;
+          }),
+      );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(putBlob).toHaveBeenCalledTimes(1);
+      });
+      expect(submitPhoto).not.toHaveBeenCalled();
+
+      resolvePut({
+        blobId: "walrus-blob-789",
+        aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-789",
+      });
+
+      await waitFor(() => {
+        expect(submitPhoto).toHaveBeenCalledWith("walrus-blob-789");
+      });
+    });
+
+    it("shows a Walrus failure message and skips submitPhoto when putBlob rejects with a final error", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const { WalrusPutError } = await import("../../../lib/walrus/put");
+      const putBlob = vi
+        .fn<PutMock>()
+        .mockRejectedValue(
+          new WalrusPutError(
+            "final",
+            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+          ),
+        );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toContain(
+          "Walrus への写真の保存に失敗",
+        );
+      });
+      expect(submitPhoto).not.toHaveBeenCalled();
+    });
+
+    it("disconnects and returns to the login step when submitPhoto fails with auth_expired", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const disconnectMutate = vi.fn();
+      useDisconnectWalletMock.mockReturnValue({ mutate: disconnectMutate });
+      const { EnokiSubmitClientError } = await import(
+        "../../../lib/enoki/client-submit"
+      );
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-xyz",
+        aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-xyz",
+      }));
+      submitPhoto.mockRejectedValue(
+        new EnokiSubmitClientError(
+          401,
+          "auth_expired",
+          "ログインが切れました。Google でもう一度ログインしてください。",
+        ),
+      );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(disconnectMutate).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toContain(
+          "ログインが切れました",
+        );
+      });
+    });
+
+    it("shows a completion message with the transaction digest on success", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-ok",
+        aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-ok",
+      }));
+      submitPhoto.mockResolvedValue({
+        digest: "final-digest-XYZ",
+        sender: "0xabc123",
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+      expect(screen.getByText(/final-digest-XYZ/)).toBeTruthy();
+    });
+  });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -11,6 +11,7 @@ const {
   useCurrentWalletMock,
   useConnectWalletMock,
   useDisconnectWalletMock,
+  useOwnedKakeraMock,
 } = vi.hoisted(() => ({
   useEnokiConfigStateMock: vi.fn(),
   useSubmitPhotoMock: vi.fn(),
@@ -19,6 +20,7 @@ const {
   useCurrentWalletMock: vi.fn(),
   useConnectWalletMock: vi.fn(),
   useDisconnectWalletMock: vi.fn(),
+  useOwnedKakeraMock: vi.fn(),
 }));
 
 vi.mock("../../../lib/enoki/provider", () => ({
@@ -51,6 +53,14 @@ vi.mock("@mysten/dapp-kit", () => ({
   useDisconnectWallet: () => useDisconnectWalletMock(),
 }));
 
+vi.mock("../../../lib/sui/react", () => ({
+  useOwnedKakera: (args: unknown) => useOwnedKakeraMock(args),
+}));
+
+vi.mock("../../../lib/sui", () => ({
+  getSuiClient: () => ({}),
+}));
+
 import { ParticipationAccess } from "./participation-access";
 
 const FILE_INPUT_LABEL = "写真を選択";
@@ -74,6 +84,10 @@ function setupSignedInEnv(): void {
     isSubmitting: false,
     submitPhoto: vi.fn(),
   });
+  useOwnedKakeraMock.mockReturnValue({
+    status: "idle",
+    kakera: null,
+  });
 }
 
 afterEach(() => {
@@ -84,6 +98,7 @@ afterEach(() => {
   useCurrentWalletMock.mockReset();
   useConnectWalletMock.mockReset();
   useDisconnectWalletMock.mockReset();
+  useOwnedKakeraMock.mockReset();
 });
 
 describe("ParticipationAccess", () => {
@@ -373,7 +388,8 @@ describe("ParticipationAccess", () => {
         callOrder.push("put");
         return {
           blobId: "walrus-blob-123",
-          aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-123",
+          aggregatorUrl:
+            "https://aggregator.example.com/v1/blobs/walrus-blob-123",
         };
       });
       submitPhoto.mockImplementation(async (_blobId: string) => {
@@ -443,7 +459,8 @@ describe("ParticipationAccess", () => {
 
       resolvePut({
         blobId: "walrus-blob-789",
-        aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-789",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-789",
       });
 
       await waitFor(() => {
@@ -496,7 +513,8 @@ describe("ParticipationAccess", () => {
       );
       const putBlob = vi.fn<PutMock>(async () => ({
         blobId: "walrus-blob-xyz",
-        aggregatorUrl: "https://aggregator.example.com/v1/blobs/walrus-blob-xyz",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-xyz",
       }));
       submitPhoto.mockRejectedValue(
         new EnokiSubmitClientError(
@@ -563,6 +581,146 @@ describe("ParticipationAccess", () => {
         expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
       });
       expect(screen.getByText(/final-digest-XYZ/)).toBeTruthy();
+    });
+
+    it("renders the participation card with preview, sender, and a pending submission_no while Kakera is being confirmed", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      useOwnedKakeraMock.mockReturnValue({
+        status: "searching",
+        kakera: null,
+      });
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-card",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-card",
+      }));
+      submitPhoto.mockResolvedValue({
+        digest: "digest-card",
+        sender: "0xabc123",
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+
+      // 参加証 card shows the locally-preprocessed preview image.
+      const previews = screen.getAllByAltText(
+        "投稿プレビュー",
+      ) as HTMLImageElement[];
+      expect(previews.some((img) => img.src.includes("blob:preview-xyz"))).toBe(
+        true,
+      );
+
+      // Sender address is visible (appears both in the login strip and
+      // inside the participation card, so just assert at least one).
+      expect(screen.getAllByText(/0xabc123/).length).toBeGreaterThan(0);
+
+      // submission_no is still being confirmed: show a pending indicator.
+      const submissionHeading = screen.getByText(/submission_no/i);
+      const submissionValue = submissionHeading.nextElementSibling;
+      expect(submissionValue?.textContent).toMatch(/確認中/);
+      expect(
+        screen.getByText(/Kakera.*確認しています|Kakera を確認しています/),
+      ).toBeTruthy();
+    });
+
+    it("shows the Kakera submission_no once the hook reports 'found'", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      useOwnedKakeraMock.mockReturnValue({
+        status: "found",
+        kakera: {
+          objectId: "0xkakera-7",
+          unitId: "0xunit-1",
+          walrusBlobId: "walrus-blob-card",
+          submissionNo: 128,
+        },
+      });
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-card",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-card",
+      }));
+      submitPhoto.mockResolvedValue({
+        digest: "digest-card",
+        sender: "0xabc123",
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/#128/)).toBeTruthy();
+      });
+      expect(screen.getByText(/Kakera を受け取りました/)).toBeTruthy();
+    });
+
+    it("shows a timeout notice when the Kakera lookup hits its retry budget", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      useOwnedKakeraMock.mockReturnValue({
+        status: "timeout",
+        kakera: null,
+      });
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-card",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-card",
+      }));
+      submitPhoto.mockResolvedValue({
+        digest: "digest-card",
+        sender: "0xabc123",
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/確認できませんでした/)).toBeTruthy();
+      });
     });
   });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -1,7 +1,16 @@
 // @vitest-environment happy-dom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SubmittedEvent } from "../../../lib/sui";
+import type { UseUnitEventsArgs } from "../../../lib/sui/react";
 
 const {
   useEnokiConfigStateMock,
@@ -12,6 +21,7 @@ const {
   useConnectWalletMock,
   useDisconnectWalletMock,
   useOwnedKakeraMock,
+  useUnitEventsMock,
 } = vi.hoisted(() => ({
   useEnokiConfigStateMock: vi.fn(),
   useSubmitPhotoMock: vi.fn(),
@@ -21,6 +31,7 @@ const {
   useConnectWalletMock: vi.fn(),
   useDisconnectWalletMock: vi.fn(),
   useOwnedKakeraMock: vi.fn(),
+  useUnitEventsMock: vi.fn(),
 }));
 
 vi.mock("../../../lib/enoki/provider", () => ({
@@ -55,12 +66,14 @@ vi.mock("@mysten/dapp-kit", () => ({
 
 vi.mock("../../../lib/sui/react", () => ({
   useOwnedKakera: (args: unknown) => useOwnedKakeraMock(args),
+  useUnitEvents: (args: UseUnitEventsArgs) => useUnitEventsMock(args),
 }));
 
 vi.mock("../../../lib/sui", () => ({
   getSuiClient: () => ({}),
 }));
 
+import { LiveProgress } from "./live-progress";
 import { ParticipationAccess } from "./participation-access";
 
 const FILE_INPUT_LABEL = "写真を選択";
@@ -99,6 +112,7 @@ afterEach(() => {
   useConnectWalletMock.mockReset();
   useDisconnectWalletMock.mockReset();
   useOwnedKakeraMock.mockReset();
+  useUnitEventsMock.mockReset();
 });
 
 describe("ParticipationAccess", () => {
@@ -504,6 +518,77 @@ describe("ParticipationAccess", () => {
       expect(submitPhoto).not.toHaveBeenCalled();
     });
 
+    it("offers a retry button after a Walrus final error that reuses the preprocessed photo", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const { WalrusPutError } = await import("../../../lib/walrus/put");
+      const putBlob = vi
+        .fn<PutMock>()
+        .mockRejectedValueOnce(
+          new WalrusPutError(
+            "final",
+            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+          ),
+        )
+        .mockResolvedValueOnce({
+          blobId: "walrus-blob-retry",
+          aggregatorUrl:
+            "https://aggregator.example.com/v1/blobs/walrus-blob-retry",
+        });
+      submitPhoto.mockResolvedValue({
+        digest: "retry-digest",
+        sender: "0xabc123",
+      });
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toContain(
+          "Walrus への写真の保存に失敗",
+        );
+      });
+
+      const retryButton = screen.getByRole("button", {
+        name: /もう一度送信する/,
+      });
+      expect(retryButton).toBeTruthy();
+
+      // preprocessPhoto should not be called again: the previously preprocessed
+      // photo is reused and we jump straight back to the Walrus upload step.
+      const preprocessCallsBefore = preprocessPhoto.mock.calls.length;
+
+      fireEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(putBlob).toHaveBeenCalledTimes(2);
+      });
+      expect(preprocessPhoto.mock.calls.length).toBe(preprocessCallsBefore);
+
+      // Retry should carry the same preprocessed photo that the first attempt
+      // used (same previewUrl proves identity).
+      expect(putBlob.mock.calls[1][0].previewUrl).toBe("blob:preview-xyz");
+
+      await waitFor(() => {
+        expect(submitPhoto).toHaveBeenCalledWith("walrus-blob-retry");
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+    });
+
     it("disconnects and returns to the login step when submitPhoto fails with auth_expired", async () => {
       const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
       const disconnectMutate = vi.fn();
@@ -721,6 +806,107 @@ describe("ParticipationAccess", () => {
       await waitFor(() => {
         expect(screen.getByText(/確認できませんでした/)).toBeTruthy();
       });
+    });
+  });
+
+  /**
+   * End-to-end waiting-room integration: renders both `ParticipationAccess`
+   * and `LiveProgress` together, walks the user through a full submission,
+   * and asserts the contract that:
+   *   - After `submit_photo` succeeds the progress counter stays flat
+   *     (no optimistic update).
+   *   - Only a `SubmittedEvent` observation increments the counter.
+   */
+  describe("integration with LiveProgress (SubmittedEvent is source of truth)", () => {
+    const SUBMIT_BUTTON_NAME = /投稿を確定/;
+
+    it("keeps the counter flat after submit success, then increments on SubmittedEvent", async () => {
+      setupSignedInEnv();
+
+      let capturedOnSubmitted: ((event: SubmittedEvent) => void) | undefined;
+      useUnitEventsMock.mockImplementation((args: UseUnitEventsArgs) => {
+        capturedOnSubmitted = args.onSubmitted;
+      });
+
+      const preprocessPhoto = vi.fn().mockResolvedValue({
+        blob: new Blob(["encoded"], { type: "image/jpeg" }),
+        width: 1024,
+        height: 768,
+        contentType: "image/jpeg",
+        sha256: "deadbeef",
+        previewUrl: "blob:preview-integration",
+      });
+      const submitPhoto = vi.fn().mockResolvedValue({
+        digest: "integration-digest",
+        sender: "0xabc123",
+      });
+      useSubmitPhotoMock.mockReturnValue({
+        isSubmitting: false,
+        submitPhoto,
+      });
+      const putBlob = vi.fn().mockResolvedValue({
+        blobId: "walrus-blob-int",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-int",
+      });
+
+      render(
+        <div>
+          <LiveProgress
+            initialSubmittedCount={41}
+            maxSlots={500}
+            packageId="0xpkg"
+            unitId="0xunit-1"
+          />
+          <ParticipationAccess
+            preprocessPhoto={preprocessPhoto}
+            putBlob={putBlob}
+            unitId="0xunit-1"
+            walrusEnv={{
+              NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+              NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+            }}
+          />
+        </div>,
+      );
+
+      expect(screen.getByText(/41\s*\/\s*500/)).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+      fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
+        target: { files: [makeFile()] },
+      });
+      await waitFor(() => {
+        expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+
+      // Progress counter MUST still be at its initial value — no optimistic
+      // increment is allowed. This is the STEP 6 contract.
+      expect(screen.getByText(/41\s*\/\s*500/)).toBeTruthy();
+      expect(screen.queryByText(/42\s*\/\s*500/)).toBeNull();
+
+      // Deliver the SubmittedEvent through the captured hook and verify the
+      // counter catches up.
+      act(() => {
+        capturedOnSubmitted?.({
+          kind: "submitted",
+          unitId: "0xunit-1",
+          athletePublicId: "1",
+          submitter: "0xabc123",
+          walrusBlobId: [],
+          submissionNo: 42,
+          submittedCount: 42,
+          maxSlots: 500,
+        });
+      });
+
+      expect(screen.getByText(/42\s*\/\s*500/)).toBeTruthy();
     });
   });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -53,6 +53,29 @@ vi.mock("@mysten/dapp-kit", () => ({
 
 import { ParticipationAccess } from "./participation-access";
 
+const FILE_INPUT_LABEL = "写真を選択";
+
+function makeFile(name = "photo.jpg", size = 1024): File {
+  const blob = new Blob([new Uint8Array(size)], { type: "image/jpeg" });
+  return new File([blob], name, { type: "image/jpeg" });
+}
+
+function setupSignedInEnv(): void {
+  useEnokiConfigStateMock.mockReturnValue({
+    submitEnabled: true,
+    config: {},
+  });
+  useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
+  useCurrentAccountMock.mockReturnValue({ address: "0xabc123" });
+  useCurrentWalletMock.mockReturnValue({ connectionStatus: "connected" });
+  useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+  useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
+  useSubmitPhotoMock.mockReturnValue({
+    isSubmitting: false,
+    submitPhoto: vi.fn(),
+  });
+}
+
 afterEach(() => {
   useEnokiConfigStateMock.mockReset();
   useSubmitPhotoMock.mockReset();
@@ -75,25 +98,18 @@ describe("ParticipationAccess", () => {
     expect(screen.getByText(/進捗の確認だけ使えます/)).toBeTruthy();
   });
 
-  it("shows the zkLogin address after login", () => {
-    const disconnectMutate = vi.fn();
+  it("shows the Google login button when the user is not signed in", () => {
     useEnokiConfigStateMock.mockReturnValue({
       submitEnabled: true,
       config: {},
     });
     useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
-    useCurrentAccountMock.mockReturnValue({
-      address: "0xabc123",
-    });
+    useCurrentAccountMock.mockReturnValue(null);
     useCurrentWalletMock.mockReturnValue({
-      connectionStatus: "connected",
+      connectionStatus: "disconnected",
     });
-    useConnectWalletMock.mockReturnValue({
-      mutateAsync: vi.fn(),
-    });
-    useDisconnectWalletMock.mockReturnValue({
-      mutate: disconnectMutate,
-    });
+    useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
     useSubmitPhotoMock.mockReturnValue({
       isSubmitting: false,
       submitPhoto: vi.fn(),
@@ -101,10 +117,9 @@ describe("ParticipationAccess", () => {
 
     render(<ParticipationAccess unitId="0xunit-1" />);
 
-    expect(screen.getByText("0xabc123")).toBeTruthy();
-    expect(screen.getByPlaceholderText("walrus-blob-id")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "ログイン解除" }));
-    expect(disconnectMutate).toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Google でログイン" }),
+    ).toBeTruthy();
   });
 
   it("shows a retry message when login fails", async () => {
@@ -120,9 +135,7 @@ describe("ParticipationAccess", () => {
     useConnectWalletMock.mockReturnValue({
       mutateAsync: vi.fn().mockRejectedValue(new Error("Google login failed")),
     });
-    useDisconnectWalletMock.mockReturnValue({
-      mutate: vi.fn(),
-    });
+    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
     useSubmitPhotoMock.mockReturnValue({
       isSubmitting: false,
       submitPhoto: vi.fn(),
@@ -140,5 +153,132 @@ describe("ParticipationAccess", () => {
     expect(
       screen.getByRole("button", { name: "もう一度ログイン" }),
     ).toBeTruthy();
+  });
+
+  it("disables the file selector until the consent box is checked", () => {
+    setupSignedInEnv();
+
+    render(<ParticipationAccess unitId="0xunit-1" />);
+
+    const fileInput = screen.getByLabelText(
+      FILE_INPUT_LABEL,
+    ) as HTMLInputElement;
+    expect(fileInput.disabled).toBe(true);
+
+    const consent = screen.getByRole("checkbox", {
+      name: /同意/,
+    }) as HTMLInputElement;
+    expect(consent.checked).toBe(false);
+    fireEvent.click(consent);
+    expect(consent.checked).toBe(true);
+    expect(fileInput.disabled).toBe(false);
+  });
+
+  it("calls preprocessPhoto with the chosen file and renders the preview URL", async () => {
+    setupSignedInEnv();
+
+    const preprocessPhoto = vi.fn().mockResolvedValue({
+      blob: new Blob(["encoded"], { type: "image/jpeg" }),
+      width: 1024,
+      height: 768,
+      contentType: "image/jpeg",
+      sha256: "deadbeef",
+      previewUrl: "blob:preview-abc",
+    });
+
+    render(
+      <ParticipationAccess
+        preprocessPhoto={preprocessPhoto}
+        unitId="0xunit-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+
+    const file = makeFile();
+    const fileInput = screen.getByLabelText(
+      FILE_INPUT_LABEL,
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(preprocessPhoto).toHaveBeenCalledTimes(1);
+    });
+    expect(preprocessPhoto.mock.calls[0][0]).toBe(file);
+
+    await waitFor(() => {
+      const preview = screen.getByAltText("投稿プレビュー") as HTMLImageElement;
+      expect(preview.src).toContain("blob:preview-abc");
+    });
+  });
+
+  it("shows a processing indicator while preprocessPhoto is pending", async () => {
+    setupSignedInEnv();
+
+    let resolvePreprocess: (value: unknown) => void = () => {};
+    const preprocessPhoto = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePreprocess = resolve;
+        }),
+    );
+
+    render(
+      <ParticipationAccess
+        preprocessPhoto={preprocessPhoto}
+        unitId="0xunit-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+
+    fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
+      target: { files: [makeFile()] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/処理中/)).toBeTruthy();
+    });
+
+    resolvePreprocess({
+      blob: new Blob(["encoded"], { type: "image/jpeg" }),
+      width: 100,
+      height: 100,
+      contentType: "image/jpeg",
+      sha256: "abc",
+      previewUrl: "blob:preview-done",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+    });
+  });
+
+  it("surfaces preprocessing errors as a UI message", async () => {
+    setupSignedInEnv();
+
+    const preprocessPhoto = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("写真のサイズが上限（10MB）を超えています。"),
+      );
+
+    render(
+      <ParticipationAccess
+        preprocessPhoto={preprocessPhoto}
+        unitId="0xunit-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+    fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
+      target: { files: [makeFile("big.jpg", 11 * 1024 * 1024)] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(
+        "写真のサイズが上限",
+      );
+    });
   });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -10,16 +10,47 @@ import {
 import { isGoogleWallet } from "@mysten/enoki";
 import { useState } from "react";
 
-import {
-  EnokiSubmitClientError,
-  useSubmitPhoto,
-} from "../../../lib/enoki/client-submit";
+import { useSubmitPhoto } from "../../../lib/enoki/client-submit";
 import { useEnokiConfigState } from "../../../lib/enoki/provider";
+import {
+  type PreprocessedPhoto,
+  preprocessPhoto as defaultPreprocessPhoto,
+} from "../../../lib/image/preprocess";
+
+/**
+ * Waiting-room submission access.
+ *
+ * Phase 2 / STEP 3 scope: the UI walks the participant through
+ *
+ *   idle (not signed in)
+ *     -> ready (signed in; consent + file picker)
+ *     -> processing (client-side preprocess in flight)
+ *     -> previewing (preprocessed blob rendered)
+ *     -> error (preprocess failed)
+ *
+ * Walrus upload and `submit_photo` wiring land in STEP 4 — we intentionally
+ * stop at previewing for now. `useSubmitPhoto` is still instantiated so the
+ * hook contract stays warm and we can plug it in without re-threading props.
+ *
+ * Consent wording follows `docs/spec.md` §3.5 (Kakera is a Soulbound NFT) and
+ * §3.7 (the original image becomes retrievable by anyone who knows the
+ * Walrus `blob_id`).
+ */
+
+type PreprocessPhotoFn = (file: File) => Promise<PreprocessedPhoto>;
+
+type UploadPhase =
+  | { readonly kind: "ready" }
+  | { readonly kind: "processing" }
+  | { readonly kind: "previewing"; readonly photo: PreprocessedPhoto }
+  | { readonly kind: "error"; readonly message: string };
 
 export function ParticipationAccess({
   unitId,
+  preprocessPhoto,
 }: {
   readonly unitId: string;
+  readonly preprocessPhoto?: PreprocessPhotoFn;
 }): React.ReactElement {
   const state = useEnokiConfigState();
 
@@ -36,23 +67,33 @@ export function ParticipationAccess({
     );
   }
 
-  return <ParticipationAccessEnabled unitId={unitId} />;
+  return (
+    <ParticipationAccessEnabled
+      preprocessPhoto={preprocessPhoto ?? defaultPreprocessPhoto}
+      unitId={unitId}
+    />
+  );
 }
 
 function ParticipationAccessEnabled({
   unitId,
+  preprocessPhoto,
 }: {
   readonly unitId: string;
+  readonly preprocessPhoto: PreprocessPhotoFn;
 }): React.ReactElement {
   const wallets = useWallets();
   const currentAccount = useCurrentAccount();
   const currentWallet = useCurrentWallet();
   const connectWallet = useConnectWallet();
   const disconnectWallet = useDisconnectWallet();
-  const { isSubmitting, submitPhoto } = useSubmitPhoto(unitId);
+  // Keep the hook mounted so STEP 4 can wire it to the preprocessed blob
+  // without restructuring the component. Not invoked in STEP 3.
+  useSubmitPhoto(unitId);
+
   const [connectError, setConnectError] = useState<string | null>(null);
-  const [blobId, setBlobId] = useState("");
-  const [submitFeedback, setSubmitFeedback] = useState<string | null>(null);
+  const [consented, setConsented] = useState(false);
+  const [phase, setPhase] = useState<UploadPhase>({ kind: "ready" });
 
   const googleWallet = wallets.find(isGoogleWallet) ?? null;
   const isConnecting = currentWallet.connectionStatus === "connecting";
@@ -66,34 +107,28 @@ function ParticipationAccessEnabled({
     setConnectError(null);
 
     try {
-      await connectWallet.mutateAsync({
-        wallet: googleWallet,
-      });
+      await connectWallet.mutateAsync({ wallet: googleWallet });
     } catch (error) {
       setConnectError(toMessage(error));
     }
   }
 
-  async function handleSubmit(): Promise<void> {
-    setSubmitFeedback(null);
+  async function handleFileChange(file: File): Promise<void> {
+    setPhase({ kind: "processing" });
 
     try {
-      const result = await submitPhoto(blobId);
-      setSubmitFeedback(`送信を開始しました。digest: ${result.digest}`);
-      setBlobId("");
+      const photo = await preprocessPhoto(file);
+      setPhase({ kind: "previewing", photo });
     } catch (error) {
-      if (
-        error instanceof EnokiSubmitClientError &&
-        error.code === "auth_expired"
-      ) {
-        disconnectWallet.mutate();
-        setConnectError(error.message);
-        return;
-      }
-
-      setSubmitFeedback(toMessage(error));
+      setPhase({ kind: "error", message: toMessage(error) });
     }
   }
+
+  const isProcessing = phase.kind === "processing";
+  const fileInputDisabled = !consented || isProcessing;
+  const previewPhoto = phase.kind === "previewing" ? phase.photo : null;
+  const preprocessErrorMessage =
+    phase.kind === "error" ? phase.message : null;
 
   return (
     <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
@@ -112,30 +147,55 @@ function ParticipationAccessEnabled({
           <p className="font-mono text-xs break-all text-cyan-100">
             {currentAccount.address}
           </p>
-          <label className="grid gap-2 text-sm text-slate-200">
-            <span>仮の blob id</span>
-            {/* TODO(issue-next): replace this temporary blob input with Walrus upload output. */}
+
+          <label className="flex items-start gap-2 text-sm text-slate-200">
             <input
-              className="rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 font-mono text-sm text-white outline-none placeholder:text-slate-500"
+              checked={consented}
+              className="mt-1"
               onChange={(event) => {
-                setBlobId(event.target.value);
+                setConsented(event.target.checked);
               }}
-              placeholder="walrus-blob-id"
-              type="text"
-              value={blobId}
+              type="checkbox"
+            />
+            <span>
+              投稿した原画像は Walrus に保存され、blob_id
+              を知る人は誰でも取得できます。
+              また、参加の証として Soulbound（譲渡不可）の Kakera NFT
+              が自分のウォレットに発行されることに同意します。
+            </span>
+          </label>
+
+          <label className="grid gap-2 text-sm text-slate-200">
+            <span>写真を選択</span>
+            <input
+              accept="image/*"
+              disabled={fileInputDisabled}
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) {
+                  void handleFileChange(file);
+                }
+              }}
+              type="file"
             />
           </label>
+
+          {isProcessing ? (
+            <p className="text-sm text-slate-300" role="status">
+              処理中…
+            </p>
+          ) : null}
+
+          {previewPhoto ? (
+            // biome-ignore lint: client-side object URL preview, next/image not applicable.
+            <img
+              alt="投稿プレビュー"
+              className="max-w-full rounded-2xl border border-white/10"
+              src={previewPhoto.previewUrl}
+            />
+          ) : null}
+
           <div className="flex flex-wrap gap-3">
-            <button
-              className="rounded-full bg-amber-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-amber-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
-              disabled={blobId.trim().length === 0 || isSubmitting}
-              onClick={() => {
-                void handleSubmit();
-              }}
-              type="button"
-            >
-              {isSubmitting ? "送信中..." : "投稿用 Tx を試す"}
-            </button>
             <button
               className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
               onClick={() => disconnectWallet.mutate()}
@@ -174,12 +234,14 @@ function ParticipationAccessEnabled({
           {connectError}
         </p>
       ) : null}
-      {submitFeedback ? (
+
+      {preprocessErrorMessage ? (
         <p
           aria-live="polite"
-          className="rounded-2xl border border-cyan-300/20 bg-cyan-400/10 px-4 py-3 text-sm text-cyan-50"
+          className="rounded-2xl border border-amber-300/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-100"
+          role="alert"
         >
-          {submitFeedback}
+          {preprocessErrorMessage}
         </p>
       ) : null}
     </section>
@@ -191,5 +253,5 @@ function toMessage(error: unknown): string {
     return error.message;
   }
 
-  return "ログインに失敗しました。時間をおいて、もう一度お試しください。";
+  return "処理に失敗しました。時間をおいて、もう一度お試しください。";
 }

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -8,7 +8,7 @@ import {
   useWallets,
 } from "@mysten/dapp-kit";
 import { isGoogleWallet } from "@mysten/enoki";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   EnokiSubmitClientError,
@@ -155,6 +155,46 @@ function ParticipationAccessEnabled({
   const [consented, setConsented] = useState(false);
   const [phase, setPhase] = useState<UploadPhase>({ kind: "ready" });
 
+  // Tracks every object URL we have handed out so we can reliably
+  // `URL.revokeObjectURL` it when the user picks a different file or the
+  // component unmounts. Without this, re-selecting a photo (or sitting on a
+  // long-running session) leaks the encoded JPEG Blob inside the browser.
+  const previewUrlsRef = useRef<Set<string>>(new Set());
+  const registerPreviewUrl = (url: string): void => {
+    previewUrlsRef.current.add(url);
+  };
+  const revokePreviewUrls = (): void => {
+    const set = previewUrlsRef.current;
+    for (const url of Array.from(set)) {
+      if (
+        typeof URL !== "undefined" &&
+        typeof URL.revokeObjectURL === "function"
+      ) {
+        URL.revokeObjectURL(url);
+      }
+      set.delete(url);
+    }
+  };
+
+  // Final cleanup on unmount so the page-level navigation away from the
+  // waiting room does not leave preview blobs pinned. The cleanup reads
+  // the ref directly so it has no external dependencies — React hooks
+  // lint is satisfied with an empty dep list.
+  useEffect(() => {
+    const set = previewUrlsRef.current;
+    return () => {
+      for (const url of Array.from(set)) {
+        if (
+          typeof URL !== "undefined" &&
+          typeof URL.revokeObjectURL === "function"
+        ) {
+          URL.revokeObjectURL(url);
+        }
+        set.delete(url);
+      }
+    };
+  }, []);
+
   const googleWallet = wallets.find(isGoogleWallet) ?? null;
   const isConnecting = currentWallet.connectionStatus === "connecting";
 
@@ -188,10 +228,15 @@ function ParticipationAccessEnabled({
   }
 
   async function handleFileChange(file: File): Promise<void> {
+    // Revoke any preview from an earlier attempt before kicking off a new
+    // preprocess run — the old Blob/object URL is no longer referenced by
+    // the UI once we enter "processing".
+    revokePreviewUrls();
     setPhase({ kind: "processing" });
 
     try {
       const photo = await preprocessPhoto(file);
+      registerPreviewUrl(photo.previewUrl);
       setPhase({ kind: "previewing", photo });
     } catch (error) {
       setPhase({ kind: "error", message: toMessage(error) });
@@ -241,8 +286,14 @@ function ParticipationAccessEnabled({
   const isProcessing = phase.kind === "processing";
   const isUploading = phase.kind === "uploading";
   const isSubmitting = phase.kind === "submitting";
+  const isDone = phase.kind === "done";
+  // Submission is one-shot: once the on-chain `submit_photo` lands, the Move
+  // side rejects any further attempt from the same sender, but the UI must
+  // also stop offering an input that would let the user overwrite the
+  // participation card with an error state. Gate every interactive control
+  // on `isDone` so the success card is the terminal view for this unit.
   const fileInputDisabled =
-    !consented || isProcessing || isUploading || isSubmitting;
+    !consented || isProcessing || isUploading || isSubmitting || isDone;
   const previewPhoto =
     phase.kind === "previewing" ||
     phase.kind === "uploading" ||
@@ -254,6 +305,7 @@ function ParticipationAccessEnabled({
     phase.kind === "previewing" ||
     phase.kind === "uploading" ||
     phase.kind === "submitting";
+  const showConsentAndFilePicker = !isDone;
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
   const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
@@ -276,37 +328,41 @@ function ParticipationAccessEnabled({
             {currentAccount.address}
           </p>
 
-          <label className="flex items-start gap-2 text-sm text-slate-200">
-            <input
-              checked={consented}
-              className="mt-1"
-              onChange={(event) => {
-                setConsented(event.target.checked);
-              }}
-              type="checkbox"
-            />
-            <span>
-              投稿した原画像は Walrus に保存され、blob_id
-              を知る人は誰でも取得できます。 また、参加の証として
-              Soulbound（譲渡不可）の Kakera NFT
-              が自分のウォレットに発行されることに同意します。
-            </span>
-          </label>
+          {showConsentAndFilePicker ? (
+            <>
+              <label className="flex items-start gap-2 text-sm text-slate-200">
+                <input
+                  checked={consented}
+                  className="mt-1"
+                  onChange={(event) => {
+                    setConsented(event.target.checked);
+                  }}
+                  type="checkbox"
+                />
+                <span>
+                  投稿した原画像は Walrus に保存され、blob_id
+                  を知る人は誰でも取得できます。 また、参加の証として
+                  Soulbound（譲渡不可）の Kakera NFT
+                  が自分のウォレットに発行されることに同意します。
+                </span>
+              </label>
 
-          <label className="grid gap-2 text-sm text-slate-200">
-            <span>写真を選択</span>
-            <input
-              accept="image/*"
-              disabled={fileInputDisabled}
-              onChange={(event) => {
-                const file = event.target.files?.[0];
-                if (file) {
-                  void handleFileChange(file);
-                }
-              }}
-              type="file"
-            />
-          </label>
+              <label className="grid gap-2 text-sm text-slate-200">
+                <span>写真を選択</span>
+                <input
+                  accept="image/*"
+                  disabled={fileInputDisabled}
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleFileChange(file);
+                    }
+                  }}
+                  type="file"
+                />
+              </label>
+            </>
+          ) : null}
 
           {isProcessing ? (
             <p className="text-sm text-slate-300" role="status">

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -10,27 +10,42 @@ import {
 import { isGoogleWallet } from "@mysten/enoki";
 import { useState } from "react";
 
-import { useSubmitPhoto } from "../../../lib/enoki/client-submit";
+import {
+  EnokiSubmitClientError,
+  type SubmitPhotoSuccess,
+  useSubmitPhoto,
+} from "../../../lib/enoki/client-submit";
 import { useEnokiConfigState } from "../../../lib/enoki/provider";
 import {
   type PreprocessedPhoto,
   preprocessPhoto as defaultPreprocessPhoto,
 } from "../../../lib/image/preprocess";
+import {
+  putBlobToWalrus as defaultPutBlobToWalrus,
+  type WalrusEnv,
+  WalrusPutError,
+  type WalrusPutResult,
+} from "../../../lib/walrus/put";
 
 /**
  * Waiting-room submission access.
  *
- * Phase 2 / STEP 3 scope: the UI walks the participant through
+ * Phase 2 / STEP 4 scope: the UI walks the participant through the full
+ * submission line:
  *
  *   idle (not signed in)
  *     -> ready (signed in; consent + file picker)
  *     -> processing (client-side preprocess in flight)
  *     -> previewing (preprocessed blob rendered)
- *     -> error (preprocess failed)
+ *     -> uploading (Walrus PUT in flight)
+ *     -> submitting (Sponsored Tx `submit_photo` in flight)
+ *     -> done (digest displayed)
+ *     -> error (any of the above branches surface a UI message)
  *
- * Walrus upload and `submit_photo` wiring land in STEP 4 — we intentionally
- * stop at previewing for now. `useSubmitPhoto` is still instantiated so the
- * hook contract stays warm and we can plug it in without re-threading props.
+ * `putBlobToWalrus` and `useSubmitPhoto` are both injected through props so the
+ * test harness can drive the orchestration directly. The `moveCallTargets`
+ * constraint (see `CLAUDE.md`: only `PACKAGE_ID::accessors::submit_photo`) is
+ * enforced server-side inside `useSubmitPhoto`; we do not re-thread it here.
  *
  * Consent wording follows `docs/spec.md` §3.5 (Kakera is a Soulbound NFT) and
  * §3.7 (the original image becomes retrievable by anyone who knows the
@@ -38,19 +53,34 @@ import {
  */
 
 type PreprocessPhotoFn = (file: File) => Promise<PreprocessedPhoto>;
+type PutBlobFn = (
+  photo: PreprocessedPhoto,
+  deps: { readonly env: WalrusEnv },
+) => Promise<WalrusPutResult>;
 
 type UploadPhase =
   | { readonly kind: "ready" }
   | { readonly kind: "processing" }
   | { readonly kind: "previewing"; readonly photo: PreprocessedPhoto }
+  | { readonly kind: "uploading"; readonly photo: PreprocessedPhoto }
+  | {
+      readonly kind: "submitting";
+      readonly photo: PreprocessedPhoto;
+      readonly blobId: string;
+    }
+  | { readonly kind: "done"; readonly result: SubmitPhotoSuccess }
   | { readonly kind: "error"; readonly message: string };
 
 export function ParticipationAccess({
   unitId,
   preprocessPhoto,
+  putBlob,
+  walrusEnv,
 }: {
   readonly unitId: string;
   readonly preprocessPhoto?: PreprocessPhotoFn;
+  readonly putBlob?: PutBlobFn;
+  readonly walrusEnv?: WalrusEnv;
 }): React.ReactElement {
   const state = useEnokiConfigState();
 
@@ -70,7 +100,9 @@ export function ParticipationAccess({
   return (
     <ParticipationAccessEnabled
       preprocessPhoto={preprocessPhoto ?? defaultPreprocessPhoto}
+      putBlob={putBlob ?? defaultPutBlobToWalrus}
       unitId={unitId}
+      walrusEnv={walrusEnv ?? readWalrusEnvFromProcess()}
     />
   );
 }
@@ -78,18 +110,20 @@ export function ParticipationAccess({
 function ParticipationAccessEnabled({
   unitId,
   preprocessPhoto,
+  putBlob,
+  walrusEnv,
 }: {
   readonly unitId: string;
   readonly preprocessPhoto: PreprocessPhotoFn;
+  readonly putBlob: PutBlobFn;
+  readonly walrusEnv: WalrusEnv;
 }): React.ReactElement {
   const wallets = useWallets();
   const currentAccount = useCurrentAccount();
   const currentWallet = useCurrentWallet();
   const connectWallet = useConnectWallet();
   const disconnectWallet = useDisconnectWallet();
-  // Keep the hook mounted so STEP 4 can wire it to the preprocessed blob
-  // without restructuring the component. Not invoked in STEP 3.
-  useSubmitPhoto(unitId);
+  const { submitPhoto } = useSubmitPhoto(unitId);
 
   const [connectError, setConnectError] = useState<string | null>(null);
   const [consented, setConsented] = useState(false);
@@ -124,11 +158,57 @@ function ParticipationAccessEnabled({
     }
   }
 
+  async function handleSubmit(photo: PreprocessedPhoto): Promise<void> {
+    setPhase({ kind: "uploading", photo });
+
+    let putResult: WalrusPutResult;
+    try {
+      putResult = await putBlob(photo, { env: walrusEnv });
+    } catch (error) {
+      setPhase({
+        kind: "error",
+        message: classifyWalrusError(error),
+      });
+      return;
+    }
+
+    setPhase({ kind: "submitting", photo, blobId: putResult.blobId });
+
+    try {
+      const result = await submitPhoto(putResult.blobId);
+      setPhase({ kind: "done", result });
+    } catch (error) {
+      if (isAuthExpired(error)) {
+        // 認証切れは再ログイン導線へ戻す。wallet を切断して
+        // <Google でログイン> ボタンが再表示される状態にする。
+        disconnectWallet.mutate();
+        setConnectError(toMessage(error));
+        setPhase({ kind: "ready" });
+        return;
+      }
+      setPhase({ kind: "error", message: toSubmitErrorMessage(error) });
+    }
+  }
+
   const isProcessing = phase.kind === "processing";
-  const fileInputDisabled = !consented || isProcessing;
-  const previewPhoto = phase.kind === "previewing" ? phase.photo : null;
-  const preprocessErrorMessage =
+  const isUploading = phase.kind === "uploading";
+  const isSubmitting = phase.kind === "submitting";
+  const fileInputDisabled =
+    !consented || isProcessing || isUploading || isSubmitting;
+  const previewPhoto =
+    phase.kind === "previewing" ||
+    phase.kind === "uploading" ||
+    phase.kind === "submitting"
+      ? phase.photo
+      : null;
+  const submitButtonDisabled = isUploading || isSubmitting;
+  const showSubmitButton =
+    phase.kind === "previewing" ||
+    phase.kind === "uploading" ||
+    phase.kind === "submitting";
+  const phaseErrorMessage =
     phase.kind === "error" ? phase.message : null;
+  const doneResult = phase.kind === "done" ? phase.result : null;
 
   return (
     <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
@@ -195,6 +275,47 @@ function ParticipationAccessEnabled({
             />
           ) : null}
 
+          {isUploading ? (
+            <p className="text-sm text-slate-300" role="status">
+              Walrus に保存しています…
+            </p>
+          ) : null}
+
+          {isSubmitting ? (
+            <p className="text-sm text-slate-300" role="status">
+              オンチェーンに投稿しています…
+            </p>
+          ) : null}
+
+          {showSubmitButton ? (
+            <div className="flex flex-wrap gap-3">
+              <button
+                className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
+                disabled={submitButtonDisabled}
+                onClick={() => {
+                  if (phase.kind === "previewing") {
+                    void handleSubmit(phase.photo);
+                  }
+                }}
+                type="button"
+              >
+                投稿を確定
+              </button>
+            </div>
+          ) : null}
+
+          {doneResult ? (
+            <div
+              className="grid gap-1 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-100"
+              role="status"
+            >
+              <p>投稿が完了しました。</p>
+              <p className="font-mono text-xs break-all">
+                digest: {doneResult.digest}
+              </p>
+            </div>
+          ) : null}
+
           <div className="flex flex-wrap gap-3">
             <button
               className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
@@ -235,13 +356,13 @@ function ParticipationAccessEnabled({
         </p>
       ) : null}
 
-      {preprocessErrorMessage ? (
+      {phaseErrorMessage ? (
         <p
           aria-live="polite"
           className="rounded-2xl border border-amber-300/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-100"
           role="alert"
         >
-          {preprocessErrorMessage}
+          {phaseErrorMessage}
         </p>
       ) : null}
     </section>
@@ -254,4 +375,41 @@ function toMessage(error: unknown): string {
   }
 
   return "処理に失敗しました。時間をおいて、もう一度お試しください。";
+}
+
+/**
+ * Normalize {@link WalrusPutError} to a UI-friendly message. `transient` only
+ * surfaces here after the internal retry loop has exhausted 3 attempts, so we
+ * treat it the same as `final`. `config_missing` keeps its own wording because
+ * it signals an operator misconfiguration rather than a retryable failure.
+ */
+function classifyWalrusError(error: unknown): string {
+  if (error instanceof WalrusPutError) {
+    return error.message;
+  }
+  return toMessage(error);
+}
+
+function isAuthExpired(error: unknown): boolean {
+  return (
+    error instanceof EnokiSubmitClientError && error.code === "auth_expired"
+  );
+}
+
+function toSubmitErrorMessage(error: unknown): string {
+  if (error instanceof EnokiSubmitClientError) {
+    return error.message;
+  }
+  return toMessage(error);
+}
+
+function readWalrusEnvFromProcess(): WalrusEnv {
+  // Next.js inlines `process.env.NEXT_PUBLIC_*` at build time on the client;
+  // on the server the same access pattern works. `putBlobToWalrus` throws a
+  // `config_missing` error if either value is empty, which the UI then
+  // surfaces through {@link classifyWalrusError}.
+  return {
+    NEXT_PUBLIC_WALRUS_PUBLISHER: process.env.NEXT_PUBLIC_WALRUS_PUBLISHER,
+    NEXT_PUBLIC_WALRUS_AGGREGATOR: process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR,
+  };
 }

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -16,10 +16,13 @@ import {
   useSubmitPhoto,
 } from "../../../lib/enoki/client-submit";
 import { useEnokiConfigState } from "../../../lib/enoki/provider";
+import { loadPublicEnv } from "../../../lib/env";
 import {
-  type PreprocessedPhoto,
   preprocessPhoto as defaultPreprocessPhoto,
+  type PreprocessedPhoto,
 } from "../../../lib/image/preprocess";
+import { getSuiClient } from "../../../lib/sui";
+import { useOwnedKakera } from "../../../lib/sui/react";
 import {
   putBlobToWalrus as defaultPutBlobToWalrus,
   type WalrusEnv,
@@ -68,7 +71,12 @@ type UploadPhase =
       readonly photo: PreprocessedPhoto;
       readonly blobId: string;
     }
-  | { readonly kind: "done"; readonly result: SubmitPhotoSuccess }
+  | {
+      readonly kind: "done";
+      readonly result: SubmitPhotoSuccess;
+      readonly photo: PreprocessedPhoto;
+      readonly blobId: string;
+    }
   | { readonly kind: "error"; readonly message: string };
 
 export function ParticipationAccess({
@@ -132,6 +140,20 @@ function ParticipationAccessEnabled({
   const googleWallet = wallets.find(isGoogleWallet) ?? null;
   const isConnecting = currentWallet.connectionStatus === "connecting";
 
+  // Kakera polling kicks in only once we know the Walrus blob id and the
+  // zkLogin address. The hook stays idle while any of the inputs are
+  // missing (`ownerAddress: null` branch inside `useOwnedKakera`).
+  const doneBlobId = phase.kind === "done" ? phase.blobId : "";
+  const packageId = safeReadPackageId();
+  const ownedKakera = useOwnedKakera({
+    suiClient: getSuiClient(),
+    ownerAddress:
+      phase.kind === "done" ? (currentAccount?.address ?? null) : null,
+    unitId,
+    walrusBlobId: doneBlobId,
+    packageId: packageId ?? "",
+  });
+
   async function handleLogin(): Promise<void> {
     if (!googleWallet) {
       setConnectError("Google ログインの設定が見つかりません。");
@@ -176,7 +198,12 @@ function ParticipationAccessEnabled({
 
     try {
       const result = await submitPhoto(putResult.blobId);
-      setPhase({ kind: "done", result });
+      setPhase({
+        kind: "done",
+        result,
+        photo,
+        blobId: putResult.blobId,
+      });
     } catch (error) {
       if (isAuthExpired(error)) {
         // 認証切れは再ログイン導線へ戻す。wallet を切断して
@@ -206,9 +233,8 @@ function ParticipationAccessEnabled({
     phase.kind === "previewing" ||
     phase.kind === "uploading" ||
     phase.kind === "submitting";
-  const phaseErrorMessage =
-    phase.kind === "error" ? phase.message : null;
-  const doneResult = phase.kind === "done" ? phase.result : null;
+  const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
+  const donePhase = phase.kind === "done" ? phase : null;
 
   return (
     <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
@@ -239,8 +265,8 @@ function ParticipationAccessEnabled({
             />
             <span>
               投稿した原画像は Walrus に保存され、blob_id
-              を知る人は誰でも取得できます。
-              また、参加の証として Soulbound（譲渡不可）の Kakera NFT
+              を知る人は誰でも取得できます。 また、参加の証として
+              Soulbound（譲渡不可）の Kakera NFT
               が自分のウォレットに発行されることに同意します。
             </span>
           </label>
@@ -304,14 +330,53 @@ function ParticipationAccessEnabled({
             </div>
           ) : null}
 
-          {doneResult ? (
+          {donePhase ? (
             <div
-              className="grid gap-1 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-100"
+              className="grid gap-3 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100"
               role="status"
             >
-              <p>投稿が完了しました。</p>
-              <p className="font-mono text-xs break-all">
-                digest: {doneResult.digest}
+              <p className="text-base">投稿が完了しました。</p>
+
+              {/* biome-ignore lint: local object URL preview, next/image N/A. */}
+              <img
+                alt="投稿プレビュー"
+                className="max-w-full rounded-xl border border-white/10"
+                src={donePhase.photo.previewUrl}
+              />
+
+              <dl className="grid gap-2">
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    送信アドレス
+                  </dt>
+                  <dd className="font-mono text-xs break-all">
+                    {donePhase.result.sender}
+                  </dd>
+                </div>
+
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    submission_no
+                  </dt>
+                  <dd className="font-mono text-sm">
+                    {ownedKakera.kakera
+                      ? `#${ownedKakera.kakera.submissionNo}`
+                      : "確認中…"}
+                  </dd>
+                </div>
+
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    digest
+                  </dt>
+                  <dd className="font-mono text-xs break-all">
+                    {donePhase.result.digest}
+                  </dd>
+                </div>
+              </dl>
+
+              <p aria-live="polite" className="text-xs text-emerald-100/90">
+                {describeKakeraStatus(ownedKakera.status)}
               </p>
             </div>
           ) : null}
@@ -412,4 +477,33 @@ function readWalrusEnvFromProcess(): WalrusEnv {
     NEXT_PUBLIC_WALRUS_PUBLISHER: process.env.NEXT_PUBLIC_WALRUS_PUBLISHER,
     NEXT_PUBLIC_WALRUS_AGGREGATOR: process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR,
   };
+}
+
+function safeReadPackageId(): string | null {
+  try {
+    return loadPublicEnv(process.env).packageId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * User-facing narration of the Kakera polling state. The `idle` case only
+ * appears while we don't yet have an owner + blob id pair, so the card
+ * uses empty wording; the rest map to the three visible states listed in
+ * the STEP 5 spec.
+ */
+function describeKakeraStatus(
+  status: "idle" | "searching" | "found" | "timeout",
+): string {
+  switch (status) {
+    case "found":
+      return "Kakera を受け取りました。";
+    case "timeout":
+      return "Kakera を確認できませんでした（タイムアウト）。時間を置いてから再読み込みしてください。";
+    case "searching":
+      return "Kakera を確認しています…";
+    default:
+      return "";
+  }
 }

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -61,6 +61,20 @@ type PutBlobFn = (
   deps: { readonly env: WalrusEnv },
 ) => Promise<WalrusPutResult>;
 
+/**
+ * Recoverable error context.
+ *
+ * `retry.kind === "upload"` means the Walrus PUT failed after our internal
+ * retries were exhausted, but the locally preprocessed photo is still valid.
+ * The UI can offer a "もう一度送信する" button that jumps straight back to
+ * the uploading phase with the same {@link PreprocessedPhoto}, skipping
+ * preprocessing.
+ */
+type RetryContext = {
+  readonly kind: "upload";
+  readonly photo: PreprocessedPhoto;
+};
+
 type UploadPhase =
   | { readonly kind: "ready" }
   | { readonly kind: "processing" }
@@ -77,7 +91,11 @@ type UploadPhase =
       readonly photo: PreprocessedPhoto;
       readonly blobId: string;
     }
-  | { readonly kind: "error"; readonly message: string };
+  | {
+      readonly kind: "error";
+      readonly message: string;
+      readonly retry?: RetryContext;
+    };
 
 export function ParticipationAccess({
   unitId,
@@ -190,6 +208,9 @@ function ParticipationAccessEnabled({
       setPhase({
         kind: "error",
         message: classifyWalrusError(error),
+        // Keep the preprocessed photo so the "もう一度送信する" button can
+        // retry the Walrus PUT without re-running preprocessing.
+        retry: isWalrusRetryable(error) ? { kind: "upload", photo } : undefined,
       });
       return;
     }
@@ -234,6 +255,7 @@ function ParticipationAccessEnabled({
     phase.kind === "uploading" ||
     phase.kind === "submitting";
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
+  const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
 
   return (
@@ -430,6 +452,23 @@ function ParticipationAccessEnabled({
           {phaseErrorMessage}
         </p>
       ) : null}
+
+      {phaseRetry ? (
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200"
+            onClick={() => {
+              // Jump straight back into the Walrus upload step with the same
+              // PreprocessedPhoto; the user does not have to re-select or
+              // re-preprocess the image.
+              void handleSubmit(phaseRetry.photo);
+            }}
+            type="button"
+          >
+            もう一度送信する
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -453,6 +492,25 @@ function classifyWalrusError(error: unknown): string {
     return error.message;
   }
   return toMessage(error);
+}
+
+/**
+ * Whether a Walrus PUT failure is worth offering a "retry" button for.
+ *
+ * `config_missing` is a deploy-time misconfiguration (missing publisher /
+ * aggregator URL), so clicking retry will only produce the same error. The
+ * internal retry loop in `putBlobToWalrus` already surfaces `transient` only
+ * after exhausting 3 attempts — but the user may still recover by getting to
+ * a better network, so we treat it as retryable. `final` covers genuine
+ * Walrus-side failures and is likewise retryable from the user's perspective.
+ */
+function isWalrusRetryable(error: unknown): boolean {
+  if (!(error instanceof WalrusPutError)) {
+    // Non-Walrus errors (e.g. a thrown string from a test fixture) are not
+    // something the retry path can fix; be conservative and hide the button.
+    return false;
+  }
+  return error.kind === "final" || error.kind === "transient";
 }
 
 function isAuthExpired(error: unknown): boolean {

--- a/apps/web/src/lib/image/preprocess.test.ts
+++ b/apps/web/src/lib/image/preprocess.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ImagePreprocessError, preprocessPhoto } from "./preprocess";
+
+const TEN_MB = 10 * 1024 * 1024;
+
+/**
+ * Create a fake {@link File} of an exact byte length without allocating real
+ * image bytes. The preprocessing pipeline never inspects these bytes because
+ * we inject the `createImageBitmap` dependency in tests.
+ */
+function fakeFile(options: {
+  readonly size: number;
+  readonly type?: string;
+  readonly name?: string;
+}): File {
+  const bytes = new Uint8Array(options.size);
+  return new File([bytes], options.name ?? "photo.jpg", {
+    type: options.type ?? "image/jpeg",
+  });
+}
+
+type FakeBitmap = {
+  readonly width: number;
+  readonly height: number;
+  close: () => void;
+};
+
+function fakeBitmap(width: number, height: number): FakeBitmap {
+  return {
+    width,
+    height,
+    close: vi.fn(),
+  };
+}
+
+type DrawCall = {
+  readonly bitmap: unknown;
+  readonly dx: number;
+  readonly dy: number;
+  readonly dw: number;
+  readonly dh: number;
+};
+
+function buildDeps(options?: {
+  readonly bitmap?: FakeBitmap;
+  readonly encoded?: Blob;
+  readonly digest?: ArrayBuffer;
+  readonly previewUrl?: string;
+}) {
+  const drawCalls: DrawCall[] = [];
+  const convertOptions: { type: string; quality: number }[] = [];
+  const bitmap = options?.bitmap ?? fakeBitmap(2000, 1000);
+  const encoded =
+    options?.encoded ?? new Blob([new Uint8Array(64)], { type: "image/jpeg" });
+  const digestBuffer = options?.digest ?? new ArrayBuffer(32);
+  const previewUrl = options?.previewUrl ?? "blob:preview";
+
+  const createImageBitmap = vi.fn(async (_input: Blob) => bitmap);
+  const createCanvas = vi.fn((width: number, height: number) => ({
+    width,
+    height,
+    getContext: (_type: "2d") => ({
+      drawImage: (
+        b: unknown,
+        dx: number,
+        dy: number,
+        dw: number,
+        dh: number,
+      ) => {
+        drawCalls.push({ bitmap: b, dx, dy, dw, dh });
+      },
+    }),
+    convertToBlob: async ({
+      type,
+      quality,
+    }: {
+      readonly type: string;
+      readonly quality: number;
+    }) => {
+      convertOptions.push({ type, quality });
+      return encoded;
+    },
+  }));
+  const digest = vi.fn(
+    async (_algorithm: "SHA-256", _data: ArrayBuffer) => digestBuffer,
+  );
+  const createObjectURL = vi.fn((_blob: Blob) => previewUrl);
+
+  return {
+    deps: {
+      createImageBitmap,
+      createCanvas,
+      digest,
+      createObjectURL,
+    },
+    drawCalls,
+    convertOptions,
+    createImageBitmap,
+    createCanvas,
+    digest,
+    createObjectURL,
+  };
+}
+
+describe("preprocessPhoto", () => {
+  it("rejects files larger than 10MB before decoding", async () => {
+    const { deps, createImageBitmap } = buildDeps();
+    const file = fakeFile({ size: TEN_MB + 1 });
+
+    await expect(preprocessPhoto(file, deps)).rejects.toBeInstanceOf(
+      ImagePreprocessError,
+    );
+    await expect(preprocessPhoto(file, deps)).rejects.toMatchObject({
+      code: "file_too_large",
+    });
+    expect(createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it("accepts files exactly at the 10MB limit", async () => {
+    const { deps } = buildDeps();
+    const file = fakeFile({ size: TEN_MB });
+
+    await expect(preprocessPhoto(file, deps)).resolves.toMatchObject({
+      contentType: "image/jpeg",
+    });
+  });
+
+  it("resizes the long edge down to 1024px while preserving aspect ratio", async () => {
+    const { deps, createCanvas, drawCalls } = buildDeps({
+      bitmap: fakeBitmap(2048, 1024),
+    });
+    const file = fakeFile({ size: 1024 });
+
+    const result = await preprocessPhoto(file, deps);
+
+    expect(createCanvas).toHaveBeenCalledWith(1024, 512);
+    expect(drawCalls).toHaveLength(1);
+    expect(drawCalls[0]).toMatchObject({
+      dx: 0,
+      dy: 0,
+      dw: 1024,
+      dh: 512,
+    });
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(512);
+  });
+
+  it("does not upscale when both edges are within 1024px", async () => {
+    const { deps, createCanvas } = buildDeps({
+      bitmap: fakeBitmap(800, 600),
+    });
+    const file = fakeFile({ size: 1024 });
+
+    const result = await preprocessPhoto(file, deps);
+
+    expect(createCanvas).toHaveBeenCalledWith(800, 600);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(600);
+  });
+
+  it("re-encodes to JPEG at quality 0.85 (EXIF is dropped by the re-encode)", async () => {
+    const reencoded = new Blob([new Uint8Array(128)], { type: "image/jpeg" });
+    const { deps, convertOptions } = buildDeps({
+      bitmap: fakeBitmap(1000, 500),
+      encoded: reencoded,
+    });
+    // The input file stands in for a photo that may carry EXIF metadata.
+    // After preprocessing, the output must be the re-encoded blob, not the
+    // original file – the re-encode path is what strips EXIF.
+    const file = fakeFile({ size: 4096, type: "image/jpeg" });
+
+    const result = await preprocessPhoto(file, deps);
+
+    expect(convertOptions).toEqual([{ type: "image/jpeg", quality: 0.85 }]);
+    expect(result.contentType).toBe("image/jpeg");
+    expect(result.blob).toBe(reencoded);
+    expect(result.blob).not.toBe(file);
+  });
+
+  it("computes SHA-256 of the re-encoded blob via the injected digest", async () => {
+    const digestBytes = new Uint8Array(32);
+    for (let index = 0; index < digestBytes.length; index += 1) {
+      digestBytes[index] = index;
+    }
+    const { deps, digest } = buildDeps({
+      digest: digestBytes.buffer,
+    });
+    const file = fakeFile({ size: 1024 });
+
+    const result = await preprocessPhoto(file, deps);
+
+    expect(digest).toHaveBeenCalledTimes(1);
+    expect(digest.mock.calls[0]?.[0]).toBe("SHA-256");
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.sha256).toBe(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    );
+  });
+
+  it("returns a preview URL produced from the re-encoded blob", async () => {
+    const { deps, createObjectURL } = buildDeps({
+      previewUrl: "blob:fake-preview",
+    });
+    const file = fakeFile({ size: 1024 });
+
+    const result = await preprocessPhoto(file, deps);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(result.previewUrl).toBe("blob:fake-preview");
+  });
+
+  it("wraps decode failures into a UI-friendly ImagePreprocessError", async () => {
+    const { deps, createImageBitmap } = buildDeps();
+    createImageBitmap.mockRejectedValueOnce(new Error("bad image"));
+    const file = fakeFile({ size: 1024 });
+
+    try {
+      await preprocessPhoto(file, deps);
+      expect.unreachable("preprocessPhoto should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ImagePreprocessError);
+      const e = error as ImagePreprocessError;
+      expect(e.code).toBe("decode_failed");
+      expect(e.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("surfaces a UI-friendly message on the file_too_large error", async () => {
+    const { deps } = buildDeps();
+    const file = fakeFile({ size: TEN_MB + 1 });
+
+    try {
+      await preprocessPhoto(file, deps);
+      expect.unreachable("preprocessPhoto should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ImagePreprocessError);
+      const e = error as ImagePreprocessError;
+      expect(e.code).toBe("file_too_large");
+      expect(e.message).toContain("10MB");
+    }
+  });
+});

--- a/apps/web/src/lib/image/preprocess.ts
+++ b/apps/web/src/lib/image/preprocess.ts
@@ -1,0 +1,275 @@
+"use client";
+
+/**
+ * Client-side photo preprocessing for Walrus uploads.
+ *
+ * Spec (see `docs/tech.md` §5.3 / §6):
+ * - 入力は 10MB 上限でサイズ検証
+ * - 長辺 1024px へリサイズ（縮小のみ、拡大しない）
+ * - JPEG 品質 0.85 で再エンコード（EXIF は再エンコードで除去される）
+ * - 再エンコード後の Blob から SHA-256 を算出
+ * - UI が貼れるプレビュー URL を返す
+ *
+ * ブラウザ API（`createImageBitmap` / `OffscreenCanvas` / `crypto.subtle` /
+ * `URL.createObjectURL`）は DI で差し替え可能にして、テスト環境（happy-dom /
+ * jsdom）でもロジックを検証できるようにしている。
+ */
+
+export const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+export const MAX_LONG_EDGE_PX = 1024;
+export const JPEG_QUALITY = 0.85;
+export const OUTPUT_CONTENT_TYPE = "image/jpeg";
+
+export type ImagePreprocessErrorCode =
+  | "file_too_large"
+  | "decode_failed"
+  | "encode_failed"
+  | "canvas_unavailable"
+  | "digest_unavailable";
+
+export class ImagePreprocessError extends Error {
+  readonly code: ImagePreprocessErrorCode;
+
+  constructor(code: ImagePreprocessErrorCode, message: string) {
+    super(message);
+    this.name = "ImagePreprocessError";
+    this.code = code;
+  }
+}
+
+export type PreprocessedPhoto = {
+  readonly blob: Blob;
+  readonly width: number;
+  readonly height: number;
+  readonly contentType: "image/jpeg";
+  readonly sha256: string;
+  readonly previewUrl: string;
+};
+
+type BitmapLike = {
+  readonly width: number;
+  readonly height: number;
+  close?: () => void;
+};
+
+type CanvasContextLike = {
+  drawImage: (
+    image: BitmapLike,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ) => void;
+};
+
+type CanvasLike = {
+  getContext: (type: "2d") => CanvasContextLike | null;
+  convertToBlob: (options: {
+    readonly type: string;
+    readonly quality: number;
+  }) => Promise<Blob>;
+};
+
+export type PreprocessDeps = {
+  readonly createImageBitmap?: (blob: Blob) => Promise<BitmapLike>;
+  readonly createCanvas?: (width: number, height: number) => CanvasLike;
+  readonly digest?: (
+    algorithm: "SHA-256",
+    data: ArrayBuffer,
+  ) => Promise<ArrayBuffer>;
+  readonly createObjectURL?: (blob: Blob) => string;
+};
+
+/**
+ * Preprocess an uploaded photo for Walrus ingestion.
+ *
+ * Throws {@link ImagePreprocessError} with a UI-friendly Japanese message when
+ * validation / decoding / encoding fails.
+ */
+export async function preprocessPhoto(
+  file: File,
+  deps: PreprocessDeps = {},
+): Promise<PreprocessedPhoto> {
+  if (file.size > MAX_PHOTO_BYTES) {
+    throw new ImagePreprocessError(
+      "file_too_large",
+      "写真のサイズが上限（10MB）を超えています。別の写真を選び直してください。",
+    );
+  }
+
+  const bitmap = await decode(file, deps);
+
+  try {
+    const { width, height } = fitWithinLongEdge(
+      bitmap.width,
+      bitmap.height,
+      MAX_LONG_EDGE_PX,
+    );
+
+    const blob = await reencode(bitmap, width, height, deps);
+    const sha256 = await sha256Hex(blob, deps);
+    const previewUrl = makePreviewUrl(blob, deps);
+
+    return {
+      blob,
+      width,
+      height,
+      contentType: OUTPUT_CONTENT_TYPE,
+      sha256,
+      previewUrl,
+    };
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+async function decode(file: File, deps: PreprocessDeps): Promise<BitmapLike> {
+  const decoder = deps.createImageBitmap ?? resolveDefaultBitmapDecoder();
+
+  if (!decoder) {
+    throw new ImagePreprocessError(
+      "canvas_unavailable",
+      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+    );
+  }
+
+  try {
+    return await decoder(file);
+  } catch {
+    throw new ImagePreprocessError(
+      "decode_failed",
+      "写真を読み込めませんでした。別の写真で試してみてください。",
+    );
+  }
+}
+
+async function reencode(
+  bitmap: BitmapLike,
+  width: number,
+  height: number,
+  deps: PreprocessDeps,
+): Promise<Blob> {
+  const canvasFactory = deps.createCanvas ?? resolveDefaultCanvasFactory();
+
+  if (!canvasFactory) {
+    throw new ImagePreprocessError(
+      "canvas_unavailable",
+      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+    );
+  }
+
+  const canvas = canvasFactory(width, height);
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new ImagePreprocessError(
+      "canvas_unavailable",
+      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+    );
+  }
+
+  context.drawImage(bitmap, 0, 0, width, height);
+
+  try {
+    return await canvas.convertToBlob({
+      type: OUTPUT_CONTENT_TYPE,
+      quality: JPEG_QUALITY,
+    });
+  } catch {
+    throw new ImagePreprocessError(
+      "encode_failed",
+      "写真の変換に失敗しました。もう一度お試しください。",
+    );
+  }
+}
+
+async function sha256Hex(blob: Blob, deps: PreprocessDeps): Promise<string> {
+  const digestFn = deps.digest ?? resolveDefaultDigest();
+
+  if (!digestFn) {
+    throw new ImagePreprocessError(
+      "digest_unavailable",
+      "このブラウザでは写真のハッシュ計算がサポートされていません。別の環境でお試しください。",
+    );
+  }
+
+  const buffer = await blob.arrayBuffer();
+  const hash = await digestFn("SHA-256", buffer);
+  return toHex(new Uint8Array(hash));
+}
+
+function makePreviewUrl(blob: Blob, deps: PreprocessDeps): string {
+  const create = deps.createObjectURL ?? resolveDefaultObjectUrl();
+
+  if (!create) {
+    throw new ImagePreprocessError(
+      "canvas_unavailable",
+      "このブラウザでは写真のプレビュー表示がサポートされていません。別の環境でお試しください。",
+    );
+  }
+
+  return create(blob);
+}
+
+function fitWithinLongEdge(
+  width: number,
+  height: number,
+  maxLongEdge: number,
+): { readonly width: number; readonly height: number } {
+  const longEdge = Math.max(width, height);
+  if (longEdge <= maxLongEdge) {
+    return { width, height };
+  }
+
+  const scale = maxLongEdge / longEdge;
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let index = 0; index < bytes.length; index += 1) {
+    const byte = bytes[index] ?? 0;
+    out += byte.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+function resolveDefaultBitmapDecoder():
+  | ((blob: Blob) => Promise<BitmapLike>)
+  | undefined {
+  const value = (globalThis as Record<string, unknown>).createImageBitmap;
+  return typeof value === "function"
+    ? (value as (blob: Blob) => Promise<BitmapLike>)
+    : undefined;
+}
+
+function resolveDefaultCanvasFactory():
+  | ((width: number, height: number) => CanvasLike)
+  | undefined {
+  const ctor = (globalThis as Record<string, unknown>).OffscreenCanvas;
+  if (typeof ctor !== "function") {
+    return undefined;
+  }
+  const Ctor = ctor as new (w: number, h: number) => CanvasLike;
+  return (width, height) => new Ctor(width, height);
+}
+
+function resolveDefaultDigest():
+  | ((algorithm: "SHA-256", data: ArrayBuffer) => Promise<ArrayBuffer>)
+  | undefined {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    return undefined;
+  }
+  return (algorithm, data) => subtle.digest(algorithm, data);
+}
+
+function resolveDefaultObjectUrl(): ((blob: Blob) => string) | undefined {
+  if (typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+    return undefined;
+  }
+  return URL.createObjectURL.bind(URL);
+}

--- a/apps/web/src/lib/sui/kakera.test.ts
+++ b/apps/web/src/lib/sui/kakera.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { findKakeraForSubmission, type KakeraOwnedClient } from "./kakera";
+
+const PACKAGE_ID = "0xpkg";
+const OWNER = "0xowner";
+const UNIT_ID = "0xunit-1";
+const WALRUS_BLOB_ID = "walrus-blob-xyz";
+
+/**
+ * `vector<u8>` serializes in `showContent` responses as an array of byte
+ * integers. The Move side stores the Walrus blob id as UTF-8 bytes of the
+ * string returned by the Publisher (see `lib/enoki/submit-photo.ts`), so
+ * tests mirror the same shape.
+ */
+function encodeBytes(value: string): number[] {
+  return Array.from(new TextEncoder().encode(value));
+}
+
+function kakeraObject(overrides: {
+  readonly type?: string;
+  readonly fields?: Partial<{
+    unit_id: unknown;
+    walrus_blob_id: unknown;
+    submission_no: unknown;
+    submitter: unknown;
+  }>;
+  readonly objectId?: string;
+}) {
+  return {
+    data: {
+      objectId: overrides.objectId ?? "0xkakera-1",
+      digest: "d",
+      version: "1",
+      type: overrides.type ?? `${PACKAGE_ID}::kakera::Kakera`,
+      content: {
+        dataType: "moveObject",
+        hasPublicTransfer: false,
+        type: overrides.type ?? `${PACKAGE_ID}::kakera::Kakera`,
+        fields: {
+          id: { id: overrides.objectId ?? "0xkakera-1" },
+          unit_id: UNIT_ID,
+          athlete_id: 1,
+          submitter: OWNER,
+          walrus_blob_id: encodeBytes(WALRUS_BLOB_ID),
+          submission_no: "42",
+          minted_at_ms: "1700000000000",
+          ...overrides.fields,
+        },
+      },
+    },
+  };
+}
+
+function clientReturning(
+  objects: ReadonlyArray<ReturnType<typeof kakeraObject>>,
+): KakeraOwnedClient {
+  return {
+    getOwnedObjects: vi.fn(async ({ owner }) => {
+      expect(owner).toBe(OWNER);
+      return {
+        data: objects,
+        hasNextPage: false,
+        nextCursor: null,
+      };
+    }),
+  } as unknown as KakeraOwnedClient;
+}
+
+describe("findKakeraForSubmission", () => {
+  it("returns the matching Kakera when type / unit_id / walrus_blob_id all align", async () => {
+    const client = clientReturning([kakeraObject({})]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.objectId).toBe("0xkakera-1");
+    expect(result?.unitId).toBe(UNIT_ID);
+    expect(result?.walrusBlobId).toBe(WALRUS_BLOB_ID);
+    expect(result?.submissionNo).toBe(42);
+  });
+
+  it("returns null when the object type is not Kakera", async () => {
+    const client = clientReturning([
+      kakeraObject({ type: `${PACKAGE_ID}::kakera::NotKakera` }),
+    ]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the Kakera belongs to another unit", async () => {
+    const client = clientReturning([
+      kakeraObject({ fields: { unit_id: "0xunit-other" } }),
+    ]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the walrus_blob_id does not match", async () => {
+    const client = clientReturning([
+      kakeraObject({
+        fields: { walrus_blob_id: encodeBytes("walrus-blob-other") },
+      }),
+    ]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the owner has no objects", async () => {
+    const client = clientReturning([]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("skips non-Kakera objects and returns the matching one", async () => {
+    const client = clientReturning([
+      kakeraObject({ type: "0xpkg::other::Thing", objectId: "0xother" }),
+      kakeraObject({ objectId: "0xkakera-real" }),
+    ]);
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result?.objectId).toBe("0xkakera-real");
+  });
+});

--- a/apps/web/src/lib/sui/kakera.test.ts
+++ b/apps/web/src/lib/sui/kakera.test.ts
@@ -166,4 +166,78 @@ describe("findKakeraForSubmission", () => {
 
     expect(result?.objectId).toBe("0xkakera-real");
   });
+
+  it("walks pagination cursors until the matching Kakera is found", async () => {
+    // A participant who has previously joined another unit can legitimately
+    // hold multiple Kakera; the target may sit on the second page of a
+    // paginated `getOwnedObjects` response. The helper must not declare
+    // "not found" as soon as the first page fails to match.
+    const otherUnitKakera = kakeraObject({
+      objectId: "0xkakera-other",
+      fields: { unit_id: "0xunit-other" },
+    });
+    const matchingKakera = kakeraObject({ objectId: "0xkakera-match" });
+
+    const getOwnedObjects = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [otherUnitKakera],
+        hasNextPage: true,
+        nextCursor: "cursor-1",
+      })
+      .mockResolvedValueOnce({
+        data: [matchingKakera],
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+    const client = {
+      getOwnedObjects,
+    } as unknown as KakeraOwnedClient;
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result?.objectId).toBe("0xkakera-match");
+    expect(getOwnedObjects).toHaveBeenCalledTimes(2);
+    const firstCall = getOwnedObjects.mock.calls[0]?.[0];
+    const secondCall = getOwnedObjects.mock.calls[1]?.[0];
+    expect(firstCall?.cursor).toBeNull();
+    expect(secondCall?.cursor).toBe("cursor-1");
+  });
+
+  it("returns null after exhausting pagination without a match", async () => {
+    const getOwnedObjects = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [kakeraObject({ fields: { unit_id: "0xunit-other" } })],
+        hasNextPage: true,
+        nextCursor: "cursor-1",
+      })
+      .mockResolvedValueOnce({
+        data: [kakeraObject({ fields: { unit_id: "0xunit-other-2" } })],
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+    const client = {
+      getOwnedObjects,
+    } as unknown as KakeraOwnedClient;
+
+    const result = await findKakeraForSubmission({
+      suiClient: client,
+      ownerAddress: OWNER,
+      unitId: UNIT_ID,
+      walrusBlobId: WALRUS_BLOB_ID,
+      packageId: PACKAGE_ID,
+    });
+
+    expect(result).toBeNull();
+    expect(getOwnedObjects).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/lib/sui/kakera.ts
+++ b/apps/web/src/lib/sui/kakera.ts
@@ -1,0 +1,146 @@
+/**
+ * Read helper for `Kakera` Soulbound NFTs.
+ *
+ * Looks up the Kakera that matches a specific submission (unit + Walrus
+ * blob id) directly from the owner's address. This is used after a
+ * Sponsored `submit_photo` to confirm that the mint reached the chain:
+ * Kakera is Soulbound (`key`-only, no `store`), so it only ever lives on
+ * the submitter's address and cannot be fished out of a shared registry.
+ *
+ * Returns `null` when the Kakera hasn't been observed yet — callers poll
+ * on a short interval until the mint propagates through the fullnode.
+ */
+
+import type { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+
+/**
+ * Narrow surface used by {@link findKakeraForSubmission}. Mirrors the
+ * pattern in `client.ts` where we type only the SDK methods we call so
+ * tests can supply a stub without implementing the full RPC client.
+ */
+export type KakeraOwnedClient = {
+  getOwnedObjects: SuiJsonRpcClient["getOwnedObjects"];
+};
+
+export type OwnedKakera = {
+  readonly objectId: string;
+  readonly unitId: string;
+  readonly walrusBlobId: string;
+  readonly submissionNo: number;
+};
+
+export type FindKakeraForSubmissionArgs = {
+  readonly suiClient: KakeraOwnedClient;
+  readonly ownerAddress: string;
+  readonly unitId: string;
+  readonly walrusBlobId: string;
+  readonly packageId: string;
+};
+
+/**
+ * Locate the Kakera that matches a specific submission, or `null` if the
+ * owner does not (yet) hold such an object.
+ *
+ * Matching criteria:
+ *   - Move type is exactly `${packageId}::kakera::Kakera`.
+ *   - `unit_id` field equals {@link FindKakeraForSubmissionArgs.unitId}.
+ *   - `walrus_blob_id` bytes decode to {@link FindKakeraForSubmissionArgs.walrusBlobId}.
+ *
+ * Fullnode-side we narrow to `StructType` for efficiency, and we re-check
+ * the type in TS because stubs (and some RPC shapes) don't always honour
+ * the filter perfectly — defence in depth keeps the helper safe against
+ * unrelated objects that happen to slip through.
+ */
+export async function findKakeraForSubmission(
+  args: FindKakeraForSubmissionArgs,
+): Promise<OwnedKakera | null> {
+  const expectedType = `${args.packageId}::kakera::Kakera`;
+
+  const response = await args.suiClient.getOwnedObjects({
+    owner: args.ownerAddress,
+    filter: {
+      StructType: expectedType,
+    },
+    options: { showContent: true, showType: true },
+  });
+
+  for (const entry of response.data ?? []) {
+    const data = entry.data;
+    if (!data?.content) continue;
+    if (data.type !== expectedType) continue;
+
+    const fields = extractMoveObjectFields(data.content);
+    const unitId = readIdField(fields.unit_id);
+    if (unitId !== args.unitId) continue;
+
+    const blobId = readVectorU8AsString(fields.walrus_blob_id);
+    if (blobId !== args.walrusBlobId) continue;
+
+    return {
+      objectId: data.objectId,
+      unitId,
+      walrusBlobId: blobId,
+      submissionNo: readIntegerField(fields.submission_no),
+    };
+  }
+
+  return null;
+}
+
+type MoveStructLike = {
+  readonly dataType: "moveObject";
+  readonly fields: Record<string, unknown>;
+};
+
+function extractMoveObjectFields(content: unknown): Record<string, unknown> {
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    (content as { dataType?: unknown }).dataType === "moveObject"
+  ) {
+    const fields = (content as MoveStructLike).fields;
+    if (typeof fields === "object" && fields !== null) {
+      return fields;
+    }
+  }
+  return {};
+}
+
+function readIdField(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  // Some RPC shapes wrap `ID` values as `{ id: "0x..." }` — accept both.
+  if (typeof value === "object" && value !== null) {
+    const inner = (value as { id?: unknown }).id;
+    if (typeof inner === "string" && inner.length > 0) {
+      return inner;
+    }
+  }
+  return null;
+}
+
+function readVectorU8AsString(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const bytes = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i += 1) {
+    const entry = value[i];
+    if (typeof entry !== "number" || !Number.isInteger(entry)) {
+      return null;
+    }
+    bytes[i] = entry & 0xff;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function readIntegerField(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && /^[0-9]+$/.test(value)) {
+    return Number(value);
+  }
+  return 0;
+}

--- a/apps/web/src/lib/sui/kakera.ts
+++ b/apps/web/src/lib/sui/kakera.ts
@@ -38,6 +38,14 @@ export type FindKakeraForSubmissionArgs = {
 };
 
 /**
+ * Safety cap on pagination. A participant never legitimately holds more
+ * than a few Kakera at once (one per unit they've completed), but we guard
+ * against an attacker / unrelated object spam inflating the fullnode
+ * response so the hook cannot spin indefinitely.
+ */
+const MAX_OWNED_OBJECT_PAGES = 20;
+
+/**
  * Locate the Kakera that matches a specific submission, or `null` if the
  * owner does not (yet) hold such an object.
  *
@@ -50,38 +58,57 @@ export type FindKakeraForSubmissionArgs = {
  * the type in TS because stubs (and some RPC shapes) don't always honour
  * the filter perfectly — defence in depth keeps the helper safe against
  * unrelated objects that happen to slip through.
+ *
+ * Pagination: `getOwnedObjects` is a paginated RPC. A participant who has
+ * already received one or more Kakera from other units (multi-unit
+ * lifecycle) can legitimately hold multiple matching objects, and fullnode
+ * page sizes are not guaranteed large enough to fit everything. We walk
+ * `hasNextPage` / `nextCursor` until we find the target or exhaust the
+ * safety cap.
  */
 export async function findKakeraForSubmission(
   args: FindKakeraForSubmissionArgs,
 ): Promise<OwnedKakera | null> {
   const expectedType = `${args.packageId}::kakera::Kakera`;
 
-  const response = await args.suiClient.getOwnedObjects({
-    owner: args.ownerAddress,
-    filter: {
-      StructType: expectedType,
-    },
-    options: { showContent: true, showType: true },
-  });
+  let cursor: string | null | undefined;
+  for (let page = 0; page < MAX_OWNED_OBJECT_PAGES; page += 1) {
+    const response = await args.suiClient.getOwnedObjects({
+      owner: args.ownerAddress,
+      filter: {
+        StructType: expectedType,
+      },
+      options: { showContent: true, showType: true },
+      cursor: cursor ?? null,
+    });
 
-  for (const entry of response.data ?? []) {
-    const data = entry.data;
-    if (!data?.content) continue;
-    if (data.type !== expectedType) continue;
+    for (const entry of response.data ?? []) {
+      const data = entry.data;
+      if (!data?.content) continue;
+      if (data.type !== expectedType) continue;
 
-    const fields = extractMoveObjectFields(data.content);
-    const unitId = readIdField(fields.unit_id);
-    if (unitId !== args.unitId) continue;
+      const fields = extractMoveObjectFields(data.content);
+      const unitId = readIdField(fields.unit_id);
+      if (unitId !== args.unitId) continue;
 
-    const blobId = readVectorU8AsString(fields.walrus_blob_id);
-    if (blobId !== args.walrusBlobId) continue;
+      const blobId = readVectorU8AsString(fields.walrus_blob_id);
+      if (blobId !== args.walrusBlobId) continue;
 
-    return {
-      objectId: data.objectId,
-      unitId,
-      walrusBlobId: blobId,
-      submissionNo: readIntegerField(fields.submission_no),
-    };
+      return {
+        objectId: data.objectId,
+        unitId,
+        walrusBlobId: blobId,
+        submissionNo: readIntegerField(fields.submission_no),
+      };
+    }
+
+    if (!response.hasNextPage) {
+      return null;
+    }
+    cursor = response.nextCursor ?? null;
+    if (cursor == null) {
+      return null;
+    }
   }
 
   return null;

--- a/apps/web/src/lib/sui/react.ts
+++ b/apps/web/src/lib/sui/react.ts
@@ -12,5 +12,16 @@
  * `"use client"`). Anything else should import from `@/lib/sui`.
  */
 
+export type { KakeraOwnedClient, OwnedKakera } from "./kakera";
+export type {
+  UseOwnedKakeraArgs,
+  UseOwnedKakeraResult,
+  UseOwnedKakeraStatus,
+} from "./use-owned-kakera";
+export {
+  OWNED_KAKERA_DEFAULT_INTERVAL_MS,
+  OWNED_KAKERA_DEFAULT_MAX_ATTEMPTS,
+  useOwnedKakera,
+} from "./use-owned-kakera";
 export type { UseUnitEventsArgs } from "./use-unit-events";
 export { useUnitEvents } from "./use-unit-events";

--- a/apps/web/src/lib/sui/use-owned-kakera.test.ts
+++ b/apps/web/src/lib/sui/use-owned-kakera.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { findKakeraMock } = vi.hoisted(() => ({
+  findKakeraMock: vi.fn(),
+}));
+
+vi.mock("./kakera", () => ({
+  findKakeraForSubmission: findKakeraMock,
+}));
+
+import type { KakeraOwnedClient, OwnedKakera } from "./kakera";
+import { useOwnedKakera } from "./use-owned-kakera";
+
+const FAKE_CLIENT = {
+  getOwnedObjects: vi.fn(),
+} as unknown as KakeraOwnedClient;
+
+const PACKAGE_ID = "0xpkg";
+const OWNER = "0xowner";
+const UNIT_ID = "0xunit-1";
+const WALRUS_BLOB_ID = "walrus-blob-xyz";
+
+function makeKakera(): OwnedKakera {
+  return {
+    objectId: "0xkakera-1",
+    unitId: UNIT_ID,
+    walrusBlobId: WALRUS_BLOB_ID,
+    submissionNo: 42,
+  };
+}
+
+type FakeTimers = {
+  readonly schedule: (ms: number, fn: () => void) => number;
+  readonly clear: (handle: number) => void;
+  readonly advance: () => Promise<void>;
+};
+
+function createFakeTimers(): FakeTimers {
+  type Scheduled = { readonly handle: number; readonly fn: () => void };
+  let queue: Scheduled[] = [];
+  let nextHandle = 1;
+
+  return {
+    schedule(_ms, fn) {
+      const handle = nextHandle;
+      nextHandle += 1;
+      queue.push({ handle, fn });
+      return handle;
+    },
+    clear(handle) {
+      queue = queue.filter((item) => item.handle !== handle);
+    },
+    advance: async () => {
+      const snapshot = queue;
+      queue = [];
+      for (const item of snapshot) {
+        item.fn();
+      }
+      // Yield so any awaited promises triggered by the timer fire.
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+  };
+}
+
+afterEach(() => {
+  findKakeraMock.mockReset();
+});
+
+describe("useOwnedKakera", () => {
+  it("starts in 'searching' and transitions to 'found' when the Kakera is discovered on the second poll", async () => {
+    const timers = createFakeTimers();
+    const kakera = makeKakera();
+
+    findKakeraMock.mockResolvedValueOnce(null).mockResolvedValueOnce(kakera);
+
+    const { result } = renderHook(() =>
+      useOwnedKakera({
+        suiClient: FAKE_CLIENT,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+        intervalMs: 1_500,
+        maxAttempts: 20,
+        scheduleTimeout: timers.schedule,
+        clearTimeout: timers.clear,
+      }),
+    );
+
+    // First poll is kicked off synchronously. Wait for it to settle.
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.status).toBe("searching");
+    expect(result.current.kakera).toBeNull();
+
+    // Fire the scheduled retry.
+    await act(async () => {
+      await timers.advance();
+    });
+
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.status).toBe("found");
+    });
+    expect(result.current.kakera).toEqual(kakera);
+  });
+
+  it("stops polling once a Kakera is found", async () => {
+    const timers = createFakeTimers();
+    const kakera = makeKakera();
+
+    findKakeraMock.mockResolvedValue(kakera);
+
+    renderHook(() =>
+      useOwnedKakera({
+        suiClient: FAKE_CLIENT,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+        intervalMs: 1_500,
+        maxAttempts: 20,
+        scheduleTimeout: timers.schedule,
+        clearTimeout: timers.clear,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Advancing timers a few times should not trigger additional lookups.
+    await act(async () => {
+      await timers.advance();
+      await timers.advance();
+      await timers.advance();
+    });
+
+    expect(findKakeraMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("transitions to 'timeout' after the configured maximum attempts", async () => {
+    const timers = createFakeTimers();
+    findKakeraMock.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useOwnedKakera({
+        suiClient: FAKE_CLIENT,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+        intervalMs: 1_500,
+        maxAttempts: 3,
+        scheduleTimeout: timers.schedule,
+        clearTimeout: timers.clear,
+      }),
+    );
+
+    // Attempt 1 (synchronous kick-off).
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Attempt 2.
+    await act(async () => {
+      await timers.advance();
+    });
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(2);
+    });
+
+    // Attempt 3 (final).
+    await act(async () => {
+      await timers.advance();
+    });
+    await waitFor(() => {
+      expect(findKakeraMock).toHaveBeenCalledTimes(3);
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("timeout");
+    });
+
+    // No further polls after timeout.
+    await act(async () => {
+      await timers.advance();
+      await timers.advance();
+    });
+    expect(findKakeraMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stays idle when ownerAddress is missing", async () => {
+    const timers = createFakeTimers();
+
+    const { result } = renderHook(() =>
+      useOwnedKakera({
+        suiClient: FAKE_CLIENT,
+        ownerAddress: null,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+        intervalMs: 1_500,
+        maxAttempts: 3,
+        scheduleTimeout: timers.schedule,
+        clearTimeout: timers.clear,
+      }),
+    );
+
+    expect(result.current.status).toBe("idle");
+    expect(findKakeraMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/sui/use-owned-kakera.ts
+++ b/apps/web/src/lib/sui/use-owned-kakera.ts
@@ -1,0 +1,159 @@
+/**
+ * React hook that polls for the Kakera Soulbound NFT minted by a specific
+ * submission.
+ *
+ * Motivation: after the Sponsored `submit_photo` transaction resolves, the
+ * Kakera mint is already on-chain but the fullnode index may take a moment
+ * to surface it via `getOwnedObjects`. This hook polls
+ * {@link findKakeraForSubmission} at a short fixed interval until either
+ * the Kakera shows up ({@link UseOwnedKakeraResult.status} `"found"`) or
+ * the retry budget is exhausted (`"timeout"`).
+ *
+ * The SuiClient and timer implementations are both DI parameters so that
+ * tests can assert polling behaviour deterministically without leaning on
+ * real network or real `setTimeout`.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  findKakeraForSubmission,
+  type KakeraOwnedClient,
+  type OwnedKakera,
+} from "./kakera";
+
+/** Default cadence: 1.5s × 20 attempts = 30s before we give up. */
+export const OWNED_KAKERA_DEFAULT_INTERVAL_MS = 1_500;
+export const OWNED_KAKERA_DEFAULT_MAX_ATTEMPTS = 20;
+
+export type UseOwnedKakeraStatus = "idle" | "searching" | "found" | "timeout";
+
+export type UseOwnedKakeraResult = {
+  readonly status: UseOwnedKakeraStatus;
+  readonly kakera: OwnedKakera | null;
+};
+
+export type UseOwnedKakeraArgs = {
+  readonly suiClient: KakeraOwnedClient;
+  readonly ownerAddress: string | null;
+  readonly unitId: string;
+  readonly walrusBlobId: string;
+  readonly packageId: string;
+  readonly intervalMs?: number;
+  readonly maxAttempts?: number;
+  /** Injected timer scheduler. Defaults to `setTimeout`. */
+  readonly scheduleTimeout?: (ms: number, fn: () => void) => number;
+  /** Injected clearer. Defaults to `clearTimeout`. */
+  readonly clearTimeout?: (handle: number) => void;
+};
+
+export function useOwnedKakera(args: UseOwnedKakeraArgs): UseOwnedKakeraResult {
+  const {
+    suiClient,
+    ownerAddress,
+    unitId,
+    walrusBlobId,
+    packageId,
+    intervalMs = OWNED_KAKERA_DEFAULT_INTERVAL_MS,
+    maxAttempts = OWNED_KAKERA_DEFAULT_MAX_ATTEMPTS,
+    scheduleTimeout,
+    clearTimeout: clearHandle,
+  } = args;
+
+  const [result, setResult] = useState<UseOwnedKakeraResult>({
+    status: ownerAddress ? "searching" : "idle",
+    kakera: null,
+  });
+
+  // Latest inputs captured in a ref so the polling effect can read them
+  // without having to list every function in its dependency array (which
+  // would restart polling on every render).
+  const latestRef = useRef({
+    suiClient,
+    intervalMs,
+    maxAttempts,
+    schedule: scheduleTimeout ?? defaultSchedule,
+    clear: clearHandle ?? defaultClear,
+  });
+  latestRef.current = {
+    suiClient,
+    intervalMs,
+    maxAttempts,
+    schedule: scheduleTimeout ?? defaultSchedule,
+    clear: clearHandle ?? defaultClear,
+  };
+
+  useEffect(() => {
+    if (!ownerAddress || !unitId || !walrusBlobId || !packageId) {
+      setResult({ status: ownerAddress ? "searching" : "idle", kakera: null });
+      return;
+    }
+
+    setResult({ status: "searching", kakera: null });
+
+    let cancelled = false;
+    let pending: number | null = null;
+    let attempts = 0;
+
+    const runPoll = async (): Promise<void> => {
+      if (cancelled) return;
+      attempts += 1;
+
+      const latest = latestRef.current;
+      let found: OwnedKakera | null = null;
+      try {
+        found = await findKakeraForSubmission({
+          suiClient: latest.suiClient,
+          ownerAddress,
+          unitId,
+          walrusBlobId,
+          packageId,
+        });
+      } catch {
+        // Treat transport errors like "not yet found" so the UI doesn't
+        // flip into an error state mid-poll; the final timeout branch
+        // still covers persistent failures.
+        found = null;
+      }
+
+      if (cancelled) return;
+
+      if (found) {
+        setResult({ status: "found", kakera: found });
+        return;
+      }
+
+      if (attempts >= latest.maxAttempts) {
+        setResult({ status: "timeout", kakera: null });
+        return;
+      }
+
+      pending = latest.schedule(latest.intervalMs, () => {
+        pending = null;
+        void runPoll();
+      });
+    };
+
+    void runPoll();
+
+    return () => {
+      cancelled = true;
+      if (pending !== null) {
+        latestRef.current.clear(pending);
+        pending = null;
+      }
+    };
+  }, [ownerAddress, unitId, walrusBlobId, packageId]);
+
+  return result;
+}
+
+function defaultSchedule(ms: number, fn: () => void): number {
+  return setTimeout(fn, ms) as unknown as number;
+}
+
+function defaultClear(handle: number): void {
+  clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+}

--- a/apps/web/src/lib/walrus/put.test.ts
+++ b/apps/web/src/lib/walrus/put.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { putBlobToWalrus, WalrusPutError } from "./put";
+
+const PUBLISHER = "https://publisher.example.com";
+const AGGREGATOR = "https://aggregator.example.com";
+
+type FetchInit = RequestInit | undefined;
+
+/**
+ * Build a mock `fetch` whose queued responses are consumed in order. If the
+ * queue is exhausted we throw – tests should assert exact call counts.
+ */
+function queuedFetch(
+  responses: ReadonlyArray<
+    | { readonly kind: "ok"; readonly body: unknown }
+    | {
+        readonly kind: "status";
+        readonly status: number;
+        readonly body?: unknown;
+      }
+    | { readonly kind: "throw"; readonly error: Error }
+  >,
+) {
+  const calls: { readonly url: string; readonly init: FetchInit }[] = [];
+  let index = 0;
+
+  const fetchFn = vi.fn(async (url: string, init?: FetchInit) => {
+    calls.push({ url, init });
+    const spec = responses[index];
+    index += 1;
+    if (!spec) {
+      throw new Error(`fetch called more than ${responses.length} times`);
+    }
+    if (spec.kind === "throw") {
+      throw spec.error;
+    }
+    if (spec.kind === "status") {
+      return new Response(
+        spec.body === undefined ? null : JSON.stringify(spec.body),
+        {
+          status: spec.status,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response(JSON.stringify(spec.body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  return { fetchFn, calls };
+}
+
+function blob() {
+  return new Blob([new Uint8Array(16)], { type: "image/jpeg" });
+}
+
+function baseDeps(fetchFn: typeof fetch) {
+  return {
+    fetchFn,
+    // 0 delay keeps the backoff instantaneous in tests; logic still goes
+    // through the same schedule helper.
+    sleep: vi.fn(async (_ms: number) => {}),
+    env: {
+      NEXT_PUBLIC_WALRUS_PUBLISHER: PUBLISHER,
+      NEXT_PUBLIC_WALRUS_AGGREGATOR: AGGREGATOR,
+    },
+  };
+}
+
+describe("putBlobToWalrus", () => {
+  it("PUTs the blob to <publisher>/v1/blobs?epochs=5 with the raw body", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: {
+            blobObject: { blobId: "blob-xyz" },
+          },
+        },
+      },
+    ]);
+
+    const body = blob();
+    const result = await putBlobToWalrus(
+      body,
+      baseDeps(fetchFn as typeof fetch),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=5`);
+    expect(calls[0]?.init?.method).toBe("PUT");
+    expect(calls[0]?.init?.body).toBe(body);
+    expect(result.blobId).toBe("blob-xyz");
+    expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/blob-xyz`);
+  });
+
+  it("extracts the blob id from an `alreadyCertified` response", async () => {
+    const { fetchFn } = queuedFetch([
+      {
+        kind: "ok",
+        body: {
+          alreadyCertified: { blobId: "already-abc" },
+        },
+      },
+    ]);
+
+    const result = await putBlobToWalrus(
+      blob(),
+      baseDeps(fetchFn as typeof fetch),
+    );
+
+    expect(result.blobId).toBe("already-abc");
+    expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/already-abc`);
+  });
+
+  it("retries a 5xx transient failure and succeeds on the third attempt", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      { kind: "status", status: 502 },
+      { kind: "status", status: 503 },
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: { blobObject: { blobId: "blob-final" } },
+        },
+      },
+    ]);
+
+    const deps = baseDeps(fetchFn as typeof fetch);
+    const result = await putBlobToWalrus(blob(), deps);
+
+    expect(calls).toHaveLength(3);
+    expect(result.blobId).toBe("blob-final");
+    // Sleeps happen *between* attempts: after attempt 1 and after attempt 2.
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries network errors (TypeError) up to three attempts", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      { kind: "throw", error: new TypeError("Failed to fetch") },
+      { kind: "throw", error: new TypeError("Failed to fetch") },
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: { blobObject: { blobId: "net-ok" } },
+        },
+      },
+    ]);
+
+    const result = await putBlobToWalrus(
+      blob(),
+      baseDeps(fetchFn as typeof fetch),
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(result.blobId).toBe("net-ok");
+  });
+
+  it("throws a `final` error after three failed attempts", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      { kind: "status", status: 502 },
+      { kind: "status", status: 502 },
+      { kind: "status", status: 502 },
+    ]);
+
+    try {
+      await putBlobToWalrus(blob(), baseDeps(fetchFn as typeof fetch));
+      expect.unreachable("putBlobToWalrus should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WalrusPutError);
+      const e = error as WalrusPutError;
+      expect(e.kind).toBe("final");
+      expect(e.attempts).toBe(3);
+    }
+
+    expect(calls).toHaveLength(3);
+  });
+
+  it("does not retry on a 4xx client error and returns a `final` error immediately", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      { kind: "status", status: 400, body: { error: "bad request" } },
+    ]);
+
+    try {
+      await putBlobToWalrus(blob(), baseDeps(fetchFn as typeof fetch));
+      expect.unreachable("putBlobToWalrus should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WalrusPutError);
+      const e = error as WalrusPutError;
+      expect(e.kind).toBe("final");
+    }
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns `config_missing` immediately when the publisher URL is absent", async () => {
+    const { fetchFn, calls } = queuedFetch([]);
+    const deps = {
+      fetchFn: fetchFn as typeof fetch,
+      sleep: vi.fn(async (_ms: number) => {}),
+      env: {
+        NEXT_PUBLIC_WALRUS_PUBLISHER: "",
+        NEXT_PUBLIC_WALRUS_AGGREGATOR: AGGREGATOR,
+      },
+    };
+
+    try {
+      await putBlobToWalrus(blob(), deps);
+      expect.unreachable("putBlobToWalrus should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WalrusPutError);
+      const e = error as WalrusPutError;
+      expect(e.kind).toBe("config_missing");
+    }
+
+    expect(calls).toHaveLength(0);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("returns `config_missing` when the aggregator URL is absent", async () => {
+    const { fetchFn } = queuedFetch([]);
+    const deps = {
+      fetchFn: fetchFn as typeof fetch,
+      sleep: vi.fn(async (_ms: number) => {}),
+      env: {
+        NEXT_PUBLIC_WALRUS_PUBLISHER: PUBLISHER,
+        NEXT_PUBLIC_WALRUS_AGGREGATOR: "   ",
+      },
+    };
+
+    await expect(putBlobToWalrus(blob(), deps)).rejects.toMatchObject({
+      kind: "config_missing",
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("uses exponential backoff between attempts", async () => {
+    const { fetchFn } = queuedFetch([
+      { kind: "status", status: 502 },
+      { kind: "status", status: 502 },
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: { blobObject: { blobId: "later" } },
+        },
+      },
+    ]);
+
+    const deps = baseDeps(fetchFn as typeof fetch);
+    await putBlobToWalrus(blob(), deps);
+
+    // Exponential backoff: the second delay should be strictly larger than
+    // the first. We don't pin exact numbers so we don't fight the clock.
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+    const firstDelay = deps.sleep.mock.calls[0]?.[0] as number;
+    const secondDelay = deps.sleep.mock.calls[1]?.[0] as number;
+    expect(typeof firstDelay).toBe("number");
+    expect(typeof secondDelay).toBe("number");
+    expect(secondDelay).toBeGreaterThan(firstDelay);
+  });
+
+  it("trims trailing slashes in the publisher and aggregator URLs", async () => {
+    const { fetchFn, calls } = queuedFetch([
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: { blobObject: { blobId: "blob-trim" } },
+        },
+      },
+    ]);
+
+    const deps = {
+      fetchFn: fetchFn as typeof fetch,
+      sleep: vi.fn(async (_ms: number) => {}),
+      env: {
+        NEXT_PUBLIC_WALRUS_PUBLISHER: `${PUBLISHER}/`,
+        NEXT_PUBLIC_WALRUS_AGGREGATOR: `${AGGREGATOR}/`,
+      },
+    };
+
+    const result = await putBlobToWalrus(blob(), deps);
+
+    expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=5`);
+    expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/blob-trim`);
+  });
+
+  it("surfaces the `transient` classification through the onRetry hook", async () => {
+    const { fetchFn } = queuedFetch([
+      { kind: "status", status: 500 },
+      {
+        kind: "ok",
+        body: {
+          newlyCreated: { blobObject: { blobId: "blob-recovered" } },
+        },
+      },
+    ]);
+
+    const deps = baseDeps(fetchFn as typeof fetch);
+    const onRetry = vi.fn();
+
+    const result = await putBlobToWalrus(blob(), {
+      ...deps,
+      onRetry,
+    });
+
+    expect(result.blobId).toBe("blob-recovered");
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0]).toMatchObject({
+      kind: "transient",
+      attempt: 1,
+    });
+  });
+});

--- a/apps/web/src/lib/walrus/put.test.ts
+++ b/apps/web/src/lib/walrus/put.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { PreprocessedPhoto } from "../image/preprocess";
 import { putBlobToWalrus, WalrusPutError } from "./put";
 
 const PUBLISHER = "https://publisher.example.com";
@@ -57,6 +58,18 @@ function blob() {
   return new Blob([new Uint8Array(16)], { type: "image/jpeg" });
 }
 
+function photo(override: Partial<PreprocessedPhoto> = {}): PreprocessedPhoto {
+  const b = override.blob ?? blob();
+  return {
+    blob: b,
+    width: override.width ?? 1024,
+    height: override.height ?? 768,
+    contentType: "image/jpeg",
+    sha256: override.sha256 ?? "a".repeat(64),
+    previewUrl: override.previewUrl ?? "blob:preview",
+  };
+}
+
 function baseDeps(fetchFn: typeof fetch) {
   return {
     fetchFn,
@@ -71,7 +84,7 @@ function baseDeps(fetchFn: typeof fetch) {
 }
 
 describe("putBlobToWalrus", () => {
-  it("PUTs the blob to <publisher>/v1/blobs?epochs=5 with the raw body", async () => {
+  it("PUTs the preprocessed blob to <publisher>/v1/blobs?epochs=5", async () => {
     const { fetchFn, calls } = queuedFetch([
       {
         kind: "ok",
@@ -85,7 +98,7 @@ describe("putBlobToWalrus", () => {
 
     const body = blob();
     const result = await putBlobToWalrus(
-      body,
+      photo({ blob: body }),
       baseDeps(fetchFn as typeof fetch),
     );
 
@@ -93,6 +106,8 @@ describe("putBlobToWalrus", () => {
     expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=5`);
     expect(calls[0]?.init?.method).toBe("PUT");
     expect(calls[0]?.init?.body).toBe(body);
+    // AbortSignal must be attached so a hung request can be cancelled.
+    expect(calls[0]?.init?.signal).toBeInstanceOf(AbortSignal);
     expect(result.blobId).toBe("blob-xyz");
     expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/blob-xyz`);
   });
@@ -108,7 +123,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     const result = await putBlobToWalrus(
-      blob(),
+      photo(),
       baseDeps(fetchFn as typeof fetch),
     );
 
@@ -129,7 +144,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     const deps = baseDeps(fetchFn as typeof fetch);
-    const result = await putBlobToWalrus(blob(), deps);
+    const result = await putBlobToWalrus(photo(), deps);
 
     expect(calls).toHaveLength(3);
     expect(result.blobId).toBe("blob-final");
@@ -150,7 +165,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     const result = await putBlobToWalrus(
-      blob(),
+      photo(),
       baseDeps(fetchFn as typeof fetch),
     );
 
@@ -166,7 +181,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     try {
-      await putBlobToWalrus(blob(), baseDeps(fetchFn as typeof fetch));
+      await putBlobToWalrus(photo(), baseDeps(fetchFn as typeof fetch));
       expect.unreachable("putBlobToWalrus should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(WalrusPutError);
@@ -184,7 +199,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     try {
-      await putBlobToWalrus(blob(), baseDeps(fetchFn as typeof fetch));
+      await putBlobToWalrus(photo(), baseDeps(fetchFn as typeof fetch));
       expect.unreachable("putBlobToWalrus should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(WalrusPutError);
@@ -207,7 +222,7 @@ describe("putBlobToWalrus", () => {
     };
 
     try {
-      await putBlobToWalrus(blob(), deps);
+      await putBlobToWalrus(photo(), deps);
       expect.unreachable("putBlobToWalrus should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(WalrusPutError);
@@ -230,7 +245,7 @@ describe("putBlobToWalrus", () => {
       },
     };
 
-    await expect(putBlobToWalrus(blob(), deps)).rejects.toMatchObject({
+    await expect(putBlobToWalrus(photo(), deps)).rejects.toMatchObject({
       kind: "config_missing",
     });
     expect(fetchFn).not.toHaveBeenCalled();
@@ -249,7 +264,7 @@ describe("putBlobToWalrus", () => {
     ]);
 
     const deps = baseDeps(fetchFn as typeof fetch);
-    await putBlobToWalrus(blob(), deps);
+    await putBlobToWalrus(photo(), deps);
 
     // Exponential backoff: the second delay should be strictly larger than
     // the first. We don't pin exact numbers so we don't fight the clock.
@@ -280,7 +295,7 @@ describe("putBlobToWalrus", () => {
       },
     };
 
-    const result = await putBlobToWalrus(blob(), deps);
+    const result = await putBlobToWalrus(photo(), deps);
 
     expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=5`);
     expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/blob-trim`);
@@ -300,7 +315,7 @@ describe("putBlobToWalrus", () => {
     const deps = baseDeps(fetchFn as typeof fetch);
     const onRetry = vi.fn();
 
-    const result = await putBlobToWalrus(blob(), {
+    const result = await putBlobToWalrus(photo(), {
       ...deps,
       onRetry,
     });
@@ -311,5 +326,56 @@ describe("putBlobToWalrus", () => {
       kind: "transient",
       attempt: 1,
     });
+  });
+
+  it("aborts a hung request via the timeout and treats it as transient", async () => {
+    // fetchFn that never resolves on its own. It only settles when the
+    // AbortSignal fires, which mirrors how `fetch` behaves on a real abort.
+    // Without the timeout + AbortController wiring in put.ts, this test would
+    // hang the vitest worker.
+    const callSignals: AbortSignal[] = [];
+    const fetchFn = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("signal missing"));
+            return;
+          }
+          callSignals.push(signal);
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const deps = {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      sleep: vi.fn(async (_ms: number) => {}),
+      env: {
+        NEXT_PUBLIC_WALRUS_PUBLISHER: PUBLISHER,
+        NEXT_PUBLIC_WALRUS_AGGREGATOR: AGGREGATOR,
+      },
+      // Keep the timeout small so the test runs fast.
+      requestTimeoutMs: 5,
+    };
+
+    try {
+      await putBlobToWalrus(photo(), deps);
+      expect.unreachable("putBlobToWalrus should have thrown on final timeout");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WalrusPutError);
+      const e = error as WalrusPutError;
+      expect(e.kind).toBe("final");
+      expect(e.attempts).toBe(3);
+    }
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    // Every attempt received its own AbortSignal and every one of them
+    // eventually aborted — that's what allowed the retry loop to advance.
+    expect(callSignals).toHaveLength(3);
+    for (const signal of callSignals) {
+      expect(signal.aborted).toBe(true);
+    }
   });
 });

--- a/apps/web/src/lib/walrus/put.ts
+++ b/apps/web/src/lib/walrus/put.ts
@@ -1,13 +1,20 @@
 "use client";
 
+import type { PreprocessedPhoto } from "../image/preprocess";
+
 /**
  * Thin client for uploading a preprocessed photo to a Walrus Publisher.
  *
  * Spec (see `docs/tech.md` §5.3 / §6 / §10):
  * - ブラウザから Walrus Publisher へ直接 `PUT /v1/blobs?epochs=5` で送る。
- * - 一時的な失敗（ネットワーク / 5xx）は指数バックオフで合計 3 回まで再試行。
+ * - 一時的な失敗（ネットワーク / 5xx / タイムアウト）は指数バックオフで
+ *   合計 3 回まで再試行。
  * - 最終的な失敗は UI が再試行ボタンを出せるよう分類済みのエラーで投げる。
  * - 成功時は `blob_id` と Aggregator 参照 URL を返す。
+ *
+ * 入力は {@link PreprocessedPhoto} に絞っており、10MB 検証・長辺 1024px・
+ * JPEG 再エンコード・EXIF 除去を通過した Blob のみが PUT される。原画像が
+ * そのまま Walrus に載らないよう型レベルで守る。
  *
  * `fetch` と `setTimeout` は DI で差し替え可能にしている。テストは実時計や実
  * ネットワークに依存せず、リトライ回数・URL 組み立て・エラー分類だけを検証
@@ -18,6 +25,9 @@ export const WALRUS_EPOCHS = 5;
 export const WALRUS_MAX_ATTEMPTS = 3;
 /** Base delay for exponential backoff. Kept small – retries are cheap. */
 export const WALRUS_BASE_BACKOFF_MS = 200;
+/** Per-attempt request timeout. 30s covers mobile uploads; beyond that we
+ * abort and classify as transient so the retry loop / final error kicks in. */
+export const WALRUS_REQUEST_TIMEOUT_MS = 30_000;
 
 export type WalrusPutErrorKind = "transient" | "final" | "config_missing";
 
@@ -60,6 +70,8 @@ export type WalrusPutDeps = {
   readonly sleep?: (ms: number) => Promise<void>;
   readonly env: WalrusEnv;
   readonly onRetry?: (info: WalrusPutRetryInfo) => void;
+  /** Per-attempt timeout in ms. Defaults to {@link WALRUS_REQUEST_TIMEOUT_MS}. */
+  readonly requestTimeoutMs?: number;
 };
 
 export type WalrusPutResult = {
@@ -68,11 +80,16 @@ export type WalrusPutResult = {
 };
 
 /**
- * Upload a blob to the configured Walrus Publisher and return the resulting
- * `blobId` + an Aggregator URL usable for immediate preview.
+ * Upload a preprocessed photo to the configured Walrus Publisher and return
+ * the resulting `blobId` + an Aggregator URL usable for immediate preview.
+ *
+ * Accepting {@link PreprocessedPhoto} (not a raw `Blob`) enforces at the type
+ * level that 10MB validation, 1024px downscaling, JPEG re-encoding, and EXIF
+ * stripping have all been performed. Raw originals cannot accidentally be
+ * uploaded to Walrus — which would violate `docs/tech.md` §5.3 / §11.
  */
 export async function putBlobToWalrus(
-  body: Blob,
+  photo: PreprocessedPhoto,
   deps: WalrusPutDeps,
 ): Promise<WalrusPutResult> {
   const endpoints = resolveEndpoints(deps.env);
@@ -86,16 +103,19 @@ export async function putBlobToWalrus(
   }
 
   const sleep = deps.sleep ?? defaultSleep;
+  const requestTimeoutMs = deps.requestTimeoutMs ?? WALRUS_REQUEST_TIMEOUT_MS;
 
   let lastError: unknown = null;
   let lastStatus: number | null = null;
 
   for (let attempt = 1; attempt <= WALRUS_MAX_ATTEMPTS; attempt += 1) {
     try {
-      const response = await fetchFn(endpoints.putUrl, {
-        method: "PUT",
-        body,
-      });
+      const response = await fetchWithTimeout(
+        fetchFn,
+        endpoints.putUrl,
+        photo.blob,
+        requestTimeoutMs,
+      );
 
       if (response.ok) {
         const blobId = await extractBlobId(response);
@@ -121,6 +141,8 @@ export async function putBlobToWalrus(
       if (error instanceof WalrusPutError) {
         throw error;
       }
+      // AbortError（タイムアウトで自発的に中断）は一時失敗として扱う。
+      // fetch がハングしたまま永遠に待つのを防ぐ。
       lastError = error;
     }
 
@@ -257,4 +279,30 @@ function defaultSleep(ms: number): Promise<void> {
 function resolveDefaultFetch(): typeof fetch | undefined {
   const value = (globalThis as Record<string, unknown>).fetch;
   return typeof value === "function" ? (value as typeof fetch) : undefined;
+}
+
+/**
+ * Wrap a single fetch attempt with an AbortController so that a hung request
+ * cannot stall the retry loop indefinitely. The signal is aborted after
+ * `timeoutMs` elapses; the aborted fetch rejects and is treated as transient.
+ */
+async function fetchWithTimeout(
+  fetchFn: typeof fetch,
+  url: string,
+  body: Blob,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await fetchFn(url, {
+      method: "PUT",
+      body,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/apps/web/src/lib/walrus/put.ts
+++ b/apps/web/src/lib/walrus/put.ts
@@ -1,0 +1,260 @@
+"use client";
+
+/**
+ * Thin client for uploading a preprocessed photo to a Walrus Publisher.
+ *
+ * Spec (see `docs/tech.md` §5.3 / §6 / §10):
+ * - ブラウザから Walrus Publisher へ直接 `PUT /v1/blobs?epochs=5` で送る。
+ * - 一時的な失敗（ネットワーク / 5xx）は指数バックオフで合計 3 回まで再試行。
+ * - 最終的な失敗は UI が再試行ボタンを出せるよう分類済みのエラーで投げる。
+ * - 成功時は `blob_id` と Aggregator 参照 URL を返す。
+ *
+ * `fetch` と `setTimeout` は DI で差し替え可能にしている。テストは実時計や実
+ * ネットワークに依存せず、リトライ回数・URL 組み立て・エラー分類だけを検証
+ * する。
+ */
+
+export const WALRUS_EPOCHS = 5;
+export const WALRUS_MAX_ATTEMPTS = 3;
+/** Base delay for exponential backoff. Kept small – retries are cheap. */
+export const WALRUS_BASE_BACKOFF_MS = 200;
+
+export type WalrusPutErrorKind = "transient" | "final" | "config_missing";
+
+export class WalrusPutError extends Error {
+  readonly kind: WalrusPutErrorKind;
+  readonly attempts: number;
+  readonly status: number | null;
+
+  constructor(
+    kind: WalrusPutErrorKind,
+    message: string,
+    options: {
+      readonly attempts?: number;
+      readonly status?: number | null;
+      readonly cause?: unknown;
+    } = {},
+  ) {
+    super(message, options.cause !== undefined ? { cause: options.cause } : {});
+    this.name = "WalrusPutError";
+    this.kind = kind;
+    this.attempts = options.attempts ?? 0;
+    this.status = options.status ?? null;
+  }
+}
+
+export type WalrusEnv = {
+  readonly NEXT_PUBLIC_WALRUS_PUBLISHER: string | undefined;
+  readonly NEXT_PUBLIC_WALRUS_AGGREGATOR: string | undefined;
+};
+
+export type WalrusPutRetryInfo = {
+  readonly kind: "transient";
+  readonly attempt: number;
+  readonly status: number | null;
+  readonly error: unknown;
+};
+
+export type WalrusPutDeps = {
+  readonly fetchFn?: typeof fetch;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly env: WalrusEnv;
+  readonly onRetry?: (info: WalrusPutRetryInfo) => void;
+};
+
+export type WalrusPutResult = {
+  readonly blobId: string;
+  readonly aggregatorUrl: string;
+};
+
+/**
+ * Upload a blob to the configured Walrus Publisher and return the resulting
+ * `blobId` + an Aggregator URL usable for immediate preview.
+ */
+export async function putBlobToWalrus(
+  body: Blob,
+  deps: WalrusPutDeps,
+): Promise<WalrusPutResult> {
+  const endpoints = resolveEndpoints(deps.env);
+
+  const fetchFn = deps.fetchFn ?? resolveDefaultFetch();
+  if (!fetchFn) {
+    throw new WalrusPutError(
+      "config_missing",
+      "このブラウザでは Walrus へのアップロードがサポートされていません。",
+    );
+  }
+
+  const sleep = deps.sleep ?? defaultSleep;
+
+  let lastError: unknown = null;
+  let lastStatus: number | null = null;
+
+  for (let attempt = 1; attempt <= WALRUS_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetchFn(endpoints.putUrl, {
+        method: "PUT",
+        body,
+      });
+
+      if (response.ok) {
+        const blobId = await extractBlobId(response);
+        return {
+          blobId,
+          aggregatorUrl: buildAggregatorUrl(endpoints.aggregatorBase, blobId),
+        };
+      }
+
+      lastStatus = response.status;
+      lastError = new Error(`Walrus PUT failed with status ${response.status}`);
+
+      // 4xx は再試行しても結果が変わらない。即 final で抜ける。
+      if (!isTransientStatus(response.status)) {
+        throw new WalrusPutError(
+          "final",
+          "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+          { attempts: attempt, status: response.status, cause: lastError },
+        );
+      }
+    } catch (error) {
+      // 既に final 分類を付けて投げた場合はそのまま上げる。
+      if (error instanceof WalrusPutError) {
+        throw error;
+      }
+      lastError = error;
+    }
+
+    const isLastAttempt = attempt >= WALRUS_MAX_ATTEMPTS;
+    if (isLastAttempt) {
+      break;
+    }
+
+    deps.onRetry?.({
+      kind: "transient",
+      attempt,
+      status: lastStatus,
+      error: lastError,
+    });
+
+    await sleep(backoffDelayMs(attempt));
+  }
+
+  throw new WalrusPutError(
+    "final",
+    "Walrus への写真の保存に失敗しました。通信状況を確認してから、再試行ボタンでもう一度お試しください。",
+    {
+      attempts: WALRUS_MAX_ATTEMPTS,
+      status: lastStatus,
+      cause: lastError,
+    },
+  );
+}
+
+function resolveEndpoints(env: WalrusEnv): {
+  readonly putUrl: string;
+  readonly aggregatorBase: string;
+} {
+  const publisher = trimTrailingSlashes(env.NEXT_PUBLIC_WALRUS_PUBLISHER);
+  const aggregator = trimTrailingSlashes(env.NEXT_PUBLIC_WALRUS_AGGREGATOR);
+
+  if (!publisher || !aggregator) {
+    throw new WalrusPutError(
+      "config_missing",
+      "Walrus のエンドポイントが設定されていません。NEXT_PUBLIC_WALRUS_PUBLISHER / NEXT_PUBLIC_WALRUS_AGGREGATOR を確認してください。",
+    );
+  }
+
+  return {
+    putUrl: `${publisher}/v1/blobs?epochs=${WALRUS_EPOCHS}`,
+    aggregatorBase: aggregator,
+  };
+}
+
+function buildAggregatorUrl(aggregatorBase: string, blobId: string): string {
+  return `${aggregatorBase}/v1/blobs/${blobId}`;
+}
+
+async function extractBlobId(response: Response): Promise<string> {
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new WalrusPutError(
+      "final",
+      "Walrus からの応答を解釈できませんでした。",
+      { cause: error },
+    );
+  }
+
+  const blobId = readBlobId(payload);
+  if (!blobId) {
+    throw new WalrusPutError(
+      "final",
+      "Walrus から blob_id を取得できませんでした。",
+      { cause: payload },
+    );
+  }
+  return blobId;
+}
+
+function readBlobId(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+
+  // Shape 1: `{ newlyCreated: { blobObject: { blobId } } }`
+  const newly = record.newlyCreated;
+  if (newly && typeof newly === "object") {
+    const blobObject = (newly as Record<string, unknown>).blobObject;
+    if (blobObject && typeof blobObject === "object") {
+      const id = (blobObject as Record<string, unknown>).blobId;
+      if (typeof id === "string" && id.length > 0) {
+        return id;
+      }
+    }
+  }
+
+  // Shape 2: `{ alreadyCertified: { blobId } }`
+  const already = record.alreadyCertified;
+  if (already && typeof already === "object") {
+    const id = (already as Record<string, unknown>).blobId;
+    if (typeof id === "string" && id.length > 0) {
+      return id;
+    }
+  }
+
+  return null;
+}
+
+function isTransientStatus(status: number): boolean {
+  // 408 Request Timeout と 429 Too Many Requests は一時障害として扱う。
+  if (status === 408 || status === 429) {
+    return true;
+  }
+  return status >= 500 && status <= 599;
+}
+
+function backoffDelayMs(attempt: number): number {
+  // attempt = 1 → base * 2^0, attempt = 2 → base * 2^1, ...
+  // 指数的に増える。ハッカソンスコープなので jitter は省略する。
+  return WALRUS_BASE_BACKOFF_MS * 2 ** (attempt - 1);
+}
+
+function trimTrailingSlashes(value: string | undefined): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().replace(/\/+$/, "");
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function resolveDefaultFetch(): typeof fetch | undefined {
+  const value = (globalThis as Record<string, unknown>).fetch;
+  return typeof value === "function" ? (value as typeof fetch) : undefined;
+}


### PR DESCRIPTION
## 概要

ファンが 1 人ぶんの参加を 1 つのトランザクションで完結させる導線を実装する。

トランザクションは「複数の更新をまとめて成功または失敗にする仕組み」で、今回は「写真を分散ストレージに置く」と「オンチェーンに投稿を書き込む」を 1 本で通す。これによって、ファンは Google ログインだけで写真を 1 枚提出でき、同時に Kakera（Soulbound の参加証 NFT、他人に渡せない）を受け取る。

UI のデザインは暫定。後続でデザイナーが正式デザインを作成するため、本 PR では機能の通り方を優先している。

Closes #5

## 実装サマリー

ファン体験の主線を end-to-end でつなぐ。

- 同意（原画像が公開される旨に同意しないと投稿に進めない）
- 画像前処理（長辺 1024px / JPEG 再エンコード / EXIF 除去 / 10MB 検証 / SHA-256）
- Walrus PUT（画像を Walrus という分散ストレージに置く操作）
- Sponsored Transaction 経由の `submit_photo` 発火（ファンは SUI を持たない前提）
- Kakera の受領確認と参加証カード表示
- Walrus 最終失敗時の再試行導線
- 進捗カウンタは `SubmittedEvent` 観測を正本にする（楽観的な仮増加はしない）

## フェーズと STEP

### フェーズ 1: 投稿基盤（UI から切り離した契約）

- STEP 1: 画像前処理ユーティリティ
- STEP 2: Walrus PUT クライアント

### フェーズ 2: 待機ルーム主線と仕上げ

- STEP 3: 待機ルーム同意 UI
- STEP 4: Sponsored Tx 経由の `submit_photo` 連携
- STEP 5: Kakera 受領 + 参加証 UI
- STEP 6: `SubmittedEvent` 連携と Walrus 失敗時の再試行導線

## 変更内容

- `apps/web/src/lib/image/preprocess.ts` / `preprocess.test.ts`
    - 写真を Walrus に投げて良い形に整える共通関数を新設する。
    - 10MB 超は前処理前に止める。
    - 長辺 1024px に縮小する（拡大はしない）。
    - JPEG 品質 0.85 で再エンコードする（EXIF は再エンコードで落ちる）。
    - 再エンコード後の Blob から SHA-256 を算出する。
- `apps/web/src/lib/walrus/put.ts` / `put.test.ts`
    - Walrus Publisher に `PUT /v1/blobs?epochs=5` で直接送るクライアントを新設する。
    - 入力は `PreprocessedPhoto` に型で絞り、原画像をそのまま PUT できないようにする。
    - 一時失敗は指数バックオフで 3 回まで自動再試行する。
    - 各アテンプトは `AbortController` でタイムアウトさせ、無限ハングを防ぐ。
    - エラーは `transient` / `final` / `config_missing` に分類して UI が判別できるようにする。
- `apps/web/src/lib/sui/kakera.ts` / `kakera.test.ts`
    - 自分のアドレスが持つ Kakera から、今回投稿した 1 件を `unit_id` と `walrus_blob_id` で特定するヘルパーを新設する。
    - ページネーションに対応し、最大 20 ページまで走査する。
- `apps/web/src/lib/sui/use-owned-kakera.ts` / `use-owned-kakera.test.ts`
    - Kakera 受領を 1.5 秒間隔で最大 20 回ポーリングする React フックを新設する。
    - 見つかれば即停止、未発見のまま上限で `timeout` を返す。
    - `localStorage` に依存せず、毎回チェーンから確認する。
- `apps/web/src/lib/sui/react.ts`
    - 新設した Kakera フックの再エクスポートを追加する。
- `apps/web/src/app/units/[unitId]/participation-access.tsx` / `participation-access.test.tsx`
    - 仮の `blob_id` 手入力 UI を撤去する。
    - 段階式の状態機械に置き換える（`ready → processing → previewing → uploading → submitting → done`、失敗時は `error`）。
    - 同意を必須にし、同意しないとファイル選択に進めないようにする。
    - プレビュー確定で Walrus PUT → `submit_photo` を直列に発火する。
    - 失敗の種類ごとにメッセージを分ける（Walrus 失敗 / Enoki 認証切れ / チェーン送信失敗）。
    - 完了後は参加証カードを表示する（プレビュー、送信アドレス、`submission_no`、Kakera 確認状態）。
    - Walrus 最終失敗時は「もう一度送信する」ボタンを出し、前処理済み写真を再利用して PUT から再開する。
    - 完了状態では同意と写真選びの UI を閉じ、成功カードが上書きされないようにする。
    - プレビュー URL を `revokeObjectURL` で回収し、長時間セッションでの Blob メモリ滞留を防ぐ。
- `apps/web/src/app/units/[unitId]/live-progress.tsx`
    - カウンタは `SubmittedEvent` を正本にする不変条件を docstring に明記する（既に楽観更新は存在しなかった）。

## 主なレビュー指摘と対応

- フェーズ 1 末レビュー
    - 指摘: 任意の `Blob` を PUT できてしまい、前処理をバイパスできる。
    - 対応: 入力型を `PreprocessedPhoto` に絞った（コミット `d35ee6f`）。
    - 指摘: `fetch` にタイムアウトが無くハング時にリトライが動かない。
    - 対応: 各アテンプトに `AbortController` を付け、ハングを一時失敗として扱うようにした（コミット `d35ee6f`）。
- ファイナライズレビュー
    - 指摘: Kakera 検索が先頭ページしか見ていない。
    - 対応: ページネーション対応に変更した（コミット `250b257`）。
    - 指摘: 完了後にもファイル選び直しができ、成功カードが上書きされる。
    - 対応: 完了状態で同意と写真選びの UI を閉じる one-shot 化に変更した（コミット `250b257`）。
    - 指摘: `createObjectURL` の回収漏れでメモリが溜まる。
    - 対応: 発行済み URL を追跡し、選び直しと unmount 時に `revokeObjectURL` する（コミット `250b257`）。

## スコープ外メモ

- Enoki の `execute` 部分失敗の再照会導線は本 PR に含めない。
    - 現象: `/api/enoki/submit-photo/execute` が失敗しても、チェーン上は成功している場合がある。
    - 影響: UI は「失敗」に倒れるが、Move 側が重複投稿を拒否するため Kakera 自体は mint 済みで安全である。
    - 扱い: 「`digest` 照会で状態を確定する導線」を後続 issue として切る方針にする。

## テスト

- `apps/web`: 21 ファイル / 143 テスト（新規含む）がパスする。
- `generator`: 1 ファイル / 1 テストがパスする。
- `corepack pnpm run typecheck`: 全ワークスペースでエラーなし。
- `corepack pnpm run lint`（biome）: 75 ファイル、指摘なし。
- `corepack pnpm run build`（Next.js 16 + Turbopack）: 全ルート生成成功。
- `contracts/` の Move パッケージは本 PR では変更していないため対象外。

## デザインについて

本 PR の UI はデザイン確定前の暫定版。配色やレイアウトの細部は後続でデザイナーが引き継ぐ前提で、命名や見た目ではなく、状態遷移と失敗経路の正しさを優先している。
