### PR TITLE
fix: Enoki execute 部分失敗の回復導線を追加

### DIFF
--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -23,6 +23,7 @@ const {
   useDisconnectWalletMock,
   useOwnedKakeraMock,
   useUnitEventsMock,
+  checkSubmissionExecutionMock,
 } = vi.hoisted(() => ({
   useEnokiConfigStateMock: vi.fn(),
   useSubmitPhotoMock: vi.fn(),
@@ -33,6 +34,7 @@ const {
   useDisconnectWalletMock: vi.fn(),
   useOwnedKakeraMock: vi.fn(),
   useUnitEventsMock: vi.fn(),
+  checkSubmissionExecutionMock: vi.fn(),
 }));
 
 vi.mock("../../../lib/enoki/provider", () => ({
@@ -43,11 +45,33 @@ vi.mock("../../../lib/enoki/client-submit", () => ({
   EnokiSubmitClientError: class extends Error {
     code: string;
     status: number;
+    submissionStatus: "recovering" | "failed";
+    recovery:
+      | {
+          readonly digest: string;
+          readonly sender: string;
+          readonly blobId: string;
+        }
+      | null;
 
-    constructor(status: number, code: string, message: string) {
+    constructor(
+      status: number,
+      code: string,
+      message: string,
+      options?: {
+        readonly submissionStatus?: "recovering" | "failed";
+        readonly recovery?: {
+          readonly digest: string;
+          readonly sender: string;
+          readonly blobId: string;
+        } | null;
+      },
+    ) {
       super(message);
       this.status = status;
       this.code = code;
+      this.submissionStatus = options?.submissionStatus ?? "failed";
+      this.recovery = options?.recovery ?? null;
     }
   },
   useSubmitPhoto: () => useSubmitPhotoMock(),
@@ -72,6 +96,8 @@ vi.mock("../../../lib/sui/react", () => ({
 
 vi.mock("../../../lib/sui", () => ({
   getSuiClient: () => ({}),
+  checkSubmissionExecution: (args: unknown) =>
+    checkSubmissionExecutionMock(args),
 }));
 
 import { LiveProgress } from "./live-progress";
@@ -105,6 +131,7 @@ function setupSignedInEnv(): void {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   useEnokiConfigStateMock.mockReset();
   useSubmitPhotoMock.mockReset();
   useWalletsMock.mockReset();
@@ -114,6 +141,7 @@ afterEach(() => {
   useDisconnectWalletMock.mockReset();
   useOwnedKakeraMock.mockReset();
   useUnitEventsMock.mockReset();
+  checkSubmissionExecutionMock.mockReset();
 });
 
 describe("ParticipationAccess", () => {
@@ -667,6 +695,152 @@ describe("ParticipationAccess", () => {
         expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
       });
       expect(screen.getByText(/final-digest-XYZ/)).toBeTruthy();
+    });
+
+    it("keeps showing a recovery message while execution confirmation is still pending, then offers retry only after confirmed failure", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const { EnokiSubmitClientError } = await import(
+        "../../../lib/enoki/client-submit"
+      );
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-recovery",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-recovery",
+      }));
+      let resolveExecutionCheck: (
+        value: { readonly status: "failed"; readonly kakera: null },
+      ) => void = () => {};
+      checkSubmissionExecutionMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveExecutionCheck = resolve;
+          }),
+      );
+      submitPhoto.mockRejectedValue(
+        new EnokiSubmitClientError(503, "submit_unavailable", "execute failed", {
+          submissionStatus: "recovering",
+          recovery: {
+            digest: "recover-digest",
+            sender: "0xabc123",
+            blobId: "walrus-blob-recovery",
+          },
+        }),
+      );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(checkSubmissionExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            digest: "recover-digest",
+            ownerAddress: "0xabc123",
+            unitId: "0xunit-1",
+            walrusBlobId: "walrus-blob-recovery",
+          }),
+        );
+      });
+
+      expect(
+        screen.getByText(/投稿結果を確認しています。しばらくお待ちください。/),
+      ).toBeTruthy();
+      expect(
+        screen.queryByRole("button", { name: /もう一度送信する/ }),
+      ).toBeNull();
+
+      resolveExecutionCheck({
+        status: "failed",
+        kakera: null,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toContain(
+          "投稿を完了できませんでした",
+        );
+      });
+      expect(
+        screen.getByRole("button", { name: /もう一度送信する/ }),
+      ).toBeTruthy();
+    });
+
+    it("re-queries recovering execution and merges into the participation card once recovery succeeds", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const { EnokiSubmitClientError } = await import(
+        "../../../lib/enoki/client-submit"
+      );
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-recovery",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-recovery",
+      }));
+      checkSubmissionExecutionMock
+        .mockResolvedValueOnce({
+          status: "recovering",
+          kakera: null,
+        })
+        .mockResolvedValueOnce({
+          status: "success",
+          kakera: null,
+        });
+      submitPhoto.mockRejectedValue(
+        new EnokiSubmitClientError(503, "submit_unavailable", "execute failed", {
+          submissionStatus: "recovering",
+          recovery: {
+            digest: "recover-digest",
+            sender: "0xabc123",
+            blobId: "walrus-blob-recovery",
+          },
+        }),
+      );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        screen.queryByRole("button", { name: /もう一度送信する/ }),
+      ).toBeNull();
+
+      await waitFor(() => {
+        expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(2);
+      }, { timeout: 3_000 });
+
+      await waitFor(() => {
+        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+      });
+      expect(screen.getByText(/recover-digest/)).toBeTruthy();
+      expect(useOwnedKakeraMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          ownerAddress: "0xabc123",
+          walrusBlobId: "walrus-blob-recovery",
+        }),
+      );
     });
 
     it("renders the participation card with preview, sender, and a pending submission_no while Kakera is being confirmed", async () => {

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -716,19 +716,14 @@ describe("ParticipationAccess", () => {
           }),
       );
       submitPhoto.mockRejectedValue(
-        new EnokiSubmitClientError(
-          503,
-          "submit_unavailable",
-          "execute failed",
-          {
-            submissionStatus: "recovering",
-            recovery: {
-              digest: "recover-digest",
-              sender: "0xabc123",
-              blobId: "walrus-blob-recovery",
-            },
+        new EnokiSubmitClientError(503, "sponsor_failed", "execute failed", {
+          submissionStatus: "recovering",
+          recovery: {
+            digest: "recover-digest",
+            sender: "0xabc123",
+            blobId: "walrus-blob-recovery",
           },
-        ),
+        }),
       );
 
       render(
@@ -799,22 +794,17 @@ describe("ParticipationAccess", () => {
           kakera: null,
         });
       submitPhoto.mockRejectedValue(
-        new EnokiSubmitClientError(
-          503,
-          "submit_unavailable",
-          "execute failed",
-          {
-            submissionStatus: "recovering",
-            recovery: {
-              digest: "recover-digest",
-              sender: "0xabc123",
-              blobId: "walrus-blob-recovery",
-            },
+        new EnokiSubmitClientError(503, "sponsor_failed", "execute failed", {
+          submissionStatus: "recovering",
+          recovery: {
+            digest: "recover-digest",
+            sender: "0xabc123",
+            blobId: "walrus-blob-recovery",
           },
-        ),
+        }),
       );
 
-      render(
+      const view = render(
         <ParticipationAccess
           preprocessPhoto={preprocessPhoto}
           putBlob={putBlob}
@@ -853,6 +843,26 @@ describe("ParticipationAccess", () => {
           walrusBlobId: "walrus-blob-recovery",
         }),
       );
+
+      useCurrentAccountMock.mockReturnValue({ address: "0xother999" });
+      view.rerender(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      expect(useOwnedKakeraMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          ownerAddress: "0xabc123",
+          walrusBlobId: "walrus-blob-recovery",
+        }),
+      );
     });
 
     it("falls back to retry after the recovery poll budget is exhausted", async () => {
@@ -870,19 +880,14 @@ describe("ParticipationAccess", () => {
         kakera: null,
       });
       submitPhoto.mockRejectedValue(
-        new EnokiSubmitClientError(
-          503,
-          "submit_unavailable",
-          "execute failed",
-          {
-            submissionStatus: "recovering",
-            recovery: {
-              digest: "recover-digest",
-              sender: "0xabc123",
-              blobId: "walrus-blob-recovery",
-            },
+        new EnokiSubmitClientError(503, "sponsor_failed", "execute failed", {
+          submissionStatus: "recovering",
+          recovery: {
+            digest: "recover-digest",
+            sender: "0xabc123",
+            blobId: "walrus-blob-recovery",
           },
-        ),
+        }),
       );
 
       render(

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -46,13 +46,11 @@ vi.mock("../../../lib/enoki/client-submit", () => ({
     code: string;
     status: number;
     submissionStatus: "recovering" | "failed";
-    recovery:
-      | {
-          readonly digest: string;
-          readonly sender: string;
-          readonly blobId: string;
-        }
-      | null;
+    recovery: {
+      readonly digest: string;
+      readonly sender: string;
+      readonly blobId: string;
+    } | null;
 
     constructor(
       status: number,
@@ -707,9 +705,10 @@ describe("ParticipationAccess", () => {
         aggregatorUrl:
           "https://aggregator.example.com/v1/blobs/walrus-blob-recovery",
       }));
-      let resolveExecutionCheck: (
-        value: { readonly status: "failed"; readonly kakera: null },
-      ) => void = () => {};
+      let resolveExecutionCheck: (value: {
+        readonly status: "failed";
+        readonly kakera: null;
+      }) => void = () => {};
       checkSubmissionExecutionMock.mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -717,14 +716,19 @@ describe("ParticipationAccess", () => {
           }),
       );
       submitPhoto.mockRejectedValue(
-        new EnokiSubmitClientError(503, "submit_unavailable", "execute failed", {
-          submissionStatus: "recovering",
-          recovery: {
-            digest: "recover-digest",
-            sender: "0xabc123",
-            blobId: "walrus-blob-recovery",
+        new EnokiSubmitClientError(
+          503,
+          "submit_unavailable",
+          "execute failed",
+          {
+            submissionStatus: "recovering",
+            recovery: {
+              digest: "recover-digest",
+              sender: "0xabc123",
+              blobId: "walrus-blob-recovery",
+            },
           },
-        }),
+        ),
       );
 
       render(
@@ -795,14 +799,19 @@ describe("ParticipationAccess", () => {
           kakera: null,
         });
       submitPhoto.mockRejectedValue(
-        new EnokiSubmitClientError(503, "submit_unavailable", "execute failed", {
-          submissionStatus: "recovering",
-          recovery: {
-            digest: "recover-digest",
-            sender: "0xabc123",
-            blobId: "walrus-blob-recovery",
+        new EnokiSubmitClientError(
+          503,
+          "submit_unavailable",
+          "execute failed",
+          {
+            submissionStatus: "recovering",
+            recovery: {
+              digest: "recover-digest",
+              sender: "0xabc123",
+              blobId: "walrus-blob-recovery",
+            },
           },
-        }),
+        ),
       );
 
       render(
@@ -827,9 +836,12 @@ describe("ParticipationAccess", () => {
         screen.queryByRole("button", { name: /もう一度送信する/ }),
       ).toBeNull();
 
-      await waitFor(() => {
-        expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(2);
-      }, { timeout: 3_000 });
+      await waitFor(
+        () => {
+          expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 3_000 },
+      );
 
       await waitFor(() => {
         expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -855,6 +855,79 @@ describe("ParticipationAccess", () => {
       );
     });
 
+    it("falls back to retry after the recovery poll budget is exhausted", async () => {
+      const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
+      const { EnokiSubmitClientError } = await import(
+        "../../../lib/enoki/client-submit"
+      );
+      const putBlob = vi.fn<PutMock>(async () => ({
+        blobId: "walrus-blob-recovery",
+        aggregatorUrl:
+          "https://aggregator.example.com/v1/blobs/walrus-blob-recovery",
+      }));
+      checkSubmissionExecutionMock.mockResolvedValue({
+        status: "recovering",
+        kakera: null,
+      });
+      submitPhoto.mockRejectedValue(
+        new EnokiSubmitClientError(
+          503,
+          "submit_unavailable",
+          "execute failed",
+          {
+            submissionStatus: "recovering",
+            recovery: {
+              digest: "recover-digest",
+              sender: "0xabc123",
+              blobId: "walrus-blob-recovery",
+            },
+          },
+        ),
+      );
+
+      render(
+        <ParticipationAccess
+          preprocessPhoto={preprocessPhoto}
+          putBlob={putBlob}
+          recoveryMaxAttempts={2}
+          recoveryRetryIntervalMs={10}
+          unitId="0xunit-1"
+          walrusEnv={{
+            NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+            NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+          }}
+        />,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(checkSubmissionExecutionMock).toHaveBeenCalled();
+      });
+      expect(
+        screen.getByText(/投稿結果を確認しています。しばらくお待ちください。/),
+      ).toBeTruthy();
+
+      await waitFor(
+        () => {
+          expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 1_000 },
+      );
+      await waitFor(
+        () => {
+          expect(screen.getByRole("alert").textContent).toContain(
+            "投稿結果を確認できませんでした",
+          );
+        },
+        { timeout: 1_000 },
+      );
+      expect(
+        screen.getByRole("button", { name: /もう一度送信する/ }),
+      ).toBeTruthy();
+    });
+
     it("renders the participation card with preview, sender, and a pending submission_no while Kakera is being confirmed", async () => {
       const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
       useOwnedKakeraMock.mockReturnValue({

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -223,8 +223,7 @@ function ParticipationAccessEnabled({
   const packageId = safeReadPackageId();
   const ownedKakera = useOwnedKakera({
     suiClient: getSuiClient(),
-    ownerAddress:
-      phase.kind === "done" ? (currentAccount?.address ?? null) : null,
+    ownerAddress: phase.kind === "done" ? phase.result.sender : null,
     unitId,
     walrusBlobId: doneBlobId,
     packageId: packageId ?? "",
@@ -327,7 +326,7 @@ function ParticipationAccessEnabled({
         result = await checkSubmissionExecution({
           suiClient: getSuiClient(),
           digest: phase.recovery.digest,
-          ownerAddress: currentAccount?.address ?? phase.recovery.sender,
+          ownerAddress: phase.recovery.sender,
           unitId,
           walrusBlobId: phase.recovery.blobId,
           packageId: packageId ?? "",
@@ -385,14 +384,7 @@ function ParticipationAccessEnabled({
         clearTimeout(pending);
       }
     };
-  }, [
-    currentAccount?.address,
-    packageId,
-    phase,
-    recoveryMaxAttempts,
-    recoveryRetryIntervalMs,
-    unitId,
-  ]);
+  }, [packageId, phase, recoveryMaxAttempts, recoveryRetryIntervalMs, unitId]);
 
   const isProcessing = phase.kind === "processing";
   const isUploading = phase.kind === "uploading";

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -308,7 +308,7 @@ function ParticipationAccessEnabled({
     let pending: ReturnType<typeof setTimeout> | null = null;
 
     const verifyExecution = async (): Promise<void> => {
-      let result;
+      let result: Awaited<ReturnType<typeof checkSubmissionExecution>>;
       try {
         result = await checkSubmissionExecution({
           suiClient: getSuiClient(),
@@ -669,9 +669,7 @@ function isAuthExpired(error: unknown): boolean {
   );
 }
 
-function isSubmitRecovering(
-  error: unknown,
-): error is EnokiSubmitClientError & {
+function isSubmitRecovering(error: unknown): error is EnokiSubmitClientError & {
   readonly recovery: SubmitPhotoRecoveryContext;
 } {
   return (

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -107,11 +107,15 @@ export function ParticipationAccess({
   unitId,
   preprocessPhoto,
   putBlob,
+  recoveryMaxAttempts,
+  recoveryRetryIntervalMs,
   walrusEnv,
 }: {
   readonly unitId: string;
   readonly preprocessPhoto?: PreprocessPhotoFn;
   readonly putBlob?: PutBlobFn;
+  readonly recoveryMaxAttempts?: number;
+  readonly recoveryRetryIntervalMs?: number;
   readonly walrusEnv?: WalrusEnv;
 }): React.ReactElement {
   const state = useEnokiConfigState();
@@ -133,6 +137,10 @@ export function ParticipationAccess({
     <ParticipationAccessEnabled
       preprocessPhoto={preprocessPhoto ?? defaultPreprocessPhoto}
       putBlob={putBlob ?? defaultPutBlobToWalrus}
+      recoveryMaxAttempts={recoveryMaxAttempts ?? RECOVERY_MAX_ATTEMPTS}
+      recoveryRetryIntervalMs={
+        recoveryRetryIntervalMs ?? RECOVERY_RETRY_INTERVAL_MS
+      }
       unitId={unitId}
       walrusEnv={walrusEnv ?? readWalrusEnvFromProcess()}
     />
@@ -143,11 +151,15 @@ function ParticipationAccessEnabled({
   unitId,
   preprocessPhoto,
   putBlob,
+  recoveryMaxAttempts,
+  recoveryRetryIntervalMs,
   walrusEnv,
 }: {
   readonly unitId: string;
   readonly preprocessPhoto: PreprocessPhotoFn;
   readonly putBlob: PutBlobFn;
+  readonly recoveryMaxAttempts: number;
+  readonly recoveryRetryIntervalMs: number;
   readonly walrusEnv: WalrusEnv;
 }): React.ReactElement {
   const wallets = useWallets();
@@ -306,8 +318,10 @@ function ParticipationAccessEnabled({
 
     let cancelled = false;
     let pending: ReturnType<typeof setTimeout> | null = null;
+    let attempts = 0;
 
     const verifyExecution = async (): Promise<void> => {
+      attempts += 1;
       let result: Awaited<ReturnType<typeof checkSubmissionExecution>>;
       try {
         result = await checkSubmissionExecution({
@@ -348,10 +362,19 @@ function ParticipationAccessEnabled({
         return;
       }
 
+      if (attempts >= recoveryMaxAttempts) {
+        setPhase({
+          kind: "error",
+          message: "投稿結果を確認できませんでした。もう一度送信してください。",
+          retry: { kind: "submit", photo: phase.photo },
+        });
+        return;
+      }
+
       pending = setTimeout(() => {
         pending = null;
         void verifyExecution();
-      }, RECOVERY_RETRY_INTERVAL_MS);
+      }, recoveryRetryIntervalMs);
     };
 
     void verifyExecution();
@@ -362,7 +385,14 @@ function ParticipationAccessEnabled({
         clearTimeout(pending);
       }
     };
-  }, [currentAccount?.address, packageId, phase, unitId]);
+  }, [
+    currentAccount?.address,
+    packageId,
+    phase,
+    recoveryMaxAttempts,
+    recoveryRetryIntervalMs,
+    unitId,
+  ]);
 
   const isProcessing = phase.kind === "processing";
   const isUploading = phase.kind === "uploading";
@@ -727,3 +757,4 @@ function describeKakeraStatus(
 }
 
 const RECOVERY_RETRY_INTERVAL_MS = 1_500;
+const RECOVERY_MAX_ATTEMPTS = 20;

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   EnokiSubmitClientError,
+  type SubmitPhotoRecoveryContext,
   type SubmitPhotoSuccess,
   useSubmitPhoto,
 } from "../../../lib/enoki/client-submit";
@@ -21,7 +22,7 @@ import {
   preprocessPhoto as defaultPreprocessPhoto,
   type PreprocessedPhoto,
 } from "../../../lib/image/preprocess";
-import { getSuiClient } from "../../../lib/sui";
+import { checkSubmissionExecution, getSuiClient } from "../../../lib/sui";
 import { useOwnedKakera } from "../../../lib/sui/react";
 import {
   putBlobToWalrus as defaultPutBlobToWalrus,
@@ -71,7 +72,7 @@ type PutBlobFn = (
  * preprocessing.
  */
 type RetryContext = {
-  readonly kind: "upload";
+  readonly kind: "upload" | "submit";
   readonly photo: PreprocessedPhoto;
 };
 
@@ -84,6 +85,11 @@ type UploadPhase =
       readonly kind: "submitting";
       readonly photo: PreprocessedPhoto;
       readonly blobId: string;
+    }
+  | {
+      readonly kind: "recovering";
+      readonly photo: PreprocessedPhoto;
+      readonly recovery: SubmitPhotoRecoveryContext;
     }
   | {
       readonly kind: "done";
@@ -279,13 +285,89 @@ function ParticipationAccessEnabled({
         setPhase({ kind: "ready" });
         return;
       }
+
+      if (isSubmitRecovering(error)) {
+        setPhase({
+          kind: "recovering",
+          photo,
+          recovery: error.recovery,
+        });
+        return;
+      }
+
       setPhase({ kind: "error", message: toSubmitErrorMessage(error) });
     }
   }
 
+  useEffect(() => {
+    if (phase.kind !== "recovering") {
+      return;
+    }
+
+    let cancelled = false;
+    let pending: ReturnType<typeof setTimeout> | null = null;
+
+    const verifyExecution = async (): Promise<void> => {
+      let result;
+      try {
+        result = await checkSubmissionExecution({
+          suiClient: getSuiClient(),
+          digest: phase.recovery.digest,
+          ownerAddress: currentAccount?.address ?? phase.recovery.sender,
+          unitId,
+          walrusBlobId: phase.recovery.blobId,
+          packageId: packageId ?? "",
+        });
+      } catch {
+        result = { status: "recovering", kakera: null } as const;
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      if (result.status === "success") {
+        setPhase({
+          kind: "done",
+          result: {
+            digest: phase.recovery.digest,
+            sender: phase.recovery.sender,
+          },
+          photo: phase.photo,
+          blobId: phase.recovery.blobId,
+        });
+        return;
+      }
+
+      if (result.status === "failed") {
+        setPhase({
+          kind: "error",
+          message: "投稿を完了できませんでした。もう一度送信してください。",
+          retry: { kind: "submit", photo: phase.photo },
+        });
+        return;
+      }
+
+      pending = setTimeout(() => {
+        pending = null;
+        void verifyExecution();
+      }, RECOVERY_RETRY_INTERVAL_MS);
+    };
+
+    void verifyExecution();
+
+    return () => {
+      cancelled = true;
+      if (pending !== null) {
+        clearTimeout(pending);
+      }
+    };
+  }, [currentAccount?.address, packageId, phase, unitId]);
+
   const isProcessing = phase.kind === "processing";
   const isUploading = phase.kind === "uploading";
   const isSubmitting = phase.kind === "submitting";
+  const isRecovering = phase.kind === "recovering";
   const isDone = phase.kind === "done";
   // Submission is one-shot: once the on-chain `submit_photo` lands, the Move
   // side rejects any further attempt from the same sender, but the UI must
@@ -293,19 +375,25 @@ function ParticipationAccessEnabled({
   // participation card with an error state. Gate every interactive control
   // on `isDone` so the success card is the terminal view for this unit.
   const fileInputDisabled =
-    !consented || isProcessing || isUploading || isSubmitting || isDone;
+    !consented ||
+    isProcessing ||
+    isUploading ||
+    isSubmitting ||
+    isRecovering ||
+    isDone;
   const previewPhoto =
     phase.kind === "previewing" ||
     phase.kind === "uploading" ||
-    phase.kind === "submitting"
+    phase.kind === "submitting" ||
+    phase.kind === "recovering"
       ? phase.photo
       : null;
-  const submitButtonDisabled = isUploading || isSubmitting;
+  const submitButtonDisabled = isUploading || isSubmitting || isRecovering;
   const showSubmitButton =
     phase.kind === "previewing" ||
     phase.kind === "uploading" ||
     phase.kind === "submitting";
-  const showConsentAndFilePicker = !isDone;
+  const showConsentAndFilePicker = !isDone && !isRecovering;
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
   const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
@@ -388,6 +476,12 @@ function ParticipationAccessEnabled({
           {isSubmitting ? (
             <p className="text-sm text-slate-300" role="status">
               オンチェーンに投稿しています…
+            </p>
+          ) : null}
+
+          {isRecovering ? (
+            <p className="text-sm text-slate-300" role="status">
+              投稿結果を確認しています。しばらくお待ちください。
             </p>
           ) : null}
 
@@ -575,6 +669,18 @@ function isAuthExpired(error: unknown): boolean {
   );
 }
 
+function isSubmitRecovering(
+  error: unknown,
+): error is EnokiSubmitClientError & {
+  readonly recovery: SubmitPhotoRecoveryContext;
+} {
+  return (
+    error instanceof EnokiSubmitClientError &&
+    error.submissionStatus === "recovering" &&
+    error.recovery !== null
+  );
+}
+
 function toSubmitErrorMessage(error: unknown): string {
   if (error instanceof EnokiSubmitClientError) {
     return error.message;
@@ -621,3 +727,5 @@ function describeKakeraStatus(
       return "";
   }
 }
+
+const RECOVERY_RETRY_INTERVAL_MS = 1_500;

--- a/apps/web/src/lib/enoki/client-submit.test.ts
+++ b/apps/web/src/lib/enoki/client-submit.test.ts
@@ -117,4 +117,142 @@ describe("submitPhotoWithEnoki", () => {
       new EnokiSubmitClientError(400, "invalid_args", "blob id is invalid"),
     );
   });
+
+  it("marks execute API failures as recovering and keeps sponsor context", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: "submit_unavailable",
+            message: "execute failed",
+          }),
+          { status: 503 },
+        ),
+      );
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getJwt: async () => "header.jwt.value",
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "submit_unavailable",
+      status: 503,
+      submissionStatus: "recovering",
+      recovery: {
+        digest: "sponsor-digest",
+        sender: "0xsender",
+        blobId: "walrus-blob_1",
+      },
+    });
+  });
+
+  it("marks execute transport failures as recovering and keeps sponsor context", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockRejectedValueOnce(new Error("network down"));
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getJwt: async () => "header.jwt.value",
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "sponsor_failed",
+      status: 502,
+      submissionStatus: "recovering",
+      recovery: {
+        digest: "sponsor-digest",
+        sender: "0xsender",
+        blobId: "walrus-blob_1",
+      },
+    });
+  });
+
+  it("keeps execute auth_expired as a confirmed failure", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: "auth_expired",
+            message: "please log in again",
+          }),
+          { status: 401 },
+        ),
+      );
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getJwt: async () => "header.jwt.value",
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "auth_expired",
+      status: 401,
+      submissionStatus: "failed",
+      recovery: null,
+    });
+  });
 });

--- a/apps/web/src/lib/enoki/client-submit.test.ts
+++ b/apps/web/src/lib/enoki/client-submit.test.ts
@@ -134,10 +134,10 @@ describe("submitPhotoWithEnoki", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            code: "submit_unavailable",
+            code: "sponsor_failed",
             message: "execute failed",
           }),
-          { status: 503 },
+          { status: 502 },
         ),
       );
 
@@ -157,8 +157,8 @@ describe("submitPhotoWithEnoki", () => {
         },
       ),
     ).rejects.toMatchObject({
-      code: "submit_unavailable",
-      status: 503,
+      code: "sponsor_failed",
+      status: 502,
       submissionStatus: "recovering",
       recovery: {
         digest: "sponsor-digest",
@@ -251,6 +251,98 @@ describe("submitPhotoWithEnoki", () => {
     ).rejects.toMatchObject({
       code: "auth_expired",
       status: 401,
+      submissionStatus: "failed",
+      recovery: null,
+    });
+  });
+
+  it("keeps execute invalid_args as a confirmed failure", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: "invalid_args",
+            message: "signature is invalid",
+          }),
+          { status: 400 },
+        ),
+      );
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getJwt: async () => "header.jwt.value",
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_args",
+      status: 400,
+      submissionStatus: "failed",
+      recovery: null,
+    });
+  });
+
+  it("keeps execute submit_unavailable as a confirmed failure when execute preflight fails", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: "submit_unavailable",
+            message: "submit env missing",
+          }),
+          { status: 503 },
+        ),
+      );
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getJwt: async () => "header.jwt.value",
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "submit_unavailable",
+      status: 503,
       submissionStatus: "failed",
       recovery: null,
     });

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -21,15 +21,37 @@ export type SubmitPhotoSuccess = {
   readonly sender: string;
 };
 
+export type SubmitPhotoFailureStatus = "recovering" | "failed";
+
+export type SubmitPhotoRecoveryContext = {
+  readonly digest: string;
+  readonly sender: string;
+  readonly blobId: string;
+};
+
+type EnokiSubmitClientErrorOptions = {
+  readonly submissionStatus?: SubmitPhotoFailureStatus;
+  readonly recovery?: SubmitPhotoRecoveryContext | null;
+};
+
 export class EnokiSubmitClientError extends Error {
   readonly status: number;
   readonly code: EnokiApiErrorCode;
+  readonly submissionStatus: SubmitPhotoFailureStatus;
+  readonly recovery: SubmitPhotoRecoveryContext | null;
 
-  constructor(status: number, code: EnokiApiErrorCode, message: string) {
+  constructor(
+    status: number,
+    code: EnokiApiErrorCode,
+    message: string,
+    options: EnokiSubmitClientErrorOptions = {},
+  ) {
     super(message);
     this.name = "EnokiSubmitClientError";
     this.status = status;
     this.code = code;
+    this.submissionStatus = options.submissionStatus ?? "failed";
+    this.recovery = options.recovery ?? null;
   }
 }
 
@@ -66,15 +88,25 @@ export async function submitPhotoWithEnoki(
     input,
   );
   const signed = await deps.signTransaction(sponsor.bytes);
-  const executed = await postJson<ExecuteSponsoredResponse>(
-    fetchFn,
-    "/api/enoki/submit-photo/execute",
-    jwt,
-    {
+  let executed: ExecuteSponsoredResponse;
+
+  try {
+    executed = await postJson<ExecuteSponsoredResponse>(
+      fetchFn,
+      "/api/enoki/submit-photo/execute",
+      jwt,
+      {
+        digest: sponsor.digest,
+        signature: signed.signature,
+      },
+    );
+  } catch (error) {
+    throw toExecuteSubmitError(error, {
       digest: sponsor.digest,
-      signature: signed.signature,
-    },
-  );
+      sender: sponsor.sender,
+      blobId: input.blobId,
+    });
+  }
 
   return {
     digest: executed.digest,
@@ -180,5 +212,43 @@ function isEnokiApiErrorCode(value: string): value is EnokiApiErrorCode {
     value === "invalid_args" ||
     value === "sponsor_failed" ||
     value === "submit_unavailable"
+  );
+}
+
+function toExecuteSubmitError(
+  error: unknown,
+  recovery: SubmitPhotoRecoveryContext,
+): EnokiSubmitClientError {
+  if (error instanceof EnokiSubmitClientError) {
+    if (error.code === "auth_expired") {
+      return error;
+    }
+
+    return new EnokiSubmitClientError(error.status, error.code, error.message, {
+      submissionStatus: "recovering",
+      recovery,
+    });
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return new EnokiSubmitClientError(
+      502,
+      "sponsor_failed",
+      error.message,
+      {
+        submissionStatus: "recovering",
+        recovery,
+      },
+    );
+  }
+
+  return new EnokiSubmitClientError(
+    502,
+    "sponsor_failed",
+    "投稿結果を確認しています。時間をおいて、もう一度ご確認ください。",
+    {
+      submissionStatus: "recovering",
+      recovery,
+    },
   );
 }

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -231,15 +231,10 @@ function toExecuteSubmitError(
   }
 
   if (error instanceof Error && error.message.trim().length > 0) {
-    return new EnokiSubmitClientError(
-      502,
-      "sponsor_failed",
-      error.message,
-      {
-        submissionStatus: "recovering",
-        recovery,
-      },
-    );
+    return new EnokiSubmitClientError(502, "sponsor_failed", error.message, {
+      submissionStatus: "recovering",
+      recovery,
+    });
   }
 
   return new EnokiSubmitClientError(

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -220,7 +220,12 @@ function toExecuteSubmitError(
   recovery: SubmitPhotoRecoveryContext,
 ): EnokiSubmitClientError {
   if (error instanceof EnokiSubmitClientError) {
-    if (error.code === "auth_expired") {
+    if (
+      error.code === "auth_expired" ||
+      error.code === "invalid_args" ||
+      error.code === "submit_unavailable" ||
+      error.status < 500
+    ) {
       return error;
     }
 

--- a/apps/web/src/lib/sui/client.ts
+++ b/apps/web/src/lib/sui/client.ts
@@ -9,8 +9,8 @@
  *     the SDK. Tests pass stubs that only implement these methods.
  *
  * The client is read-only by intent: this module never wires a `Signer` and
- * the surface only exposes `getObject` / `getDynamicFieldObject`. Write paths
- * (PTBs, sponsored transactions) live elsewhere.
+ * the surface only exposes read RPCs. Write paths (PTBs, sponsored
+ * transactions) live elsewhere.
  */
 
 import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
@@ -36,6 +36,17 @@ export type SuiReadClient = {
   readonly network: string;
   getObject: SuiJsonRpcClient["getObject"];
   getDynamicFieldObject: SuiJsonRpcClient["getDynamicFieldObject"];
+};
+
+/**
+ * Narrow surface for read helpers that inspect transaction execution state.
+ *
+ * Kept separate from {@link SuiReadClient} so object-reading helpers do not
+ * need to stub transaction RPCs they never call.
+ */
+export type SuiTransactionReadClient = {
+  readonly network: string;
+  getTransactionBlock: SuiJsonRpcClient["getTransactionBlock"];
 };
 
 /**

--- a/apps/web/src/lib/sui/index.test.ts
+++ b/apps/web/src/lib/sui/index.test.ts
@@ -16,4 +16,8 @@ describe("sui barrel", () => {
   it("re-exports the unit helper", () => {
     expect(typeof suiPublicApi.getUnitProgress).toBe("function");
   });
+
+  it("re-exports the submission execution helper", () => {
+    expect(typeof suiPublicApi.checkSubmissionExecution).toBe("function");
+  });
 });

--- a/apps/web/src/lib/sui/index.ts
+++ b/apps/web/src/lib/sui/index.ts
@@ -14,7 +14,11 @@
  *     documenting the boundary at the import site.
  */
 
-export type { SuiReadClient, SuiSubscriptionClient } from "./client";
+export type {
+  SuiReadClient,
+  SuiSubscriptionClient,
+  SuiTransactionReadClient,
+} from "./client";
 export { createSuiClient, getSuiClient, resolveFullnodeUrl } from "./client";
 export type {
   MosaicReadyEvent,
@@ -52,6 +56,13 @@ export {
   findOwnedKakeraForUnit,
   listOwnedKakera,
 } from "./kakera";
+export type {
+  CheckSubmissionExecutionArgs,
+  SubmissionExecutionReadClient,
+  SubmissionExecutionResult,
+  SubmissionExecutionStatus,
+} from "./submission-execution";
+export { checkSubmissionExecution } from "./submission-execution";
 export {
   getCurrentUnitIdForAthlete,
   getRegistryObject,

--- a/apps/web/src/lib/sui/index.ts
+++ b/apps/web/src/lib/sui/index.ts
@@ -56,6 +56,11 @@ export {
   findOwnedKakeraForUnit,
   listOwnedKakera,
 } from "./kakera";
+export {
+  getCurrentUnitIdForAthlete,
+  getRegistryObject,
+  RegistryNotFoundError,
+} from "./registry";
 export type {
   CheckSubmissionExecutionArgs,
   SubmissionExecutionReadClient,
@@ -63,11 +68,6 @@ export type {
   SubmissionExecutionStatus,
 } from "./submission-execution";
 export { checkSubmissionExecution } from "./submission-execution";
-export {
-  getCurrentUnitIdForAthlete,
-  getRegistryObject,
-  RegistryNotFoundError,
-} from "./registry";
 export type {
   AthleteProgressView,
   GalleryEntryView,

--- a/apps/web/src/lib/sui/submission-execution.test.ts
+++ b/apps/web/src/lib/sui/submission-execution.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  checkSubmissionExecution,
+  type SubmissionExecutionReadClient,
+} from "./submission-execution";
+
+const PACKAGE_ID = "0xpkg";
+const OWNER = "0xowner";
+const UNIT_ID = "0xunit-1";
+const WALRUS_BLOB_ID = "walrus-blob-xyz";
+const DIGEST = "0xdigest";
+
+function encodeBytes(value: string): number[] {
+  return Array.from(new TextEncoder().encode(value));
+}
+
+function kakeraObject() {
+  return {
+    data: {
+      objectId: "0xkakera-1",
+      digest: "d",
+      version: "1",
+      type: `${PACKAGE_ID}::kakera::Kakera`,
+      content: {
+        dataType: "moveObject",
+        hasPublicTransfer: false,
+        type: `${PACKAGE_ID}::kakera::Kakera`,
+        fields: {
+          id: { id: "0xkakera-1" },
+          unit_id: UNIT_ID,
+          athlete_id: 1,
+          submitter: OWNER,
+          walrus_blob_id: encodeBytes(WALRUS_BLOB_ID),
+          submission_no: "42",
+          minted_at_ms: "1700000000000",
+        },
+      },
+    },
+  };
+}
+
+function makeClient(overrides?: {
+  readonly getTransactionBlock?: SubmissionExecutionReadClient["getTransactionBlock"];
+  readonly getOwnedObjects?: SubmissionExecutionReadClient["getOwnedObjects"];
+}): SubmissionExecutionReadClient {
+  return {
+    network: "testnet",
+    getTransactionBlock:
+      overrides?.getTransactionBlock ??
+      (vi.fn(async () => ({
+        digest: DIGEST,
+        effects: null,
+      })) as SubmissionExecutionReadClient["getTransactionBlock"]),
+    getOwnedObjects:
+      overrides?.getOwnedObjects ??
+      (vi.fn(async () => ({
+        data: [],
+        hasNextPage: false,
+        nextCursor: null,
+      })) as SubmissionExecutionReadClient["getOwnedObjects"]),
+  };
+}
+
+describe("checkSubmissionExecution", () => {
+  it("returns success when the transaction digest resolves with success effects", async () => {
+    const getOwnedObjects = vi.fn(async () => ({
+      data: [],
+      hasNextPage: false,
+      nextCursor: null,
+    })) as unknown as SubmissionExecutionReadClient["getOwnedObjects"];
+    const client = makeClient({
+      getTransactionBlock: vi.fn(async () => ({
+        digest: DIGEST,
+        effects: {
+          status: {
+            status: "success",
+          },
+        },
+      })) as unknown as SubmissionExecutionReadClient["getTransactionBlock"],
+      getOwnedObjects,
+    });
+
+    await expect(
+      checkSubmissionExecution({
+        suiClient: client,
+        digest: DIGEST,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+      }),
+    ).resolves.toEqual({
+      status: "success",
+      kakera: null,
+    });
+
+    expect(getOwnedObjects).not.toHaveBeenCalled();
+  });
+
+  it("returns success when the digest is still unknown but the Kakera is already visible", async () => {
+    const client = makeClient({
+      getTransactionBlock: vi.fn(async () => {
+        throw new Error("transaction not found yet");
+      }) as unknown as SubmissionExecutionReadClient["getTransactionBlock"],
+      getOwnedObjects: vi.fn(async () => ({
+        data: [kakeraObject()],
+        hasNextPage: false,
+        nextCursor: null,
+      })) as unknown as SubmissionExecutionReadClient["getOwnedObjects"],
+    });
+
+    await expect(
+      checkSubmissionExecution({
+        suiClient: client,
+        digest: DIGEST,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+      }),
+    ).resolves.toEqual({
+      status: "success",
+      kakera: {
+        objectId: "0xkakera-1",
+        athletePublicId: "1",
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        submissionNo: 42,
+        mintedAtMs: 1700000000000,
+      },
+    });
+  });
+
+  it("returns recovering while the fullnode has not surfaced either the digest or the Kakera yet", async () => {
+    const client = makeClient({
+      getTransactionBlock: vi.fn(async () => {
+        throw new Error("transaction not found");
+      }) as unknown as SubmissionExecutionReadClient["getTransactionBlock"],
+    });
+
+    await expect(
+      checkSubmissionExecution({
+        suiClient: client,
+        digest: DIGEST,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+      }),
+    ).resolves.toEqual({
+      status: "recovering",
+      kakera: null,
+    });
+  });
+
+  it("returns recovering on temporary RPC failures", async () => {
+    const client = makeClient({
+      getTransactionBlock: vi.fn(async () => {
+        throw new Error("rpc timeout");
+      }) as unknown as SubmissionExecutionReadClient["getTransactionBlock"],
+      getOwnedObjects: vi.fn(async () => {
+        throw new Error("rpc unavailable");
+      }) as unknown as SubmissionExecutionReadClient["getOwnedObjects"],
+    });
+
+    await expect(
+      checkSubmissionExecution({
+        suiClient: client,
+        digest: DIGEST,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+      }),
+    ).resolves.toEqual({
+      status: "recovering",
+      kakera: null,
+    });
+  });
+
+  it("returns failed only when the digest is confirmed with failure effects", async () => {
+    const getOwnedObjects = vi.fn(async () => ({
+      data: [kakeraObject()],
+      hasNextPage: false,
+      nextCursor: null,
+    })) as unknown as SubmissionExecutionReadClient["getOwnedObjects"];
+    const client = makeClient({
+      getTransactionBlock: vi.fn(async () => ({
+        digest: DIGEST,
+        effects: {
+          status: {
+            status: "failure",
+          },
+        },
+      })) as unknown as SubmissionExecutionReadClient["getTransactionBlock"],
+      getOwnedObjects,
+    });
+
+    await expect(
+      checkSubmissionExecution({
+        suiClient: client,
+        digest: DIGEST,
+        ownerAddress: OWNER,
+        unitId: UNIT_ID,
+        walrusBlobId: WALRUS_BLOB_ID,
+        packageId: PACKAGE_ID,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      kakera: null,
+    });
+
+    expect(getOwnedObjects).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/sui/submission-execution.ts
+++ b/apps/web/src/lib/sui/submission-execution.ts
@@ -1,0 +1,92 @@
+import type { SuiTransactionReadClient } from "./client";
+import {
+  findKakeraForSubmission,
+  type KakeraOwnedClient,
+  type FindKakeraForSubmissionArgs,
+  type OwnedKakera,
+} from "./kakera";
+
+export type SubmissionExecutionReadClient = SuiTransactionReadClient &
+  KakeraOwnedClient;
+
+export type SubmissionExecutionStatus = "success" | "recovering" | "failed";
+
+export type SubmissionExecutionResult = {
+  readonly status: SubmissionExecutionStatus;
+  readonly kakera: OwnedKakera | null;
+};
+
+export type CheckSubmissionExecutionArgs = FindKakeraForSubmissionArgs & {
+  readonly suiClient: SubmissionExecutionReadClient;
+  readonly digest: string;
+};
+
+export async function checkSubmissionExecution(
+  args: CheckSubmissionExecutionArgs,
+): Promise<SubmissionExecutionResult> {
+  const digestStatus = await getDigestExecutionStatus(args);
+
+  if (digestStatus === "success") {
+    return { status: "success", kakera: null };
+  }
+
+  if (digestStatus === "failed") {
+    return { status: "failed", kakera: null };
+  }
+
+  try {
+    const kakera = await findKakeraForSubmission(args);
+    if (kakera) {
+      return { status: "success", kakera };
+    }
+  } catch {
+    return { status: "recovering", kakera: null };
+  }
+
+  return { status: "recovering", kakera: null };
+}
+
+type DigestExecutionStatus = "success" | "failed" | "unknown";
+
+async function getDigestExecutionStatus(
+  args: CheckSubmissionExecutionArgs,
+): Promise<DigestExecutionStatus> {
+  try {
+    const response = await args.suiClient.getTransactionBlock({
+      digest: args.digest,
+      options: {
+        showEffects: true,
+      },
+    });
+
+    return parseDigestExecutionStatus(response);
+  } catch {
+    return "unknown";
+  }
+}
+
+function parseDigestExecutionStatus(response: unknown): DigestExecutionStatus {
+  if (typeof response !== "object" || response === null) {
+    return "unknown";
+  }
+
+  const effects = (response as { effects?: unknown }).effects;
+  if (typeof effects !== "object" || effects === null) {
+    return "unknown";
+  }
+
+  const status = (effects as { status?: unknown }).status;
+  if (typeof status !== "object" || status === null) {
+    return "unknown";
+  }
+
+  const executionStatus = (status as { status?: unknown }).status;
+  if (executionStatus === "success") {
+    return "success";
+  }
+  if (executionStatus === "failure") {
+    return "failed";
+  }
+
+  return "unknown";
+}

--- a/apps/web/src/lib/sui/submission-execution.ts
+++ b/apps/web/src/lib/sui/submission-execution.ts
@@ -1,8 +1,8 @@
 import type { SuiTransactionReadClient } from "./client";
 import {
+  type FindKakeraForSubmissionArgs,
   findKakeraForSubmission,
   type KakeraOwnedClient,
-  type FindKakeraForSubmissionArgs,
   type OwnedKakera,
 } from "./kakera";
 

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -113,7 +113,7 @@ export async function installDefaultMocks(
         status: 503,
         contentType: "application/json",
         body: JSON.stringify({
-          code: "submit_unavailable",
+          code: "sponsor_failed",
           message: "execute failed",
         }),
       });

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -229,7 +229,10 @@ async function buildResponse(
 async function handleGetTransactionBlock(
   state: MockState,
   options: Required<
-    Pick<InstallMockOptions, "transactionExecutionStatus" | "transactionBlockDelayMs">
+    Pick<
+      InstallMockOptions,
+      "transactionExecutionStatus" | "transactionBlockDelayMs"
+    >
   >,
 ): Promise<unknown> {
   if (options.transactionBlockDelayMs > 0) {
@@ -238,7 +241,10 @@ async function handleGetTransactionBlock(
     );
   }
 
-  if (!state.submitExecuted || options.transactionExecutionStatus === "unknown") {
+  if (
+    !state.submitExecuted ||
+    options.transactionExecutionStatus === "unknown"
+  ) {
     return {
       digest: STUB_DIGEST,
       effects: null,

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -8,7 +8,8 @@
  * is enough for the smoke path. Client traffic covered:
  *
  * - Sui JSON-RPC (fullnode.testnet.sui.io) — dispatched by `method`.
- * - `/api/enoki/submit-photo/sponsor` / `/execute` — return stub digest.
+ * - `/api/enoki/submit-photo/sponsor` / `/execute` — configurable success or
+ *   recovery failure.
  * - Walrus Publisher `PUT /v1/blobs` — return stub `blobId`.
  */
 
@@ -30,7 +31,7 @@ export const STUB_PACKAGE_ID =
 export const STUB_REGISTRY_OBJECT_ID =
   "0x0000000000000000000000000000000000000000000000000000000000000002";
 export const STUB_BLOB_ID = "STUB_BLOB_ID_XYZ";
-export const STUB_DIGEST = "STUB_SUBMIT_DIGEST";
+export const STUB_DIGEST = "4q49qZdCaTzeU2BP4mfQesc2dbt3h32Qn2rLHHwrBJne";
 export const STUB_KAKERA_OBJECT_ID =
   "0x00000000000000000000000000000000000000000000000000000000000ka123";
 export const STUB_SUBMISSION_NO = 1;
@@ -42,13 +43,28 @@ export type MockState = {
   submitExecuted: boolean;
 };
 
+export type InstallMockOptions = {
+  readonly executeApiMode?: "success" | "recovering_http_error";
+  readonly transactionExecutionStatus?: "success" | "failed" | "unknown";
+  readonly transactionBlockDelayMs?: number;
+  readonly kakeraVisibleAfterExecute?: boolean;
+};
+
 /**
  * Install default mocks on `page`. Returns a `state` handle the test can flip
  * (e.g., to force the Kakera to appear earlier). Also seeds the dapp-kit
  * localStorage key so the stub wallet auto-connects on first render.
  */
-export async function installDefaultMocks(page: Page): Promise<MockState> {
+export async function installDefaultMocks(
+  page: Page,
+  options: InstallMockOptions = {},
+): Promise<MockState> {
   const state: MockState = { submitExecuted: false };
+  const executeApiMode = options.executeApiMode ?? "success";
+  const transactionExecutionStatus =
+    options.transactionExecutionStatus ?? "success";
+  const transactionBlockDelayMs = options.transactionBlockDelayMs ?? 0;
+  const kakeraVisibleAfterExecute = options.kakeraVisibleAfterExecute ?? true;
 
   await page.addInitScript(
     ({ walletName, address }) => {
@@ -71,7 +87,11 @@ export async function installDefaultMocks(page: Page): Promise<MockState> {
   );
 
   await page.route(/fullnode\.[a-z]+\.sui\.io/, (route) =>
-    handleSuiRpc(route, state),
+    handleSuiRpc(route, state, {
+      transactionExecutionStatus,
+      transactionBlockDelayMs,
+      kakeraVisibleAfterExecute,
+    }),
   );
 
   await page.route("**/api/enoki/submit-photo/sponsor", async (route) => {
@@ -88,6 +108,18 @@ export async function installDefaultMocks(page: Page): Promise<MockState> {
 
   await page.route("**/api/enoki/submit-photo/execute", async (route) => {
     state.submitExecuted = true;
+    if (executeApiMode === "recovering_http_error") {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "submit_unavailable",
+          message: "execute failed",
+        }),
+      });
+      return;
+    }
+
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -120,12 +152,25 @@ export async function installDefaultMocks(page: Page): Promise<MockState> {
   return state;
 }
 
-async function handleSuiRpc(route: Route, state: MockState): Promise<void> {
+async function handleSuiRpc(
+  route: Route,
+  state: MockState,
+  options: Required<
+    Pick<
+      InstallMockOptions,
+      | "transactionExecutionStatus"
+      | "transactionBlockDelayMs"
+      | "kakeraVisibleAfterExecute"
+    >
+  >,
+): Promise<void> {
   const raw = route.request().postData();
   const payload = raw ? safeParseJson(raw) : null;
 
   if (Array.isArray(payload)) {
-    const responses = payload.map((single) => buildResponse(single, state));
+    const responses = await Promise.all(
+      payload.map((single) => buildResponse(single, state, options)),
+    );
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -137,14 +182,22 @@ async function handleSuiRpc(route: Route, state: MockState): Promise<void> {
   await route.fulfill({
     status: 200,
     contentType: "application/json",
-    body: JSON.stringify(buildResponse(payload, state)),
+    body: JSON.stringify(await buildResponse(payload, state, options)),
   });
 }
 
-function buildResponse(
+async function buildResponse(
   call: unknown,
   state: MockState,
-): Record<string, unknown> {
+  options: Required<
+    Pick<
+      InstallMockOptions,
+      | "transactionExecutionStatus"
+      | "transactionBlockDelayMs"
+      | "kakeraVisibleAfterExecute"
+    >
+  >,
+): Promise<Record<string, unknown>> {
   const id = isObject(call) ? call.id : null;
   const method =
     isObject(call) && typeof call.method === "string" ? call.method : "";
@@ -158,10 +211,12 @@ function buildResponse(
       return envelope(handleGetObject(params));
     case "suix_getDynamicFieldObject":
       return envelope(handleDynamicField(params));
+    case "sui_getTransactionBlock":
+      return envelope(await handleGetTransactionBlock(state, options));
     case "suix_queryEvents":
       return envelope({ data: [], hasNextPage: false, nextCursor: null });
     case "suix_getOwnedObjects":
-      return envelope(handleOwnedObjects(params, state));
+      return envelope(handleOwnedObjects(params, state, options));
     case "sui_getLatestCheckpointSequenceNumber":
       return envelope("1");
     case "sui_dryRunTransactionBlock":
@@ -169,6 +224,41 @@ function buildResponse(
     default:
       return envelope(null);
   }
+}
+
+async function handleGetTransactionBlock(
+  state: MockState,
+  options: Required<
+    Pick<InstallMockOptions, "transactionExecutionStatus" | "transactionBlockDelayMs">
+  >,
+): Promise<unknown> {
+  if (options.transactionBlockDelayMs > 0) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, options.transactionBlockDelayMs),
+    );
+  }
+
+  if (!state.submitExecuted || options.transactionExecutionStatus === "unknown") {
+    return {
+      digest: STUB_DIGEST,
+      effects: null,
+    };
+  }
+
+  return {
+    digest: STUB_DIGEST,
+    effects: {
+      status:
+        options.transactionExecutionStatus === "success"
+          ? {
+              status: "success",
+            }
+          : {
+              status: "failure",
+              error: "mock execution failure",
+            },
+    },
+  };
 }
 
 function handleGetObject(params: readonly unknown[]): unknown {
@@ -255,9 +345,14 @@ function handleDynamicField(params: readonly unknown[]): unknown {
 function handleOwnedObjects(
   params: readonly unknown[],
   state: MockState,
+  options: Required<Pick<InstallMockOptions, "kakeraVisibleAfterExecute">>,
 ): unknown {
   const owner = typeof params[0] === "string" ? params[0] : "";
-  if (owner !== E2E_STUB_ACCOUNT_ADDRESS || !state.submitExecuted) {
+  if (
+    owner !== E2E_STUB_ACCOUNT_ADDRESS ||
+    !state.submitExecuted ||
+    !options.kakeraVisibleAfterExecute
+  ) {
     return { data: [], hasNextPage: false, nextCursor: null };
   }
 

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -1,39 +1,44 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+import {
+  installDefaultMocks,
+  STUB_DIGEST,
+  STUB_UNIT_ID,
+} from "./fixtures/mock-network";
 import {
   TINY_JPEG_BUFFER,
   TINY_JPEG_MIME,
   TINY_JPEG_NAME,
 } from "./fixtures/tiny-jpeg";
 
+async function submitPhoto(page: Page): Promise<void> {
+  await page.goto(`/units/${STUB_UNIT_ID}`);
+
+  await expect(page.getByText(/zkLogin アドレスを確認できました/)).toBeVisible();
+
+  await page
+    .getByRole("checkbox", {
+      name: /投稿した原画像は Walrus に保存され/,
+    })
+    .check();
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: TINY_JPEG_NAME,
+    mimeType: TINY_JPEG_MIME,
+    buffer: TINY_JPEG_BUFFER,
+  });
+
+  await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "投稿を確定" }).click();
+}
+
 test.describe("submit happy path", () => {
   test("signs in via stub wallet and posts a photo through to Kakera", async ({
     page,
   }) => {
     await installDefaultMocks(page);
-
-    await page.goto(`/units/${STUB_UNIT_ID}`);
-
-    await expect(
-      page.getByText(/zkLogin アドレスを確認できました/),
-    ).toBeVisible();
-
-    await page
-      .getByRole("checkbox", {
-        name: /投稿した原画像は Walrus に保存され/,
-      })
-      .check();
-
-    await page.locator('input[type="file"]').setInputFiles({
-      name: TINY_JPEG_NAME,
-      mimeType: TINY_JPEG_MIME,
-      buffer: TINY_JPEG_BUFFER,
-    });
-
-    await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
-
-    await page.getByRole("button", { name: "投稿を確定" }).click();
+    await submitPhoto(page);
 
     await expect(page.getByText("投稿が完了しました。")).toBeVisible({
       timeout: 15_000,
@@ -48,5 +53,70 @@ test.describe("submit happy path", () => {
       path: "playwright-report/submit-success.png",
       fullPage: true,
     });
+  });
+
+  test("recovers to the participation card when execute HTTP fails but the digest confirms success", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, {
+      executeApiMode: "recovering_http_error",
+      transactionExecutionStatus: "success",
+      kakeraVisibleAfterExecute: true,
+    });
+    await submitPhoto(page);
+
+    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(STUB_DIGEST)).toBeVisible();
+    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("recovers to the participation card when the digest is still unknown but Kakera is already visible", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, {
+      executeApiMode: "recovering_http_error",
+      transactionExecutionStatus: "unknown",
+      kakeraVisibleAfterExecute: true,
+    });
+    await submitPhoto(page);
+
+    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(STUB_DIGEST)).toBeVisible();
+    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("keeps the recovery message first and only shows retry after confirmed failure", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, {
+      executeApiMode: "recovering_http_error",
+      transactionExecutionStatus: "failed",
+      transactionBlockDelayMs: 800,
+      kakeraVisibleAfterExecute: false,
+    });
+    await submitPhoto(page);
+
+    await expect(
+      page.getByText("投稿結果を確認しています。しばらくお待ちください。"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "もう一度送信する" }),
+    ).toBeHidden();
+    await expect(
+      page.getByText("投稿を完了できませんでした。もう一度送信してください。"),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "もう一度送信する" }),
+    ).toBeVisible();
   });
 });

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import {
   installDefaultMocks,
@@ -14,7 +14,9 @@ import {
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
-  await expect(page.getByText(/zkLogin アドレスを確認できました/)).toBeVisible();
+  await expect(
+    page.getByText(/zkLogin アドレスを確認できました/),
+  ).toBeVisible();
 
   await page
     .getByRole("checkbox", {


### PR DESCRIPTION
## 概要
Enoki の `execute` が HTTP 失敗しても、オンチェーンでは `submit_photo` が成功しているケースを UI が回復できるようにしました。`digest` 照会と Kakera 存在確認を使って成功・確認中・失敗を分け、本当に未成立の時だけ再試行を出します。

## 変更内容
- `apps/web/src/lib/sui/submission-execution.ts`
  - `digest` 照会と Kakera fallback を束ねた成功判定 helper を追加
- `apps/web/src/lib/sui/client.ts`
  - `getTransactionBlock` を使うための read surface を追加
- `apps/web/src/lib/enoki/client-submit.ts`
  - sponsor digest / sender / blobId を保持した回復可能エラーを追加
  - `invalid_args` や `submit_unavailable` などの確定失敗は即失敗に分離
- `apps/web/src/app/units/[unitId]/participation-access.tsx`
  - 回復中フェーズで再照会を行い、成功なら参加証カードへ復帰
  - 回復確認は submit 時点の sender に固定し、上限超過時のみ retry を表示
- `apps/web/tests/e2e/fixtures/mock-network.ts`
  - `execute` HTTP 失敗でもチェーン成功 / 未成立を再現する mock を追加
- `apps/web/**/*.test.*`
  - unit / component / E2E を拡張して回復成功、確認中、確定失敗を検証

## 関連する Issue やチケット
Close #16

## 動作確認
- `corepack pnpm run check`
- `corepack pnpm --filter web run test:e2e`
- `corepack pnpm --filter web run build`
- `corepack pnpm --filter web run test:bundle-size`
  - OpenNext build までは成功
  - wrangler の bundle size 計測のみ Docker CLI / daemon 不在で失敗
