### PR TITLE
chore: Docker 内で Playwright 同梱 Chromium を使う

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -41,6 +41,8 @@ docker compose -p one_portrait port dev 9323   # Playwright レポート
 
 Dockerfile では `@openai/codex` と `@anthropic-ai/claude-code`（公式インストーラ経由）もインストール済みです。
 
+Playwright Chromium も Docker イメージに同梱されているため、devcontainer 内では追加の browser install は不要です。コンテナ外のホスト環境で E2E を実行する場合だけ `corepack pnpm --filter web run test:e2e:install` を使ってください。
+
 `docker compose up` 単体は正式サポート外です。Git / Claude / Codex の初期化は保証しません。
 
 ## 隔離境界

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,7 @@
     "source=${localEnv:HOME}/.gitconfig,target=/mnt/host-gitconfig,type=bind,readonly",
     "source=${localEnv:HOME}/.config/gh,target=/home/pwuser/.config/gh,type=bind,readonly",
     "source=one-portrait-devcontainer-claude-home,target=/home/pwuser/.claude,type=volume",
-    "source=one-portrait-devcontainer-codex-home,target=/home/pwuser/.codex,type=volume",
-    "source=one-portrait-devcontainer-playwright-cache,target=/home/pwuser/.cache/ms-playwright,type=volume"
+    "source=one-portrait-devcontainer-codex-home,target=/home/pwuser/.codex,type=volume"
   ],
   "containerEnv": {
     "CLAUDE_CONFIG_DIR": "/home/pwuser/.claude",
@@ -30,7 +29,7 @@
     "CODEX_HOME": "/home/pwuser/.codex",
     "HOST_CODEX_DIR": "/mnt/host-codex",
     "HOST_GITCONFIG": "/mnt/host-gitconfig",
-    "PLAYWRIGHT_BROWSERS_PATH": "/home/pwuser/.cache/ms-playwright"
+    "PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright"
   },
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/pwuser/.claude",
@@ -38,7 +37,7 @@
     "CODEX_HOME": "/home/pwuser/.codex",
     "HOST_CODEX_DIR": "/mnt/host-codex",
     "HOST_GITCONFIG": "/mnt/host-gitconfig",
-    "PLAYWRIGHT_BROWSERS_PATH": "/home/pwuser/.cache/ms-playwright"
+    "PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright"
   },
   "postStartCommand": "bash .devcontainer/post-start.sh",
   "customizations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.58.2-jammy
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy
 
 ARG NODE_MAJOR=24
 ARG CLAUDE_CODE_TARGET=latest
@@ -39,7 +39,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 ENV PATH="/home/pwuser/.local/bin:${PATH}"
 ENV NPM_CONFIG_PREFIX=/home/pwuser/.local
-ENV PLAYWRIGHT_BROWSERS_PATH=/home/pwuser/.cache/ms-playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV CLAUDE_CONFIG_DIR=/home/pwuser/.claude
 ENV CODEX_HOME=/home/pwuser/.codex
 ENV TERM=xterm-256color


### PR DESCRIPTION
## 概要
Docker / devcontainer 内で Playwright 同梱 Chromium をそのまま使えるようにし、追加 install なしで E2E を実行できる状態に揃えます。

## 変更内容
- `Dockerfile`
  - Playwright 公式イメージを `v1.59.1-jammy` へ更新
  - `PLAYWRIGHT_BROWSERS_PATH` を `/ms-playwright` に変更
- `.devcontainer/devcontainer.json`
  - Playwright cache volume mount を削除
  - `containerEnv` / `remoteEnv` の browser path を `/ms-playwright` に統一
- `.devcontainer/README.md`
  - devcontainer 内では browser install 不要であることを追記
  - ホスト実行時のみ `test:e2e:install` を使う運用を明記

## 関連する Issue やチケット
なし

## 動作確認
- `docker compose build dev`
- `docker run --rm -v /home/manji/github/one_portrait-docker-playwright:/workspace/one_portrait -w /workspace/one_portrait one-portrait-dev:local bash -lc 'corepack pnpm --filter web exec playwright --version'
- `docker run --rm -v /home/manji/github/one_portrait-docker-playwright:/workspace/one_portrait -w /workspace/one_portrait one-portrait-dev:local bash -lc 'corepack pnpm --filter web exec playwright install --dry-run chromium'
- `docker run --rm -e CI=true -v /home/manji/github/one_portrait-docker-playwright:/workspace/one_portrait -w /workspace/one_portrait one-portrait-dev:local bash -lc 'corepack pnpm --filter web run test:e2e'
- `docker run --rm -e CI=true -v /home/manji/github/one_portrait-docker-playwright:/workspace/one_portrait -w /workspace/one_portrait one-portrait-dev:local bash -lc 'corepack pnpm run check'
