### PR TITLE
feat: トップ・待機室・ギャラリーの回遊導線を接続する

### DIFF
--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -7,11 +7,17 @@ import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 
 const {
   useCurrentAccountMock,
+  useCurrentWalletMock,
+  useWalletsMock,
+  useConnectWalletMock,
   getSuiClientMock,
   listOwnedKakeraMock,
   getGalleryEntryMock,
 } = vi.hoisted(() => ({
   useCurrentAccountMock: vi.fn(),
+  useCurrentWalletMock: vi.fn(),
+  useWalletsMock: vi.fn(),
+  useConnectWalletMock: vi.fn(),
   getSuiClientMock: vi.fn(),
   listOwnedKakeraMock: vi.fn(),
   getGalleryEntryMock: vi.fn(),
@@ -19,6 +25,13 @@ const {
 
 vi.mock("@mysten/dapp-kit", () => ({
   useCurrentAccount: () => useCurrentAccountMock(),
+  useCurrentWallet: () => useCurrentWalletMock(),
+  useWallets: () => useWalletsMock(),
+  useConnectWallet: () => useConnectWalletMock(),
+}));
+
+vi.mock("@mysten/enoki", () => ({
+  isGoogleWallet: (wallet: { id?: string }) => wallet.id === "google-wallet",
 }));
 
 vi.mock("../../lib/sui", () => ({
@@ -96,6 +109,11 @@ function completedEntry(
 beforeEach(() => {
   process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR = "https://aggregator.example.com";
   useCurrentAccountMock.mockReturnValue(null);
+  useCurrentWalletMock.mockReturnValue({
+    connectionStatus: "disconnected",
+  });
+  useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
+  useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
   getSuiClientMock.mockReturnValue({ network: "testnet" });
   listOwnedKakeraMock.mockResolvedValue([]);
   getGalleryEntryMock.mockResolvedValue(pendingEntry());
@@ -105,6 +123,9 @@ afterEach(() => {
   delete process.env.NEXT_PUBLIC_DEMO_MODE;
   delete process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR;
   useCurrentAccountMock.mockReset();
+  useCurrentWalletMock.mockReset();
+  useWalletsMock.mockReset();
+  useConnectWalletMock.mockReset();
   getSuiClientMock.mockReset();
   listOwnedKakeraMock.mockReset();
   getGalleryEntryMock.mockReset();
@@ -117,7 +138,25 @@ describe("GalleryClient", () => {
     expect(
       screen.getByText(/Connect a wallet to view your Kakera/i),
     ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Google でログイン" }),
+    ).toBeTruthy();
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
+  });
+
+  it("starts Google login from the signed-out shell", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useConnectWalletMock.mockReturnValue({ mutateAsync });
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        wallet: { id: "google-wallet" },
+      });
+    });
   });
 
   it("renders demo entries without requiring a connected wallet", async () => {
@@ -179,6 +218,31 @@ describe("GalleryClient", () => {
     });
 
     expect(screen.getByText(/No Kakera found for this wallet/i)).toBeTruthy();
+    expect(
+      screen.getByText(
+        /投稿直後なら、少し待ってからもう一度確認してください。/,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "もう一度確認する" }),
+    ).toBeTruthy();
+  });
+
+  it("reloads the gallery when the user asks to check again", async () => {
+    useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
+    listOwnedKakeraMock.mockResolvedValue([]);
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    await waitFor(() => {
+      expect(listOwnedKakeraMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "もう一度確認する" }));
+
+    await waitFor(() => {
+      expect(listOwnedKakeraMock).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("renders pending entries with a waiting label", async () => {

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCurrentAccount } from "@mysten/dapp-kit";
+import {
+  useConnectWallet,
+  useCurrentAccount,
+  useCurrentWallet,
+  useWallets,
+} from "@mysten/dapp-kit";
+import { isGoogleWallet } from "@mysten/enoki";
 import { useEffect, useState } from "react";
 
 import type { AthleteCatalogEntry } from "../../lib/catalog";
@@ -54,13 +60,34 @@ export function GalleryClient({
   packageId,
 }: GalleryClientProps): React.ReactElement {
   const currentAccount = useCurrentAccount();
+  const currentWallet = useCurrentWallet();
+  const wallets = useWallets();
+  const connectWallet = useConnectWallet();
   const [state, setState] = useState<LoadState>({
     kind: "idle",
     entries: [],
   });
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const [connectError, setConnectError] = useState<string | null>(null);
   const [failedOriginalBlobIds, setFailedOriginalBlobIds] = useState<
     readonly string[]
   >([]);
+  const googleWallet = wallets.find(isGoogleWallet) ?? null;
+  const isConnecting = currentWallet.connectionStatus === "connecting";
+
+  async function handleLogin(): Promise<void> {
+    if (!googleWallet) {
+      setConnectError("Google ログインの設定が見つかりません。");
+      return;
+    }
+
+    try {
+      setConnectError(null);
+      await connectWallet.mutateAsync({ wallet: googleWallet });
+    } catch (error) {
+      setConnectError(toMessage(error));
+    }
+  }
 
   useEffect(() => {
     if (demoEntries) {
@@ -83,7 +110,10 @@ export function GalleryClient({
 
     let cancelled = false;
 
-    setState({ kind: "loading", entries: [] });
+    setState((current) => ({
+      kind: "loading",
+      entries: reloadNonce > 0 ? current.entries : [],
+    }));
     setFailedOriginalBlobIds([]);
 
     const loadEntries = async (): Promise<void> => {
@@ -139,7 +169,7 @@ export function GalleryClient({
     return () => {
       cancelled = true;
     };
-  }, [currentAccount?.address, demoEntries, packageId]);
+  }, [currentAccount?.address, demoEntries, packageId, reloadNonce]);
 
   if (!demoEntries && !currentAccount?.address) {
     return (
@@ -150,6 +180,27 @@ export function GalleryClient({
         <p className="mt-3 text-slate-200">
           Connect a wallet to view your Kakera participation history.
         </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
+            disabled={isConnecting}
+            onClick={() => {
+              void handleLogin();
+            }}
+            type="button"
+          >
+            {connectError ? "もう一度ログイン" : "Google でログイン"}
+          </button>
+        </div>
+        {connectError ? (
+          <p
+            aria-live="polite"
+            className="mt-4 rounded-2xl border border-amber-300/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-100"
+            role="alert"
+          >
+            {connectError}
+          </p>
+        ) : null}
       </section>
     );
   }
@@ -164,6 +215,19 @@ export function GalleryClient({
           Gallery unavailable right now. Check the public Sui configuration and
           try again.
         </p>
+        {packageId ? (
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+              onClick={() => {
+                setReloadNonce((current) => current + 1);
+              }}
+              type="button"
+            >
+              もう一度確認する
+            </button>
+          </div>
+        ) : null}
       </section>
     );
   }
@@ -186,6 +250,20 @@ export function GalleryClient({
           Empty
         </p>
         <p className="mt-3 text-slate-200">No Kakera found for this wallet.</p>
+        <p className="mt-2 text-sm text-slate-300">
+          投稿直後なら、少し待ってからもう一度確認してください。
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+            onClick={() => {
+              setReloadNonce((current) => current + 1);
+            }}
+            type="button"
+          >
+            もう一度確認する
+          </button>
+        </div>
       </section>
     );
   }
@@ -212,6 +290,14 @@ export function GalleryClient({
       ))}
     </section>
   );
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "処理に失敗しました。時間をおいて、もう一度お試しください。";
 }
 
 type GalleryCardProps = {

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -110,6 +110,32 @@ describe("HomePage", () => {
     ).toBeTruthy();
   });
 
+  it("shows a hero link to the participation gallery", async () => {
+    getAthleteCatalogMock.mockResolvedValue([CATALOG[0]]);
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+    getCurrentUnitIdForAthleteMock.mockResolvedValue("0xunit-1");
+    getUnitProgressMock.mockResolvedValue({
+      unitId: "0xunit-1",
+      athletePublicId: "1",
+      submittedCount: 123,
+      maxSlots: unitTileCount,
+      status: "pending",
+      masterId: null,
+    });
+
+    const ui = await HomePage();
+    render(ui);
+
+    const link = screen.getByRole("link", {
+      name: /participation history/i,
+    });
+    expect(link.getAttribute("href")).toBe("/gallery");
+  });
+
   it("renders a waiting-state card when no current unit is registered", async () => {
     getAthleteCatalogMock.mockResolvedValue([CATALOG[0]]);
     loadPublicEnvMock.mockReturnValue({

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -74,6 +74,14 @@ export default async function HomePage(): Promise<React.ReactElement> {
             Pick an athlete to open their waiting room. Each mosaic reveals the
             moment the {unitTileCount}th photo lands.
           </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              className="inline-flex items-center rounded-full border border-cyan-200/40 bg-cyan-300 px-5 py-2 text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
+              href="/gallery"
+            >
+              Participation history
+            </Link>
+          </div>
         </section>
 
         <section className="grid gap-6 md:grid-cols-2">

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -115,6 +115,38 @@ describe("UnitPage", () => {
     expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
   });
 
+  it("shows a waiting-room link to the participation gallery", async () => {
+    getUnitProgressMock.mockResolvedValue({
+      unitId: "0xunit-1",
+      athletePublicId: "1",
+      submittedCount: 10,
+      maxSlots: unitTileCount,
+      status: "pending",
+      masterId: null,
+    });
+    getAthleteByPublicIdMock.mockResolvedValue({
+      athletePublicId: "1",
+      slug: "demo-athlete-one",
+      displayName: "Demo Athlete One",
+      thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
+    });
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-1" }),
+    });
+    render(ui);
+
+    const link = screen.getByRole("link", {
+      name: /participation history/i,
+    });
+    expect(link.getAttribute("href")).toBe("/gallery");
+  });
+
   it("passes the packageId from env to the live progress client component", async () => {
     getUnitProgressMock.mockResolvedValue({
       unitId: "0xunit-1",

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -57,12 +57,18 @@ export default async function UnitPage(
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#15366d,_#071120_55%,_#02060d)] px-6 py-16 text-slate-50">
       <div className="mx-auto grid max-w-3xl gap-8">
-        <nav>
+        <nav className="flex flex-wrap items-center gap-4">
           <Link
             className="text-sm uppercase tracking-[0.3em] text-cyan-200/80 hover:text-cyan-100"
             href="/"
           >
             ← All athletes
+          </Link>
+          <Link
+            className="text-sm uppercase tracking-[0.3em] text-cyan-200/80 hover:text-cyan-100"
+            href="/gallery"
+          >
+            Participation history
           </Link>
         </nav>
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -693,6 +693,14 @@ describe("ParticipationAccess", () => {
         expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
       });
       expect(screen.getByText(/final-digest-XYZ/)).toBeTruthy();
+      expect(
+        screen.getByText(/次は履歴ギャラリーで参加記録を確認できます。/),
+      ).toBeTruthy();
+      expect(
+        screen
+          .getByRole("link", { name: "履歴ギャラリーを見る" })
+          .getAttribute("href"),
+      ).toBe("/gallery");
     });
 
     it("keeps showing a recovery message while execution confirmation is still pending, then offers retry only after confirmed failure", async () => {

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import {
   useConnectWallet,
   useCurrentAccount,
@@ -9,6 +8,7 @@ import {
   useWallets,
 } from "@mysten/dapp-kit";
 import { isGoogleWallet } from "@mysten/enoki";
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 import {

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   useConnectWallet,
   useCurrentAccount,
@@ -530,6 +531,9 @@ function ParticipationAccessEnabled({
               role="status"
             >
               <p className="text-base">投稿が完了しました。</p>
+              <p className="text-sm text-emerald-50">
+                次は履歴ギャラリーで参加記録を確認できます。
+              </p>
 
               {/* biome-ignore lint: local object URL preview, next/image N/A. */}
               <img
@@ -572,6 +576,15 @@ function ParticipationAccessEnabled({
               <p aria-live="polite" className="text-xs text-emerald-100/90">
                 {describeKakeraStatus(ownedKakera.status)}
               </p>
+
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  className="inline-flex items-center rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-white"
+                  href="/gallery"
+                >
+                  履歴ギャラリーを見る
+                </Link>
+              </div>
             </div>
           ) : null}
 

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -44,6 +44,7 @@ export type MockState = {
 };
 
 export type InstallMockOptions = {
+  readonly autoConnectWallet?: boolean;
   readonly executeApiMode?: "success" | "recovering_http_error";
   readonly transactionExecutionStatus?: "success" | "failed" | "unknown";
   readonly transactionBlockDelayMs?: number;
@@ -60,31 +61,34 @@ export async function installDefaultMocks(
   options: InstallMockOptions = {},
 ): Promise<MockState> {
   const state: MockState = { submitExecuted: false };
+  const autoConnectWallet = options.autoConnectWallet ?? true;
   const executeApiMode = options.executeApiMode ?? "success";
   const transactionExecutionStatus =
     options.transactionExecutionStatus ?? "success";
   const transactionBlockDelayMs = options.transactionBlockDelayMs ?? 0;
   const kakeraVisibleAfterExecute = options.kakeraVisibleAfterExecute ?? true;
 
-  await page.addInitScript(
-    ({ walletName, address }) => {
-      try {
-        window.localStorage.setItem(
-          "sui-dapp-kit:wallet-connection-info",
-          JSON.stringify({
-            state: {
-              lastConnectedWalletName: walletName,
-              lastConnectedAccountAddress: address,
-            },
-            version: 0,
-          }),
-        );
-      } catch {
-        // localStorage may be unavailable (iframe / privacy mode); swallow.
-      }
-    },
-    { walletName: E2E_STUB_WALLET_NAME, address: E2E_STUB_ACCOUNT_ADDRESS },
-  );
+  if (autoConnectWallet) {
+    await page.addInitScript(
+      ({ walletName, address }) => {
+        try {
+          window.localStorage.setItem(
+            "sui-dapp-kit:wallet-connection-info",
+            JSON.stringify({
+              state: {
+                lastConnectedWalletName: walletName,
+                lastConnectedAccountAddress: address,
+              },
+              version: 0,
+            }),
+          );
+        } catch {
+          // localStorage may be unavailable (iframe / privacy mode); swallow.
+        }
+      },
+      { walletName: E2E_STUB_WALLET_NAME, address: E2E_STUB_ACCOUNT_ADDRESS },
+    );
+  }
 
   await page.route(/fullnode\.[a-z]+\.sui\.io/, (route) =>
     handleSuiRpc(route, state, {

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -20,4 +20,26 @@ test.describe("home smoke", () => {
     await expect(athleteHeadings.first()).toBeVisible();
     expect(await athleteHeadings.count()).toBeGreaterThanOrEqual(1);
   });
+
+  test("navigates from the landing hero to the participation gallery", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+
+    await page.goto("/");
+
+    const historyLink = page.getByRole("link", {
+      name: /participation history/i,
+    });
+    await expect(historyLink).toBeVisible();
+
+    await historyLink.click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: /participation gallery/i,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -42,4 +42,22 @@ test.describe("home smoke", () => {
       }),
     ).toBeVisible();
   });
+
+  test("shows a connect action in the gallery for signed-out visitors", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { autoConnectWallet: false });
+
+    await page.goto("/");
+    await page.getByRole("link", { name: /participation history/i }).click();
+
+    await expect(
+      page.getByText(
+        /Connect a wallet to view your Kakera participation history/i,
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Google でログイン" }),
+    ).toBeVisible();
+  });
 });

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -57,6 +57,31 @@ test.describe("submit happy path", () => {
     });
   });
 
+  test("shows a gallery CTA after successful submission on mobile", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await installDefaultMocks(page);
+    await submitPhoto(page);
+
+    const galleryLink = page.getByRole("link", {
+      name: "履歴ギャラリーを見る",
+    });
+    await expect(galleryLink).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByText("次は履歴ギャラリーで参加記録を確認できます。"),
+    ).toBeVisible();
+
+    await galleryLink.click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: /participation gallery/i,
+      }),
+    ).toBeVisible();
+  });
+
   test("recovers to the participation card when execute HTTP fails but the digest confirms success", async ({
     page,
   }) => {

--- a/apps/web/tests/e2e/waiting-room-smoke.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+
+test.describe("waiting room smoke", () => {
+  test("navigates from the waiting room to the participation gallery", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+
+    await page.goto(`/units/${STUB_UNIT_ID}`);
+
+    const historyLink = page.getByRole("link", {
+      name: /participation history/i,
+    });
+    await expect(historyLink).toBeVisible();
+
+    await historyLink.click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: /participation gallery/i,
+      }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要
トップページ、待機室、投稿完了後の 3 か所から ` /gallery ` へ進めるようにしました。
あわせて、ギャラリー側に Google ログイン導線と再確認導線を追加し、遷移先が行き止まりにならないようにしました。

## 変更内容
- `apps/web/src/app/page.tsx`
  - ヒーローに `Participation history` CTA を追加
- `apps/web/src/app/units/[unitId]/page.tsx`
  - 待機室の上段ナビに `Participation history` CTA を追加
- `apps/web/src/app/units/[unitId]/participation-access.tsx`
  - 投稿完了カードに案内文言と `履歴ギャラリーを見る` CTA を追加
- `apps/web/src/app/gallery/gallery-client.tsx`
  - 未接続時の Google ログイン導線を追加
  - 空状態と一時失敗状態に `もう一度確認する` を追加
- `apps/web/src/app/**/*.test.tsx`
  - 新しい導線と受け皿のユニットテストを追加
- `apps/web/tests/e2e/*.spec.ts`
  - ホーム、待機室、投稿完了後、signed-out ギャラリー導線の E2E を追加

## 関連する Issue やチケット
Close #23

## 動作確認
- `corepack pnpm --filter web check`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web test`
- `corepack pnpm --filter web build`
- `OP_LOCAL_FINALIZE_URL=http://127.0.0.1:8080 corepack pnpm --filter web exec playwright test tests/e2e/home-smoke.spec.ts tests/e2e/waiting-room-smoke.spec.ts tests/e2e/submit-happy.spec.ts`
