### PR TITLE
fix: 通常開発とE2E/デモ起動を分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,25 @@ one_portrait/
 
 ```bash
 corepack pnpm install
+corepack pnpm run dev
+corepack pnpm run dev:demo
+corepack pnpm run dev:e2e
+corepack pnpm run test:e2e
 corepack pnpm run check
 corepack pnpm --filter web build
 ```
 
 - Web の公開環境変数は `apps/web/.env.example` を起点に用意します
 - root の `check` は workspace 全体の `typecheck` と `test` をまとめて実行します
+
+### 起動モード
+
+| コマンド | 目的 | 挙動 |
+| :--- | :--- | :--- |
+| `corepack pnpm run dev` | 通常開発 | `apps/web/.env.local` をそのまま使います。E2E 用の stub 値が残っていたら起動を止めます。 |
+| `corepack pnpm run dev:demo` | UI の目視確認 | demo fixture を使って、top / waiting room / gallery を外部依存なしで確認しやすい状態にします。 |
+| `corepack pnpm run dev:e2e` | Playwright 用 web server | E2E 用の stub env を子 process にだけ注入します。`.env.local` は書き換えません。 |
+| `corepack pnpm run test:e2e` | Playwright 実行 | `dev:e2e` を使ってブラウザテストを実行します。通常開発用の env は汚しません。 |
 
 ### Move
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ corepack pnpm --filter web build
 | コマンド | 目的 | 挙動 |
 | :--- | :--- | :--- |
 | `corepack pnpm run dev` | 通常開発 | `apps/web/.env.local` をそのまま使います。E2E 用の stub 値が残っていたら起動を止めます。 |
-| `corepack pnpm run dev:demo` | UI の目視確認 | demo fixture を使って、top / waiting room / gallery を外部依存なしで確認しやすい状態にします。 |
+| `corepack pnpm run dev:demo` | UI の目視確認 | demo fixture を使って、top / waiting room / gallery を外部依存なしで確認しやすい状態にします。waiting room の Google login は位置確認用で、実ログインや投稿は行いません。 |
 | `corepack pnpm run dev:e2e` | Playwright 用 web server | E2E 用の stub env を子 process にだけ注入します。`.env.local` は書き換えません。 |
 | `corepack pnpm run test:e2e` | Playwright 実行 | `dev:e2e` を使ってブラウザテストを実行します。通常開発用の env は汚しません。 |
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "check": "biome check --write .",
     "lint": "biome check .",
     "dev": "node ./scripts/run-dev.mjs",
+    "dev:demo": "node ./scripts/run-demo-dev.mjs",
     "dev:e2e": "./scripts/e2e-dev.sh",
     "build": "next build",
     "start": "OP_LOCAL_FINALIZE_URL=${OP_LOCAL_FINALIZE_URL:-http://127.0.0.1:8080} next start",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "check": "biome check --write .",
     "lint": "biome check .",
     "dev": "node ./scripts/run-dev.mjs",
+    "dev:e2e": "./scripts/e2e-dev.sh",
     "build": "next build",
     "start": "OP_LOCAL_FINALIZE_URL=${OP_LOCAL_FINALIZE_URL:-http://127.0.0.1:8080} next start",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/web/scripts/dev-mode.mjs
+++ b/apps/web/scripts/dev-mode.mjs
@@ -3,10 +3,19 @@ import path from "node:path";
 
 export const forbiddenStubMarkers = [
   ["NEXT_PUBLIC_E2E_STUB_WALLET", "1"],
+  [
+    "NEXT_PUBLIC_PACKAGE_ID",
+    "0x0000000000000000000000000000000000000000000000000000000000000001",
+  ],
+  [
+    "NEXT_PUBLIC_REGISTRY_OBJECT_ID",
+    "0x0000000000000000000000000000000000000000000000000000000000000002",
+  ],
   ["NEXT_PUBLIC_ENOKI_API_KEY", "enoki-e2e-stub"],
   ["NEXT_PUBLIC_GOOGLE_CLIENT_ID", "google-e2e-stub"],
   ["NEXT_PUBLIC_WALRUS_PUBLISHER", "https://publisher.e2e.stub"],
   ["NEXT_PUBLIC_WALRUS_AGGREGATOR", "https://aggregator.e2e.stub"],
+  ["ENOKI_PRIVATE_API_KEY", "enoki-private-e2e-stub"],
 ];
 
 export function assertNormalDevEnvironment({

--- a/apps/web/scripts/dev-mode.mjs
+++ b/apps/web/scripts/dev-mode.mjs
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const forbiddenStubMarkers = [
+  ["NEXT_PUBLIC_E2E_STUB_WALLET", "1"],
+  ["NEXT_PUBLIC_ENOKI_API_KEY", "enoki-e2e-stub"],
+  ["NEXT_PUBLIC_GOOGLE_CLIENT_ID", "google-e2e-stub"],
+  ["NEXT_PUBLIC_WALRUS_PUBLISHER", "https://publisher.e2e.stub"],
+  ["NEXT_PUBLIC_WALRUS_AGGREGATOR", "https://aggregator.e2e.stub"],
+];
+
+export function assertNormalDevEnvironment({
+  cwd,
+  env = process.env,
+  envFilePath = path.join(cwd, ".env.local"),
+}) {
+  const envFileValues = readEnvFile(envFilePath);
+  const matches = findForbiddenStubMarkers({ env, envFileValues });
+
+  if (matches.length === 0) {
+    return;
+  }
+
+  const details = matches
+    .map(({ key, value, source }) => `- ${key}=${value} (${source})`)
+    .join("\n");
+
+  throw new Error(
+    [
+      "[run-dev] Refusing to start normal development with E2E stub values still present.",
+      "Clear the values below before running `pnpm run dev`.",
+      details,
+    ].join("\n"),
+  );
+}
+
+export function findForbiddenStubMarkers({ env = {}, envFileValues = {} }) {
+  const matches = [];
+
+  for (const [key, value] of forbiddenStubMarkers) {
+    if (env[key] === value) {
+      matches.push({ key, value, source: "process.env" });
+    }
+    if (envFileValues[key] === value) {
+      matches.push({ key, value, source: ".env.local" });
+    }
+  }
+
+  return matches;
+}
+
+export function parseEnvFile(content) {
+  const values = {};
+
+  for (const line of content.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const separator = trimmed.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separator).trim();
+    const value = trimmed.slice(separator + 1).trim();
+
+    if (!key) {
+      continue;
+    }
+
+    values[key] = stripWrappingQuotes(value);
+  }
+
+  return values;
+}
+
+function readEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  return parseEnvFile(fs.readFileSync(filePath, "utf8"));
+}
+
+function stripWrappingQuotes(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}

