### PR TITLE
fix: RPC劣化時の進捗と待機室フォールバックを改善する

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -148,11 +148,15 @@ describe("HomePage", () => {
 
     const link = screen
       .getAllByRole("link")
-      .find((el) => el.getAttribute("href") === "/units/0xunit-1");
+      .find(
+        (el) =>
+          el.getAttribute("href") ===
+          "/units/0xunit-1?athleteName=Demo+Athlete+One",
+      );
     expect(link).toBeTruthy();
   });
 
-  it("falls back to catalog-only display when env or RPC fails", async () => {
+  it("keeps catalog-only display and marks progress unavailable when env is missing", async () => {
     getAthleteCatalogMock.mockResolvedValue([CATALOG[0]]);
     loadPublicEnvMock.mockImplementation(() => {
       throw new Error("env missing");
@@ -163,24 +167,38 @@ describe("HomePage", () => {
 
     expect(screen.getByText("Demo Athlete One")).toBeTruthy();
     expect(getCurrentUnitIdForAthleteMock).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/進捗を一時取得できません|temporarily unavailable/i),
+    ).toBeTruthy();
   });
 
-  it("falls back to placeholder progress when Sui RPC throws", async () => {
+  it("keeps the waiting-room link when progress fetch fails after resolving unitId", async () => {
     getAthleteCatalogMock.mockResolvedValue([CATALOG[0]]);
     loadPublicEnvMock.mockReturnValue({
       suiNetwork: "testnet",
       packageId: "0xpkg",
       registryObjectId: "0xreg",
     });
-    getCurrentUnitIdForAthleteMock.mockRejectedValue(new Error("rpc down"));
+    getCurrentUnitIdForAthleteMock.mockResolvedValue("0xunit-1");
+    getUnitProgressMock.mockRejectedValue(new Error("rpc down"));
 
     const ui = await HomePage();
     render(ui);
 
     expect(screen.getByText("Demo Athlete One")).toBeTruthy();
-    // Placeholder must not crash the card — either waiting state or the slug
-    // must still render.
     expect(screen.getByText(/demo-athlete-one/)).toBeTruthy();
+    expect(
+      screen.getByText(/進捗を一時取得できません|temporarily unavailable/i),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole("link")
+        .find(
+          (el) =>
+            el.getAttribute("href") ===
+            "/units/0xunit-1?athleteName=Demo+Athlete+One",
+        ),
+    ).toBeTruthy();
   });
 
   it("uses demo fixture progress when demo mode is enabled", async () => {
@@ -192,7 +210,11 @@ describe("HomePage", () => {
 
     const link = screen
       .getAllByRole("link")
-      .find((el) => el.getAttribute("href") === `/units/${demoUnitId}`);
+      .find(
+        (el) =>
+          el.getAttribute("href") ===
+          `/units/${demoUnitId}?athleteName=Demo+Athlete+One`,
+      );
 
     expect(link).toBeTruthy();
     expect(getCurrentUnitIdForAthleteMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -108,7 +108,9 @@ function AthleteCard({
   const href =
     progress.kind === "waiting"
       ? null
-      : buildWaitingRoomHref(progress.unitId, athlete.displayName);
+      : progress.unitId
+        ? buildWaitingRoomHref(progress.unitId, athlete.displayName)
+        : null;
   const body = (
     <article className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7 transition hover:border-cyan-200/40">
       {/* External placeholder URL — keeping <img> over next/image so no

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -36,13 +36,14 @@ type CardProgress =
       readonly maxSlots: number;
     }
   | { readonly kind: "waiting" }
-  | { readonly kind: "unavailable" };
+  | {
+      readonly kind: "unavailable";
+      readonly unitId?: string;
+    };
 
 type ResolvedEnv = {
   readonly registryObjectId: string;
 };
-
-const FALLBACK_MAX_SLOTS = unitTileCount;
 
 export default async function HomePage(): Promise<React.ReactElement> {
   const catalog = await getAthleteCatalog();
@@ -104,6 +105,10 @@ function AthleteCard({
   athlete,
   progress,
 }: AthleteCardProps): React.ReactElement {
+  const href =
+    progress.kind === "waiting"
+      ? null
+      : buildWaitingRoomHref(progress.unitId, athlete.displayName);
   const body = (
     <article className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7 transition hover:border-cyan-200/40">
       {/* External placeholder URL — keeping <img> over next/image so no
@@ -124,9 +129,9 @@ function AthleteCard({
     </article>
   );
 
-  if (progress.kind === "active") {
+  if (href) {
     return (
-      <Link className="contents" href={`/units/${progress.unitId}`}>
+      <Link className="contents" href={href}>
         {body}
       </Link>
     );
@@ -155,7 +160,7 @@ function ProgressLabel({
   }
   return (
     <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-      Progress unavailable
+      進捗を一時取得できません / Progress temporarily unavailable
     </p>
   );
 }
@@ -177,7 +182,7 @@ function resolveDemoProgress(athletePublicId: string): CardProgress {
 
   const progress = getDemoUnitProgress(unitId);
   if (!progress) {
-    return { kind: "unavailable" };
+    return { kind: "unavailable", unitId };
   }
 
   return {
@@ -209,13 +214,16 @@ async function resolveProgress(
       };
     } catch {
       return {
-        kind: "active",
+        kind: "unavailable",
         unitId,
-        submittedCount: 0,
-        maxSlots: FALLBACK_MAX_SLOTS,
       };
     }
   } catch {
     return { kind: "unavailable" };
   }
+}
+
+function buildWaitingRoomHref(unitId: string, athleteName: string): string {
+  const params = new URLSearchParams({ athleteName });
+  return `/units/${unitId}?${params.toString()}`;
 }

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -90,6 +90,7 @@ describe("UnitPage", () => {
 
     const ui = await UnitPage({
       params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({}),
     });
     render(ui);
 
@@ -99,7 +100,7 @@ describe("UnitPage", () => {
     expect(screen.getByText("Demo Athlete One")).toBeTruthy();
   });
 
-  it("shows a fallback when the Unit object cannot be fetched", async () => {
+  it("shows the route athleteName when unit progress cannot be fetched", async () => {
     getUnitProgressMock.mockRejectedValue(new Error("not found"));
     loadPublicEnvMock.mockReturnValue({
       suiNetwork: "testnet",
@@ -109,10 +110,31 @@ describe("UnitPage", () => {
 
     const ui = await UnitPage({
       params: Promise.resolve({ unitId: "0xunit-missing" }),
+      searchParams: Promise.resolve({ athleteName: "Demo Athlete One" }),
     });
     render(ui);
 
+    expect(screen.getByRole("heading", { name: "Demo Athlete One" })).toBeTruthy();
     expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
+  });
+
+  it("shows a fixed fallback label when both route and catalog names are unavailable", async () => {
+    getUnitProgressMock.mockRejectedValue(new Error("not found"));
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-missing" }),
+      searchParams: Promise.resolve({}),
+    });
+    render(ui);
+
+    expect(
+      screen.getByRole("heading", { name: "選手情報を一時取得できません" }),
+    ).toBeTruthy();
   });
 
   it("passes the packageId from env to the live progress client component", async () => {
@@ -138,6 +160,7 @@ describe("UnitPage", () => {
 
     const ui = await UnitPage({
       params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({}),
     });
     render(ui);
 
@@ -167,12 +190,71 @@ describe("UnitPage", () => {
 
     const ui = await UnitPage({
       params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({}),
     });
     render(ui);
 
     expect(
       screen.getByTestId("unit-reveal-client").getAttribute("data-master-id"),
     ).toBe("0xmaster-1");
+  });
+
+  it("prefers athleteName from the route when catalog lookup also succeeds", async () => {
+    getUnitProgressMock.mockResolvedValue({
+      unitId: "0xunit-1",
+      athletePublicId: "1",
+      submittedCount: 15,
+      maxSlots: unitTileCount,
+      status: "pending",
+      masterId: null,
+    });
+    getAthleteByPublicIdMock.mockResolvedValue({
+      athletePublicId: "1",
+      slug: "demo-athlete-one",
+      displayName: "Catalog Athlete Name",
+      thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
+    });
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({ athleteName: "Route Athlete Name" }),
+    });
+    render(ui);
+
+    expect(
+      screen.getByRole("heading", { name: "Route Athlete Name" }),
+    ).toBeTruthy();
+  });
+
+  it("falls back to route athleteName when catalog lookup fails", async () => {
+    getUnitProgressMock.mockResolvedValue({
+      unitId: "0xunit-1",
+      athletePublicId: "1",
+      submittedCount: 15,
+      maxSlots: unitTileCount,
+      status: "pending",
+      masterId: null,
+    });
+    getAthleteByPublicIdMock.mockRejectedValue(new Error("catalog down"));
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({ athleteName: "Demo Athlete One" }),
+    });
+    render(ui);
+
+    expect(screen.getByText("Demo Athlete One")).toBeTruthy();
+    expect(screen.getByTestId("unit-reveal-client")).toBeTruthy();
   });
 
   it("uses demo fixture progress without calling Sui when demo mode is enabled", async () => {
@@ -191,6 +273,7 @@ describe("UnitPage", () => {
 
     const ui = await UnitPage({
       params: Promise.resolve({ unitId: demoUnitId }),
+      searchParams: Promise.resolve({}),
     });
     render(ui);
 

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -114,7 +114,9 @@ describe("UnitPage", () => {
     });
     render(ui);
 
-    expect(screen.getByRole("heading", { name: "Demo Athlete One" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Demo Athlete One" }),
+    ).toBeTruthy();
     expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
   });
 

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -139,6 +139,25 @@ describe("UnitPage", () => {
     ).toBeTruthy();
   });
 
+  it("treats a blank athleteName query as missing", async () => {
+    getUnitProgressMock.mockRejectedValue(new Error("not found"));
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-missing" }),
+      searchParams: Promise.resolve({ athleteName: "   " }),
+    });
+    render(ui);
+
+    expect(
+      screen.getByRole("heading", { name: "選手情報を一時取得できません" }),
+    ).toBeTruthy();
+  });
+
   it("passes the packageId from env to the live progress client component", async () => {
     getUnitProgressMock.mockResolvedValue({
       unitId: "0xunit-1",

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -201,7 +201,7 @@ describe("UnitPage", () => {
     ).toBe("0xmaster-1");
   });
 
-  it("prefers athleteName from the route when catalog lookup also succeeds", async () => {
+  it("prefers the catalog name when both catalog and route fallback are available", async () => {
     getUnitProgressMock.mockResolvedValue({
       unitId: "0xunit-1",
       athletePublicId: "1",
@@ -229,7 +229,7 @@ describe("UnitPage", () => {
     render(ui);
 
     expect(
-      screen.getByRole("heading", { name: "Route Athlete Name" }),
+      screen.getByRole("heading", { name: "Catalog Athlete Name" }),
     ).toBeTruthy();
   });
 

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -219,6 +219,6 @@ function resolveDisplayName(
   catalogDisplayName: string | null,
 ): string {
   return (
-    routeAthleteName ?? catalogDisplayName ?? "選手情報を一時取得できません"
+    catalogDisplayName ?? routeAthleteName ?? "選手情報を一時取得できません"
   );
 }

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -218,7 +218,11 @@ function resolveDisplayName(
   routeAthleteName: string | undefined,
   catalogDisplayName: string | null,
 ): string {
+  const normalizedRouteAthleteName = routeAthleteName?.trim();
   return (
-    catalogDisplayName ?? routeAthleteName ?? "選手情報を一時取得できません"
+    catalogDisplayName ??
+    (normalizedRouteAthleteName
+      ? normalizedRouteAthleteName
+      : "選手情報を一時取得できません")
   );
 }

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -23,6 +23,9 @@ import { UnitRevealClient } from "./unit-reveal-client";
 
 type UnitPageProps = {
   readonly params: Promise<{ readonly unitId: string }>;
+  readonly searchParams: Promise<{
+    readonly athleteName?: string;
+  }>;
 };
 
 type ResolvedProgress = {
@@ -38,6 +41,7 @@ export default async function UnitPage(
   props: UnitPageProps,
 ): Promise<React.ReactElement> {
   const { unitId } = await props.params;
+  const searchParams = await props.searchParams;
   const demoMode = isDemoModeEnabled(process.env);
 
   const packageId = safePackageId();
@@ -48,7 +52,10 @@ export default async function UnitPage(
     ? await safeGetAthleteByPublicId(progress.athletePublicId)
     : null;
 
-  const displayName = athlete?.displayName ?? "Athlete";
+  const displayName = resolveDisplayName(
+    searchParams.athleteName,
+    athlete?.displayName ?? null,
+  );
   const thumbnailUrl = athlete?.thumbnailUrl ?? null;
 
   const hasProgress =
@@ -205,4 +212,13 @@ async function safeGetAthleteByPublicId(athletePublicId: string) {
   } catch {
     return null;
   }
+}
+
+function resolveDisplayName(
+  routeAthleteName: string | undefined,
+  catalogDisplayName: string | null,
+): string {
+  return (
+    routeAthleteName ?? catalogDisplayName ?? "選手情報を一時取得できません"
+  );
 }

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -22,7 +22,9 @@ test.describe("home smoke", () => {
     expect(await athleteHeadings.count()).toBeGreaterThanOrEqual(1);
   });
 
-  test("keeps the home page readable on a mobile viewport", async ({ page }) => {
+  test("keeps the home page readable on a mobile viewport", async ({
+    page,
+  }) => {
     await installDefaultMocks(page);
     await page.setViewportSize({ width: 390, height: 844 });
 
@@ -57,7 +59,9 @@ test.describe("home smoke", () => {
       page.getByRole("heading", { level: 1, name: "Demo Athlete One" }),
     ).toBeVisible();
     await expect(
-      page.getByText(/待機中|No active unit|on-chain progress is not available/i),
+      page.getByText(
+        /待機中|No active unit|on-chain progress is not available/i,
+      ),
     ).toBeVisible();
 
     const hasNoHorizontalOverflow = await page.evaluate(

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -1,6 +1,7 @@
 import { unitTileCount } from "@one-portrait/shared";
 import { expect, test } from "@playwright/test";
 
+import { demoUnitId } from "../../src/lib/demo";
 import { installDefaultMocks } from "./fixtures/mock-network";
 
 test.describe("home smoke", () => {
@@ -19,5 +20,51 @@ test.describe("home smoke", () => {
     const athleteHeadings = page.getByRole("heading", { level: 2 });
     await expect(athleteHeadings.first()).toBeVisible();
     expect(await athleteHeadings.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("keeps the home page readable on a mobile viewport", async ({ page }) => {
+    await installDefaultMocks(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: new RegExp(`${unitTileCount} faces`, "i"),
+      }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 }).first()).toBeVisible();
+    const hasNoHorizontalOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    );
+    expect(hasNoHorizontalOverflow).toBe(true);
+  });
+
+  test("keeps the waiting room readable on a mobile viewport", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto(
+      `/units/${demoUnitId}?athleteName=${encodeURIComponent("Demo Athlete One")}`,
+    );
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Demo Athlete One" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/待機中|No active unit|on-chain progress is not available/i),
+    ).toBeVisible();
+
+    const hasNoHorizontalOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    );
+    expect(hasNoHorizontalOverflow).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要
RPC の一時失敗でトップと待機室が壊れて見える問題を抑えます。
待機中と取得失敗を分けて見せ、待機室では人向けの名前をできるだけ残します。
スマホ幅でも主要情報が読めることを自動確認に入れます。

## 変更内容
- `apps/web/src/app/page.tsx`
  - ホームで `waiting` と `unavailable` を分けました
  - `unitId` が分かる時は進捗取得失敗でも待機室リンクを残しました
  - 待機室リンクに `athleteName` query を付けました
- `apps/web/src/app/units/[unitId]/page.tsx`
  - 待機室で `searchParams.athleteName` を fallback として受けるようにしました
  - 表示名の優先順を `catalog > query fallback > 固定ラベル` にしました
  - 空文字や空白だけの query は未指定扱いにしました
- `apps/web/src/app/page.test.tsx`
  - ホームの劣化表示とリンク維持を確認するケースを追加しました
- `apps/web/src/app/units/[unitId]/page.test.tsx`
  - progress 失敗、catalog 失敗、空の query を分けて確認するケースを追加しました
- `apps/web/tests/e2e/home-smoke.spec.ts`
  - 390px 幅でホームと待機室が読めることを確認する E2E を追加しました

## 関連する Issue やチケット
Close #25

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/page.test.tsx`
- `corepack pnpm --filter web exec vitest run src/app/units/[unitId]/page.test.tsx`
- `corepack pnpm --filter web exec playwright test tests/e2e/home-smoke.spec.ts`
- `corepack pnpm run check`
- `corepack pnpm run build`