--- a/apps/web/scripts/e2e-dev.sh
+++ b/apps/web/scripts/e2e-dev.sh
@@ -1,58 +1,8 @@
 #!/bin/bash
-# Wrapper that exports the stub env matrix and starts Next.js in dev mode for
-# Playwright E2E. Env values are synthetic and never touch real backends:
-# Sui RPC, Enoki, Walrus are all intercepted by tests/e2e/fixtures/mock-network.ts.
-#
-# Why a wrapper instead of `webServer.env` in playwright.config.ts: passing
-# env via that option did not propagate `NEXT_PUBLIC_*` reliably with next@16
-# + turbopack. Exporting in the subshell — and shadowing the developer's
-# `.env` for the duration of the run via `.env.local` — works consistently.
-# `.env.local` is gitignored.
-#
-# Port: defaults to 3100 (matches playwright.config.ts), overridable via
-# `E2E_PORT`. We pre-check the port and bail loudly because Next.js silently
-# falls back to the next available port, which would leave Playwright waiting
-# on a URL that never responds.
+# Wrapper for Playwright E2E. The actual startup logic lives in
+# `scripts/run-e2e-dev.mjs`, which injects stub env only into the spawned
+# Next.js process so the developer's `.env.local` stays untouched.
 
-set -e
+set -euo pipefail
 
-# `E2E_PORT` is resolved by `playwright.config.ts` (which probes for a free
-# port before spawning us) and inherited through Playwright's process env.
-# When the wrapper is invoked directly (outside Playwright), default to 3100.
-PORT=${E2E_PORT:-3100}
-
-# Belt-and-suspenders: if the port became busy between Playwright's probe
-# and our invocation, bail loudly — `next dev` silently falls back to a
-# different port otherwise, which breaks Playwright's `webServer.url` wait.
-if (echo > /dev/tcp/127.0.0.1/"$PORT") 2>/dev/null; then
-  cat >&2 <<MSG
-[e2e-dev.sh] Port $PORT is already in use. Free the port or set E2E_PORT to
-an unused one (e.g. \`E2E_PORT=4000 pnpm run test:e2e\`). Aborting so that
-Playwright doesn't time out waiting for an unrelated process.
-MSG
-  exit 1
-fi
-
-# Nuke turbopack cache so stale compile outputs from a previous run cannot
-# leak through.
-rm -rf .next
-
-# `.env.local` wins over `.env` in Next.js. Write it unconditionally so the
-# stub matrix is applied even when a developer has an existing `.env` with
-# blank values (the default after `cp .env.example .env`). Playwright tends
-# to SIGKILL the webServer on shutdown, so we cannot reliably remove the
-# file in a trap — instead the next E2E run overwrites it. If a developer
-# wants to restore real `.env` semantics they can `rm apps/web/.env.local`.
-cat >.env.local <<'ENV'
-NEXT_PUBLIC_SUI_NETWORK=testnet
-NEXT_PUBLIC_PACKAGE_ID=0x0000000000000000000000000000000000000000000000000000000000000001
-NEXT_PUBLIC_REGISTRY_OBJECT_ID=0x0000000000000000000000000000000000000000000000000000000000000002
-NEXT_PUBLIC_ENOKI_API_KEY=enoki-e2e-stub
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=google-e2e-stub
-NEXT_PUBLIC_WALRUS_PUBLISHER=https://publisher.e2e.stub
-NEXT_PUBLIC_WALRUS_AGGREGATOR=https://aggregator.e2e.stub
-NEXT_PUBLIC_E2E_STUB_WALLET=1
-ENOKI_PRIVATE_API_KEY=enoki-private-e2e-stub
-ENV
-
-exec npx --no-install next dev -p "$PORT"
+exec node ./scripts/run-e2e-dev.mjs

--- a/apps/web/scripts/run-demo-dev.mjs
+++ b/apps/web/scripts/run-demo-dev.mjs
@@ -3,8 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const demoPackageId =
-  "0x00000000000000000000000000000000000000000000000000000000000000d0";
 const demoRegistryObjectId =
   "0x00000000000000000000000000000000000000000000000000000000000000d1";
 
@@ -22,10 +20,7 @@ const child = spawn(nextBin, ["dev"], {
     ...process.env,
     NEXT_PUBLIC_DEMO_MODE: "1",
     NEXT_PUBLIC_SUI_NETWORK: "testnet",
-    NEXT_PUBLIC_PACKAGE_ID: demoPackageId,
     NEXT_PUBLIC_REGISTRY_OBJECT_ID: demoRegistryObjectId,
-    NEXT_PUBLIC_ENOKI_API_KEY: "demo-enoki-public",
-    NEXT_PUBLIC_GOOGLE_CLIENT_ID: "demo-google-client-id",
     OP_LOCAL_FINALIZE_URL:
       process.env.OP_LOCAL_FINALIZE_URL ?? "http://127.0.0.1:8080",
   },

--- a/apps/web/scripts/run-demo-dev.mjs
+++ b/apps/web/scripts/run-demo-dev.mjs
@@ -1,0 +1,70 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const demoPackageId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d0";
+const demoRegistryObjectId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d1";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, "..");
+const lockPath = path.join(webRoot, ".next", "dev", "lock");
+const nextBin = path.join(webRoot, "node_modules", ".bin", "next");
+
+cleanupStaleNextDevLock(lockPath);
+
+const child = spawn(nextBin, ["dev"], {
+  cwd: webRoot,
+  env: {
+    ...process.env,
+    NEXT_PUBLIC_DEMO_MODE: "1",
+    NEXT_PUBLIC_SUI_NETWORK: "testnet",
+    NEXT_PUBLIC_PACKAGE_ID: demoPackageId,
+    NEXT_PUBLIC_REGISTRY_OBJECT_ID: demoRegistryObjectId,
+    NEXT_PUBLIC_ENOKI_API_KEY: "demo-enoki-public",
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: "demo-google-client-id",
+    OP_LOCAL_FINALIZE_URL:
+      process.env.OP_LOCAL_FINALIZE_URL ?? "http://127.0.0.1:8080",
+  },
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+function cleanupStaleNextDevLock(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  try {
+    const payload = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const pid = Number(payload?.pid);
+
+    if (Number.isInteger(pid) && pid > 0 && isProcessAlive(pid)) {
+      return;
+    }
+  } catch {
+    // If the lock file is malformed, removing it is the safest recovery.
+  }
+
+  fs.rmSync(filePath, { force: true });
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}

--- a/apps/web/scripts/run-dev.mjs
+++ b/apps/web/scripts/run-dev.mjs
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { assertNormalDevEnvironment } from "./dev-mode.mjs";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const webRoot = path.resolve(__dirname, "..");
@@ -10,6 +12,7 @@ const lockPath = path.join(webRoot, ".next", "dev", "lock");
 const nextBin = path.join(webRoot, "node_modules", ".bin", "next");
 
 cleanupStaleNextDevLock(lockPath);
+assertNormalDevEnvironment({ cwd: webRoot, env: process.env });
 
 const child = spawn(nextBin, ["dev"], {
   cwd: webRoot,

--- a/apps/web/scripts/run-e2e-dev.mjs
+++ b/apps/web/scripts/run-e2e-dev.mjs
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, "..");
+const nextBin = path.join(webRoot, "node_modules", ".bin", "next");
+
+export const e2eStubEnv = {
+  NEXT_PUBLIC_SUI_NETWORK: "testnet",
+  NEXT_PUBLIC_PACKAGE_ID:
+    "0x0000000000000000000000000000000000000000000000000000000000000001",
+  NEXT_PUBLIC_REGISTRY_OBJECT_ID:
+    "0x0000000000000000000000000000000000000000000000000000000000000002",
+  NEXT_PUBLIC_ENOKI_API_KEY: "enoki-e2e-stub",
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: "google-e2e-stub",
+  NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.e2e.stub",
+  NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.e2e.stub",
+  NEXT_PUBLIC_E2E_STUB_WALLET: "1",
+  ENOKI_PRIVATE_API_KEY: "enoki-private-e2e-stub",
+};
+
+export async function startE2EDev({
+  cwd = webRoot,
+  env = process.env,
+  port = Number(env.E2E_PORT ?? "3100"),
+  spawnImpl = spawn,
+  isPortBusy = defaultIsPortBusy,
+  nextDevBin = path.join(cwd, "node_modules", ".bin", "next"),
+}) {
+  if (await isPortBusy(port)) {
+    throw new Error(
+      [
+        `[e2e-dev.sh] Port ${port} is already in use.`,
+        "Free the port or set E2E_PORT to an unused value before starting Playwright.",
+      ].join(" "),
+    );
+  }
+
+  fs.rmSync(path.join(cwd, ".next"), { force: true, recursive: true });
+
+  const child = spawnImpl(nextDevBin, ["dev", "-p", String(port)], {
+    cwd,
+    env: {
+      ...env,
+      ...e2eStubEnv,
+    },
+    stdio: "inherit",
+  });
+
+  return { child, port };
+}
+
+export async function defaultIsPortBusy(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", () => resolve(true));
+    server.once("listening", () => {
+      server.close(() => resolve(false));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+if (isExecutedDirectly()) {
+  try {
+    const { child } = await startE2EDev({
+      cwd: webRoot,
+      env: process.env,
+      nextDevBin: nextBin,
+    });
+    forwardChildExit(child);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+function isExecutedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+
+  return path.resolve(entry) === __filename;
+}
+
+function forwardChildExit(child) {
+  if (!(child instanceof EventEmitter) || typeof child.on !== "function") {
+    return;
+  }
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+}

--- a/apps/web/scripts/run-e2e-dev.mjs
+++ b/apps/web/scripts/run-e2e-dev.mjs
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
-import path from "node:path";
 import { createServer } from "node:net";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -102,6 +102,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env.NEXT_PUBLIC_DEMO_MODE;
   delete process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR;
   useCurrentAccountMock.mockReset();
   getSuiClientMock.mockReset();
@@ -120,6 +121,8 @@ describe("GalleryClient", () => {
   });
 
   it("renders demo entries without requiring a connected wallet", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+
     render(
       <GalleryClient
         catalog={CATALOG}
@@ -134,6 +137,11 @@ describe("GalleryClient", () => {
 
     expect(screen.queryByText(/Wallet required/i)).toBeNull();
     expect(screen.getByText(/Placed at 12, 8/i)).toBeTruthy();
+    expect(
+      screen
+        .getByAltText(/Demo Athlete One completed mosaic/i)
+        .getAttribute("src"),
+    ).toContain("placehold.co");
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -145,6 +145,25 @@ describe("GalleryClient", () => {
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
   });
 
+  it("renders demo entries even when packageId is empty", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+
+    render(
+      <GalleryClient
+        catalog={CATALOG}
+        demoEntries={[pendingEntry()]}
+        packageId=""
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Demo Athlete One")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Unavailable/i)).toBeNull();
+    expect(screen.getByText(/Waiting for reveal/i)).toBeTruthy();
+  });
+
   it("renders the no Kakera state when the connected wallet owns none", async () => {
     useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
     listOwnedKakeraMock.mockResolvedValue([]);

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -119,6 +119,24 @@ describe("GalleryClient", () => {
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
   });
 
+  it("renders demo entries without requiring a connected wallet", async () => {
+    render(
+      <GalleryClient
+        catalog={CATALOG}
+        demoEntries={[completedEntry()]}
+        packageId="0xpkg"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Demo Athlete One")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Wallet required/i)).toBeNull();
+    expect(screen.getByText(/Placed at 12, 8/i)).toBeTruthy();
+    expect(listOwnedKakeraMock).not.toHaveBeenCalled();
+  });
+
   it("renders the no Kakera state when the connected wallet owns none", async () => {
     useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
     listOwnedKakeraMock.mockResolvedValue([]);

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -154,7 +154,7 @@ export function GalleryClient({
     );
   }
 
-  if (!packageId || state.kind === "error") {
+  if (!demoEntries && (!packageId || state.kind === "error")) {
     return (
       <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
         <p className="text-xs uppercase tracking-[0.3em] text-amber-200/80">

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -4,11 +4,13 @@ import { useCurrentAccount } from "@mysten/dapp-kit";
 import { useEffect, useState } from "react";
 
 import type { AthleteCatalogEntry } from "../../lib/catalog";
+import { isDemoModeEnabled } from "../../lib/demo";
 import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 import { getGalleryEntry, getSuiClient, listOwnedKakera } from "../../lib/sui";
 
 type GalleryClientProps = {
   readonly catalog: readonly AthleteCatalogEntry[];
+  readonly demoEntries?: readonly GalleryRenderableEntry[];
   readonly packageId: string;
 };
 
@@ -48,6 +50,7 @@ type LoadState =
 
 export function GalleryClient({
   catalog,
+  demoEntries,
   packageId,
 }: GalleryClientProps): React.ReactElement {
   const currentAccount = useCurrentAccount();
@@ -60,6 +63,15 @@ export function GalleryClient({
   >([]);
 
   useEffect(() => {
+    if (demoEntries) {
+      setState({
+        kind: "ready",
+        entries: demoEntries,
+      });
+      setFailedOriginalBlobIds([]);
+      return;
+    }
+
     if (!currentAccount?.address || !packageId) {
       setState({
         kind: currentAccount?.address ? "error" : "idle",
@@ -127,9 +139,9 @@ export function GalleryClient({
     return () => {
       cancelled = true;
     };
-  }, [currentAccount?.address, packageId]);
+  }, [currentAccount?.address, demoEntries, packageId]);
 
-  if (!currentAccount?.address) {
+  if (!demoEntries && !currentAccount?.address) {
     return (
       <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
         <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
@@ -344,6 +356,10 @@ function findAthlete(
 function buildWalrusAggregatorUrl(blobId: string | null): string | null {
   if (!blobId) {
     return null;
+  }
+
+  if (isDemoModeEnabled(process.env)) {
+    return `https://placehold.co/960x540/png?text=${encodeURIComponent(blobId)}`;
   }
 
   const aggregator = process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR?.trim().replace(

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -4,7 +4,7 @@ import { useCurrentAccount } from "@mysten/dapp-kit";
 import { useEffect, useState } from "react";
 
 import type { AthleteCatalogEntry } from "../../lib/catalog";
-import { isDemoModeEnabled } from "../../lib/demo";
+import { getDemoModeSource, isDemoModeEnabled } from "../../lib/demo";
 import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 import { getGalleryEntry, getSuiClient, listOwnedKakera } from "../../lib/sui";
 
@@ -358,7 +358,7 @@ function buildWalrusAggregatorUrl(blobId: string | null): string | null {
     return null;
   }
 
-  if (isDemoModeEnabled(process.env)) {
+  if (isDemoModeEnabled(getDemoModeSource())) {
     return `https://placehold.co/960x540/png?text=${encodeURIComponent(blobId)}`;
   }
 

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -142,4 +142,37 @@ describe("GalleryPage", () => {
         .getAttribute("data-demo-entry-count"),
     ).toBe("1");
   });
+
+  it("still passes demo entries when packageId is unavailable", async () => {
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([
+      {
+        unitId: "0xdemo-unit",
+        athletePublicId: "1",
+        walrusBlobId: "demo-original",
+        submissionNo: 17,
+        mintedAtMs: 1800000000000,
+        masterId: null,
+        mosaicWalrusBlobId: null,
+        placement: null,
+        status: { kind: "pending" },
+      },
+    ]);
+    isDemoModeEnabledMock.mockReturnValue(true);
+    loadPublicEnvMock.mockImplementation(() => {
+      throw new Error("demo mode does not need a package id");
+    });
+
+    const ui = await GalleryPage();
+    render(ui);
+
+    expect(
+      screen
+        .getByTestId("gallery-client")
+        .getAttribute("data-demo-entry-count"),
+    ).toBe("1");
+    expect(
+      screen.getByTestId("gallery-client").getAttribute("data-package-id"),
+    ).toBe("");
+  });
 });

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -3,12 +3,19 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { getAthleteCatalogMock, loadPublicEnvMock, galleryClientMock } =
-  vi.hoisted(() => ({
-    getAthleteCatalogMock: vi.fn(),
-    loadPublicEnvMock: vi.fn(),
-    galleryClientMock: vi.fn(),
-  }));
+const {
+  getAthleteCatalogMock,
+  getDemoGalleryEntriesMock,
+  isDemoModeEnabledMock,
+  loadPublicEnvMock,
+  galleryClientMock,
+} = vi.hoisted(() => ({
+  getAthleteCatalogMock: vi.fn(),
+  getDemoGalleryEntriesMock: vi.fn(),
+  isDemoModeEnabledMock: vi.fn(),
+  loadPublicEnvMock: vi.fn(),
+  galleryClientMock: vi.fn(),
+}));
 
 vi.mock("../../lib/catalog", () => ({
   getAthleteCatalog: getAthleteCatalogMock,
@@ -18,9 +25,15 @@ vi.mock("../../lib/env", () => ({
   loadPublicEnv: loadPublicEnvMock,
 }));
 
+vi.mock("../../lib/demo", () => ({
+  getDemoGalleryEntries: getDemoGalleryEntriesMock,
+  isDemoModeEnabled: isDemoModeEnabledMock,
+}));
+
 vi.mock("./gallery-client", () => ({
   GalleryClient: ({
     catalog,
+    demoEntries,
     packageId,
   }: {
     catalog: readonly {
@@ -29,13 +42,15 @@ vi.mock("./gallery-client", () => ({
       displayName: string;
       thumbnailUrl: string;
     }[];
+    demoEntries?: readonly unknown[];
     packageId: string;
   }) => (
     <div
+      data-demo-entry-count={String(demoEntries?.length ?? 0)}
       data-package-id={packageId}
       data-testid="gallery-client"
       ref={() => {
-        galleryClientMock({ catalog, packageId });
+        galleryClientMock({ catalog, demoEntries, packageId });
       }}
     >
       {catalog.length} athletes
@@ -62,6 +77,8 @@ const CATALOG = [
 
 afterEach(() => {
   getAthleteCatalogMock.mockReset();
+  getDemoGalleryEntriesMock.mockReset();
+  isDemoModeEnabledMock.mockReset();
   loadPublicEnvMock.mockReset();
   galleryClientMock.mockReset();
 });
@@ -69,6 +86,8 @@ afterEach(() => {
 describe("GalleryPage", () => {
   it("preloads the athlete catalog on the server and passes it to the client shell", async () => {
     getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([]);
+    isDemoModeEnabledMock.mockReturnValue(false);
     loadPublicEnvMock.mockReturnValue({
       suiNetwork: "testnet",
       registryObjectId: "0xregistry",
@@ -87,7 +106,40 @@ describe("GalleryPage", () => {
     ).toBe("0xpkg");
     expect(galleryClientMock).toHaveBeenCalledWith({
       catalog: CATALOG,
+      demoEntries: undefined,
       packageId: "0xpkg",
     });
+  });
+
+  it("passes demo entries to the client shell when demo mode is enabled", async () => {
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([
+      {
+        unitId: "0xdemo-unit",
+        athletePublicId: "1",
+        walrusBlobId: "demo-original",
+        submissionNo: 17,
+        mintedAtMs: 1800000000000,
+        masterId: null,
+        mosaicWalrusBlobId: null,
+        placement: null,
+        status: { kind: "pending" },
+      },
+    ]);
+    isDemoModeEnabledMock.mockReturnValue(true);
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      registryObjectId: "0xregistry",
+      packageId: "0xpkg",
+    });
+
+    const ui = await GalleryPage();
+    render(ui);
+
+    expect(
+      screen
+        .getByTestId("gallery-client")
+        .getAttribute("data-demo-entry-count"),
+    ).toBe("1");
   });
 });

--- a/apps/web/src/app/gallery/page.tsx
+++ b/apps/web/src/app/gallery/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { getAthleteCatalog } from "../../lib/catalog";
+import { getDemoGalleryEntries, isDemoModeEnabled } from "../../lib/demo";
 import { loadPublicEnv } from "../../lib/env";
 
 import { GalleryClient } from "./gallery-client";
@@ -10,6 +11,9 @@ export const dynamic = "force-dynamic";
 export default async function GalleryPage(): Promise<React.ReactElement> {
   const catalog = await getAthleteCatalog();
   const packageId = safePackageId();
+  const demoEntries = isDemoModeEnabled(process.env)
+    ? getDemoGalleryEntries()
+    : undefined;
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#15366d,_#071120_55%,_#02060d)] px-6 py-16 text-slate-50">
@@ -36,7 +40,11 @@ export default async function GalleryPage(): Promise<React.ReactElement> {
           </p>
         </header>
 
-        <GalleryClient catalog={catalog} packageId={packageId ?? ""} />
+        <GalleryClient
+          catalog={catalog}
+          demoEntries={demoEntries}
+          packageId={packageId ?? ""}
+        />
       </div>
     </main>
   );

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -4,6 +4,8 @@ import { unitTileCount } from "@one-portrait/shared";
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { demoUnitId } from "../lib/demo";
+
 const {
   getAthleteCatalogMock,
   getCurrentUnitIdForAthleteMock,
@@ -47,6 +49,7 @@ const CATALOG = [
 ] as const;
 
 afterEach(() => {
+  delete process.env.NEXT_PUBLIC_DEMO_MODE;
   getAthleteCatalogMock.mockReset();
   getCurrentUnitIdForAthleteMock.mockReset();
   getUnitProgressMock.mockReset();
@@ -178,5 +181,21 @@ describe("HomePage", () => {
     // Placeholder must not crash the card — either waiting state or the slug
     // must still render.
     expect(screen.getByText(/demo-athlete-one/)).toBeTruthy();
+  });
+
+  it("uses demo fixture progress when demo mode is enabled", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+
+    const ui = await HomePage();
+    render(ui);
+
+    const link = screen
+      .getAllByRole("link")
+      .find((el) => el.getAttribute("href") === `/units/${demoUnitId}`);
+
+    expect(link).toBeTruthy();
+    expect(getCurrentUnitIdForAthleteMock).not.toHaveBeenCalled();
+    expect(getUnitProgressMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -20,6 +20,11 @@ import { unitTileCount } from "@one-portrait/shared";
 import Link from "next/link";
 
 import { getAthleteCatalog } from "../lib/catalog";
+import {
+  getDemoCurrentUnitIdForAthlete,
+  getDemoUnitProgress,
+  isDemoModeEnabled,
+} from "../lib/demo";
 import { loadPublicEnv } from "../lib/env";
 import { getCurrentUnitIdForAthlete, getUnitProgress } from "../lib/sui";
 
@@ -42,13 +47,16 @@ const FALLBACK_MAX_SLOTS = unitTileCount;
 export default async function HomePage(): Promise<React.ReactElement> {
   const catalog = await getAthleteCatalog();
   const env = safeLoadEnv();
+  const demoMode = isDemoModeEnabled(process.env);
 
   const entries = await Promise.all(
     catalog.map(async (athlete) => ({
       athlete,
-      progress: env
-        ? await resolveProgress(athlete.athletePublicId, env)
-        : ({ kind: "unavailable" } as CardProgress),
+      progress: demoMode
+        ? resolveDemoProgress(athlete.athletePublicId)
+        : env
+          ? await resolveProgress(athlete.athletePublicId, env)
+          : ({ kind: "unavailable" } as CardProgress),
     })),
   );
 
@@ -159,6 +167,25 @@ function safeLoadEnv(): ResolvedEnv | null {
   } catch {
     return null;
   }
+}
+
+function resolveDemoProgress(athletePublicId: string): CardProgress {
+  const unitId = getDemoCurrentUnitIdForAthlete(athletePublicId);
+  if (!unitId) {
+    return { kind: "waiting" };
+  }
+
+  const progress = getDemoUnitProgress(unitId);
+  if (!progress) {
+    return { kind: "unavailable" };
+  }
+
+  return {
+    kind: "active",
+    unitId,
+    submittedCount: progress.submittedCount,
+    maxSlots: progress.maxSlots,
+  };
 }
 
 async function resolveProgress(

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -198,6 +198,9 @@ describe("UnitPage", () => {
     expect(screen.getByTestId("unit-reveal-client").textContent).toContain(
       "347 /",
     );
+    expect(
+      screen.getByRole("button", { name: "Google でログイン" }),
+    ).toBeTruthy();
     expect(getUnitProgressMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -4,6 +4,8 @@ import { unitTileCount } from "@one-portrait/shared";
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { demoUnitId } from "../../../lib/demo";
+
 const {
   getUnitProgressMock,
   getAthleteByPublicIdMock,
@@ -57,6 +59,7 @@ vi.mock("./unit-reveal-client", () => ({
 import UnitPage from "./page";
 
 afterEach(() => {
+  delete process.env.NEXT_PUBLIC_DEMO_MODE;
   getUnitProgressMock.mockReset();
   getAthleteByPublicIdMock.mockReset();
   loadPublicEnvMock.mockReset();
@@ -170,5 +173,31 @@ describe("UnitPage", () => {
     expect(
       screen.getByTestId("unit-reveal-client").getAttribute("data-master-id"),
     ).toBe("0xmaster-1");
+  });
+
+  it("uses demo fixture progress without calling Sui when demo mode is enabled", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    getAthleteByPublicIdMock.mockResolvedValue({
+      athletePublicId: "1",
+      slug: "demo-athlete-one",
+      displayName: "Demo Athlete One",
+      thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
+    });
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: demoUnitId }),
+    });
+    render(ui);
+
+    expect(screen.getByText("Demo Athlete One")).toBeTruthy();
+    expect(screen.getByTestId("unit-reveal-client").textContent).toContain(
+      "347 /",
+    );
+    expect(getUnitProgressMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -14,6 +14,7 @@ import { unitTileCount } from "@one-portrait/shared";
 import Link from "next/link";
 
 import { getAthleteByPublicId } from "../../../lib/catalog";
+import { getDemoUnitProgress, isDemoModeEnabled } from "../../../lib/demo";
 import { loadPublicEnv } from "../../../lib/env";
 import { getUnitProgress } from "../../../lib/sui";
 
@@ -39,7 +40,9 @@ export default async function UnitPage(
   const { unitId } = await props.params;
 
   const packageId = safePackageId();
-  const progress = await safeGetUnitProgress(unitId);
+  const progress = isDemoModeEnabled(process.env)
+    ? safeGetDemoUnitProgress(unitId)
+    : await safeGetUnitProgress(unitId);
   const athlete = progress.athletePublicId
     ? await safeGetAthleteByPublicId(progress.athletePublicId)
     : null;
@@ -130,6 +133,25 @@ function safePackageId(): string | null {
   } catch {
     return null;
   }
+}
+
+function safeGetDemoUnitProgress(unitId: string): ResolvedProgress {
+  const view = getDemoUnitProgress(unitId);
+  if (!view) {
+    return {
+      submittedCount: -1,
+      maxSlots: FALLBACK_MAX_SLOTS,
+      athletePublicId: null,
+      masterId: null,
+    };
+  }
+
+  return {
+    submittedCount: view.submittedCount,
+    maxSlots: view.maxSlots,
+    athletePublicId: view.athletePublicId,
+    masterId: view.masterId,
+  };
 }
 
 async function safeGetUnitProgress(unitId: string): Promise<ResolvedProgress> {

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -38,9 +38,10 @@ export default async function UnitPage(
   props: UnitPageProps,
 ): Promise<React.ReactElement> {
   const { unitId } = await props.params;
+  const demoMode = isDemoModeEnabled(process.env);
 
   const packageId = safePackageId();
-  const progress = isDemoModeEnabled(process.env)
+  const progress = demoMode
     ? safeGetDemoUnitProgress(unitId)
     : await safeGetUnitProgress(unitId);
   const athlete = progress.athletePublicId
@@ -111,7 +112,11 @@ export default async function UnitPage(
           )}
         </section>
 
-        <ParticipationAccess unitId={unitId} />
+        {demoMode ? (
+          <DemoParticipationPreview />
+        ) : (
+          <ParticipationAccess unitId={unitId} />
+        )}
 
         {/*
          * Hook points for follow-up issues (kept as comments so reviewers can
@@ -124,6 +129,27 @@ export default async function UnitPage(
          */}
       </div>
     </main>
+  );
+}
+
+function DemoParticipationPreview(): React.ReactElement {
+  return (
+    <section className="grid gap-3 rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
+      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
+        Demo login preview
+      </p>
+      <p className="text-sm text-slate-300">
+        `dev:demo` では導線だけを確認します。実際のログインや投稿は行いません。
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <button
+          className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950"
+          type="button"
+        >
+          Google でログイン
+        </button>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -910,9 +910,6 @@ describe("ParticipationAccess", () => {
       await waitFor(() => {
         expect(checkSubmissionExecutionMock).toHaveBeenCalled();
       });
-      expect(
-        screen.getByText(/投稿結果を確認しています。しばらくお待ちください。/),
-      ).toBeTruthy();
 
       await waitFor(
         () => {

--- a/apps/web/src/lib/demo/index.ts
+++ b/apps/web/src/lib/demo/index.ts
@@ -1,0 +1,85 @@
+import { unitTileCount } from "@one-portrait/shared";
+
+import type { AthleteProgressView, GalleryEntryView } from "../sui";
+
+export const demoPackageId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d0";
+export const demoRegistryObjectId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d1";
+export const demoUnitId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d2";
+export const demoMasterId =
+  "0x00000000000000000000000000000000000000000000000000000000000000d3";
+
+const demoProgressByUnitId = new Map<string, AthleteProgressView>([
+  [
+    demoUnitId,
+    {
+      unitId: demoUnitId,
+      athletePublicId: "1",
+      submittedCount: 347,
+      maxSlots: unitTileCount,
+      status: "pending",
+      masterId: null,
+    },
+  ],
+]);
+
+const demoCurrentUnitIdsByAthlete = new Map<string, string | null>([
+  ["1", demoUnitId],
+  ["2", null],
+  ["3", null],
+]);
+
+const demoGalleryEntries = [
+  {
+    unitId: demoUnitId,
+    athletePublicId: "1",
+    walrusBlobId: "demo-original-one",
+    submissionNo: 347,
+    mintedAtMs: 1_800_000_000_000,
+    masterId: demoMasterId,
+    mosaicWalrusBlobId: "demo-mosaic-one",
+    placement: {
+      x: 12,
+      y: 8,
+      submitter: "0xdemo-viewer",
+      submissionNo: 347,
+    },
+    status: { kind: "completed" },
+  },
+  {
+    unitId:
+      "0x00000000000000000000000000000000000000000000000000000000000000d4",
+    athletePublicId: "2",
+    walrusBlobId: "demo-original-two",
+    submissionNo: 88,
+    mintedAtMs: 1_790_000_000_000,
+    masterId: null,
+    mosaicWalrusBlobId: null,
+    placement: null,
+    status: { kind: "pending" },
+  },
+] satisfies readonly GalleryEntryView[];
+
+export function isDemoModeEnabled(
+  source: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return source.NEXT_PUBLIC_DEMO_MODE === "1";
+}
+
+export function getDemoCurrentUnitIdForAthlete(
+  athletePublicId: string,
+): string | null {
+  return demoCurrentUnitIdsByAthlete.get(athletePublicId) ?? null;
+}
+
+export function getDemoUnitProgress(
+  unitId: string,
+): AthleteProgressView | null {
+  return demoProgressByUnitId.get(unitId) ?? null;
+}
+
+export function getDemoGalleryEntries(): readonly GalleryEntryView[] {
+  return demoGalleryEntries;
+}

--- a/apps/web/src/lib/demo/index.ts
+++ b/apps/web/src/lib/demo/index.ts
@@ -68,6 +68,14 @@ export function isDemoModeEnabled(
   return source.NEXT_PUBLIC_DEMO_MODE === "1";
 }
 
+export function getDemoModeSource(): Readonly<
+  Record<"NEXT_PUBLIC_DEMO_MODE", string | undefined>
+> {
+  return {
+    NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
+  };
+}
+
 export function getDemoCurrentUnitIdForAthlete(
   athletePublicId: string,
 ): string | null {

--- a/apps/web/src/lib/dev-mode.test.ts
+++ b/apps/web/src/lib/dev-mode.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assertNormalDevEnvironment,
+  parseEnvFile,
+} from "../../scripts/dev-mode.mjs";
+import { e2eStubEnv, startE2EDev } from "../../scripts/run-e2e-dev.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { force: true, recursive: true });
+  }
+});
+
+describe("assertNormalDevEnvironment", () => {
+  it("throws when .env.local still contains E2E stub values", () => {
+    const cwd = createTempWebRoot();
+    fs.writeFileSync(
+      path.join(cwd, ".env.local"),
+      [
+        "NEXT_PUBLIC_SUI_NETWORK=testnet",
+        "NEXT_PUBLIC_E2E_STUB_WALLET=1",
+        "NEXT_PUBLIC_ENOKI_API_KEY=enoki-e2e-stub",
+      ].join("\n"),
+    );
+
+    expect(() =>
+      assertNormalDevEnvironment({
+        cwd,
+        env: {},
+      }),
+    ).toThrow(/E2E stub values still present/u);
+  });
+
+  it("accepts normal development env files", () => {
+    const cwd = createTempWebRoot();
+    fs.writeFileSync(
+      path.join(cwd, ".env.local"),
+      [
+        "NEXT_PUBLIC_SUI_NETWORK=testnet",
+        "NEXT_PUBLIC_ENOKI_API_KEY=real-public-key",
+      ].join("\n"),
+    );
+
+    expect(() =>
+      assertNormalDevEnvironment({
+        cwd,
+        env: {},
+      }),
+    ).not.toThrow();
+  });
+
+  it("parses quoted env values", () => {
+    expect(
+      parseEnvFile(
+        [
+          "NEXT_PUBLIC_GOOGLE_CLIENT_ID='google-e2e-stub'",
+          'NEXT_PUBLIC_WALRUS_PUBLISHER="https://publisher.e2e.stub"',
+        ].join("\n"),
+      ),
+    ).toEqual({
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: "google-e2e-stub",
+      NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.e2e.stub",
+    });
+  });
+});
+
+describe("startE2EDev", () => {
+  it("injects stub env without mutating .env.local", async () => {
+    const cwd = createTempWebRoot();
+    const envLocalPath = path.join(cwd, ".env.local");
+    const originalEnvLocal = [
+      "NEXT_PUBLIC_SUI_NETWORK=devnet",
+      "NEXT_PUBLIC_ENOKI_API_KEY=real-public-key",
+    ].join("\n");
+
+    fs.writeFileSync(envLocalPath, originalEnvLocal);
+    fs.mkdirSync(path.join(cwd, ".next"), { recursive: true });
+    fs.mkdirSync(path.join(cwd, "node_modules", ".bin"), { recursive: true });
+
+    const spawnCalls = [];
+
+    await startE2EDev({
+      cwd,
+      env: { E2E_PORT: "3100" },
+      isPortBusy: async () => false,
+      nextDevBin: "/tmp/fake-next",
+      spawnImpl: (...args) => {
+        spawnCalls.push(args);
+        return { on() {} };
+      },
+    });
+
+    expect(fs.readFileSync(envLocalPath, "utf8")).toBe(originalEnvLocal);
+    expect(fs.existsSync(path.join(cwd, ".next"))).toBe(false);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0][2].env).toMatchObject(e2eStubEnv);
+  });
+});
+
+function createTempWebRoot() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "one-portrait-web-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/apps/web/src/lib/dev-mode.test.ts
+++ b/apps/web/src/lib/dev-mode.test.ts
@@ -65,6 +65,21 @@ describe("assertNormalDevEnvironment", () => {
     ).not.toThrow();
   });
 
+  it("throws when only the private Enoki E2E stub is left behind", () => {
+    const cwd = createTempWebRoot();
+    fs.writeFileSync(
+      path.join(cwd, ".env.local"),
+      "ENOKI_PRIVATE_API_KEY=enoki-private-e2e-stub",
+    );
+
+    expect(() =>
+      assertNormalDevEnvironment({
+        cwd,
+        env: {},
+      }),
+    ).toThrow(/ENOKI_PRIVATE_API_KEY=enoki-private-e2e-stub/u);
+  });
+
   it("parses quoted env values", () => {
     expect(
       parseEnvFile(

--- a/apps/web/src/lib/dev-mode.test.ts
+++ b/apps/web/src/lib/dev-mode.test.ts
@@ -1,20 +1,29 @@
+// @ts-nocheck
+
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+// @ts-expect-error test-only import from a Node .mjs script
 import {
   assertNormalDevEnvironment,
   parseEnvFile,
 } from "../../scripts/dev-mode.mjs";
+// @ts-expect-error test-only import from a Node .mjs script
 import { e2eStubEnv, startE2EDev } from "../../scripts/run-e2e-dev.mjs";
 
-const tempDirs = [];
+const tempDirs: string[] = [];
 
 afterEach(() => {
   while (tempDirs.length > 0) {
-    fs.rmSync(tempDirs.pop(), { force: true, recursive: true });
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
   }
 });
 
@@ -84,16 +93,22 @@ describe("startE2EDev", () => {
     fs.mkdirSync(path.join(cwd, ".next"), { recursive: true });
     fs.mkdirSync(path.join(cwd, "node_modules", ".bin"), { recursive: true });
 
-    const spawnCalls = [];
+    const spawnCalls: Array<
+      [string, string[], { env: Record<string, string> }]
+    > = [];
 
     await startE2EDev({
       cwd,
       env: { E2E_PORT: "3100" },
       isPortBusy: async () => false,
       nextDevBin: "/tmp/fake-next",
-      spawnImpl: (...args) => {
-        spawnCalls.push(args);
-        return { on() {} };
+      spawnImpl: (
+        command: string,
+        args: string[],
+        options: { env: Record<string, string> },
+      ) => {
+        spawnCalls.push([command, args, options]);
+        return new EventEmitter() as ChildProcess;
       },
     });
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "vitest": "^4.1.4"
   },
   "scripts": {
+    "dev": "corepack pnpm --filter web dev",
+    "dev:e2e": "corepack pnpm --filter web dev:e2e",
+    "test:e2e": "corepack pnpm --filter web test:e2e",
     "lint": "biome check .",
     "check": "corepack pnpm run lint && corepack pnpm run typecheck && corepack pnpm test",
     "typecheck": "tsc -p tsconfig.json --noEmit && corepack pnpm -r --filter \"!one-portrait-workspace\" --if-present typecheck",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "dev": "corepack pnpm --filter web dev",
+    "dev:demo": "corepack pnpm --filter web dev:demo",
     "dev:e2e": "corepack pnpm --filter web dev:e2e",
     "test:e2e": "corepack pnpm --filter web test:e2e",
     "lint": "biome check .",

--- a/test/dev-scripts.test.ts
+++ b/test/dev-scripts.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+describe("development entrypoints", () => {
+  it("exposes root scripts for normal dev and E2E", () => {
+    const rootPackageJson = readPackageJson(path.join(repoRoot, "package.json"));
+
+    expect(rootPackageJson.scripts.dev).toBe(
+      'corepack pnpm --filter web dev',
+    );
+    expect(rootPackageJson.scripts["dev:e2e"]).toBe(
+      'corepack pnpm --filter web dev:e2e',
+    );
+    expect(rootPackageJson.scripts["test:e2e"]).toBe(
+      'corepack pnpm --filter web test:e2e',
+    );
+  });
+
+  it("keeps the web workspace E2E startup explicit", () => {
+    const webPackageJson = readPackageJson(
+      path.join(repoRoot, "apps/web/package.json"),
+    );
+
+    expect(webPackageJson.scripts.dev).toBe("node ./scripts/run-dev.mjs");
+    expect(webPackageJson.scripts["dev:e2e"]).toBe("./scripts/e2e-dev.sh");
+    expect(webPackageJson.scripts["test:e2e"]).toBe("playwright test");
+  });
+});
+
+function readPackageJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}

--- a/test/dev-scripts.test.ts
+++ b/test/dev-scripts.test.ts
@@ -7,16 +7,19 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 
 describe("development entrypoints", () => {
   it("exposes root scripts for normal dev and E2E", () => {
-    const rootPackageJson = readPackageJson(path.join(repoRoot, "package.json"));
+    const rootPackageJson = readPackageJson(
+      path.join(repoRoot, "package.json"),
+    );
 
-    expect(rootPackageJson.scripts.dev).toBe(
-      'corepack pnpm --filter web dev',
+    expect(rootPackageJson.scripts.dev).toBe("corepack pnpm --filter web dev");
+    expect(rootPackageJson.scripts["dev:demo"]).toBe(
+      "corepack pnpm --filter web dev:demo",
     );
     expect(rootPackageJson.scripts["dev:e2e"]).toBe(
-      'corepack pnpm --filter web dev:e2e',
+      "corepack pnpm --filter web dev:e2e",
     );
     expect(rootPackageJson.scripts["test:e2e"]).toBe(
-      'corepack pnpm --filter web test:e2e',
+      "corepack pnpm --filter web test:e2e",
     );
   });
 
@@ -26,11 +29,14 @@ describe("development entrypoints", () => {
     );
 
     expect(webPackageJson.scripts.dev).toBe("node ./scripts/run-dev.mjs");
+    expect(webPackageJson.scripts["dev:demo"]).toBe(
+      "node ./scripts/run-demo-dev.mjs",
+    );
     expect(webPackageJson.scripts["dev:e2e"]).toBe("./scripts/e2e-dev.sh");
     expect(webPackageJson.scripts["test:e2e"]).toBe("playwright test");
   });
 });
 
-function readPackageJson(filePath) {
+function readPackageJson(filePath: string) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }


### PR DESCRIPTION
## 概要
通常開発と E2E 用の stub 起動が混ざっていたため、`pnpm run dev` で人が触る確認がしにくい状態でした。
この PR では起動モードを分け、通常開発、UI 確認用 demo、Playwright 用 E2E をそれぞれ別の入口に整理します。

## 変更内容
- `package.json`
  - root から `dev` / `dev:demo` / `dev:e2e` / `test:e2e` を起動できるようにしました。
- `apps/web/scripts/dev-mode.mjs`
  - 通常 `dev` で E2E stub の残留 env を検知して起動を止める guard を追加しました。
- `apps/web/scripts/e2e-dev.sh`
  - `.env.local` を上書きしない薄い wrapper に置き換えました。
- `apps/web/scripts/run-e2e-dev.mjs`
  - Playwright 用の stub env を子 process にだけ注入する起動処理を追加しました。
- `apps/web/scripts/run-demo-dev.mjs`
  - demo fixture 用の env を入れて Next.js を起動する runner を追加しました。
- `apps/web/src/lib/demo/index.ts`
  - home / waiting room / gallery 用の demo fixture を追加しました。
- `apps/web/src/app/page.tsx`
  - demo mode では固定の unit 進捗を使って top から遷移しやすくしました。
- `apps/web/src/app/units/[unitId]/page.tsx`
  - demo mode では waiting room の進捗を fixture で表示し、Google 導線は preview-only にしました。
- `apps/web/src/app/gallery/page.tsx`
  - demo entry を client に渡せるようにしました。
- `apps/web/src/app/gallery/gallery-client.tsx`
  - demo entry がある場合は wallet と package id の必須分岐を回避し、placeholder 画像で状態確認できるようにしました。
- `README.md`
  - 4 つの起動モードの役割差を追記しました。
- `test/dev-scripts.test.ts`
  - root / web の起動 script 構成を固定するテストを追加しました。
- `apps/web/src/lib/dev-mode.test.ts`
  - stub 検知と `.env.local` 非破壊を固定するテストを追加しました。
- `apps/web/src/app/page.test.tsx`
  - demo mode の top 導線を固定するテストを追加しました。
- `apps/web/src/app/units/[unitId]/page.test.tsx`
  - demo waiting room の進捗と Google 導線 preview を固定するテストを追加しました。
- `apps/web/src/app/gallery/page.test.tsx`
  - package id がなくても demo entry を渡せることを固定しました。
- `apps/web/src/app/gallery/gallery-client.test.tsx`
  - signed out / empty package id でも demo gallery を描画できることを固定しました。

## 関連する Issue やチケット
Close #28

## 動作確認
- `corepack pnpm run check`
- `corepack pnpm --filter web build`
- `timeout 15s corepack pnpm run dev:demo` で Next.js が `Ready` に到達
