### PR TITLE
fix: ギャラリーを未接続でも自力で開始できるUXにする

### DIFF
--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -301,7 +301,8 @@ describe("GalleryClient", () => {
       });
     });
 
-    expect(screen.getByText(/No Kakera found for this wallet/i)).toBeTruthy();
+    expect(screen.getByText("Empty")).toBeTruthy();
+    expect(screen.getByText(/まだ Kakera が見つかりません。/)).toBeTruthy();
     expect(
       screen.getByText(
         /投稿直後なら、少し待ってからもう一度確認してください。/,
@@ -310,6 +311,42 @@ describe("GalleryClient", () => {
     expect(
       screen.getByRole("button", { name: "もう一度確認する" }),
     ).toBeTruthy();
+  });
+
+  it("shows a fetch failure shell when Kakera loading fails", async () => {
+    useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
+    listOwnedKakeraMock.mockRejectedValue(new Error("rpc down"));
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unavailable")).toBeTruthy();
+    });
+
+    expect(screen.getByText(/履歴を読み込めませんでした。/)).toBeTruthy();
+    expect(
+      screen.getByText(/時間をおいて、もう一度確認してください。/),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "もう一度確認する" }),
+    ).toBeTruthy();
+  });
+
+  it("shows a config-missing shell without a retry action", () => {
+    useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
+
+    render(<GalleryClient catalog={CATALOG} packageId="" />);
+
+    expect(screen.getByText("Unavailable")).toBeTruthy();
+    expect(screen.getByText(/公開設定を確認できません。/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Sui 接続の公開設定が不足しているため、ギャラリーを開けません。/,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "もう一度確認する" }),
+    ).toBeNull();
   });
 
   it("reloads the gallery when the user asks to check again", async () => {

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -136,11 +136,31 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
     expect(
-      screen.getByText(/Connect a wallet to view your Kakera/i),
+      screen.getByText(
+        /先に Google でログインすると、あなたの Kakera 履歴を読み込めます。/,
+      ),
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Google でログイン" }),
     ).toBeTruthy();
+    expect(listOwnedKakeraMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the signed-out shell until an account becomes available", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useConnectWalletMock.mockReturnValue({ mutateAsync });
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        wallet: { id: "google-wallet" },
+      });
+    });
+
+    expect(screen.queryByText(/^Loading$/i)).toBeNull();
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
   });
 
@@ -157,6 +177,70 @@ describe("GalleryClient", () => {
         wallet: { id: "google-wallet" },
       });
     });
+  });
+
+  it("shows a retry login action when wallet connection fails", async () => {
+    useConnectWalletMock.mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("ログインに失敗しました。")),
+    });
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "ログインに失敗しました。",
+    );
+    expect(
+      screen.getByRole("button", { name: "もう一度ログイン" }),
+    ).toBeTruthy();
+  });
+
+  it("shows a connecting label while login is in progress", () => {
+    useCurrentWalletMock.mockReturnValue({
+      connectionStatus: "connecting",
+    });
+
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    const button = screen.getByRole("button", { name: "ログイン中…" });
+
+    expect(button.getAttribute("disabled")).not.toBeNull();
+  });
+
+  it("starts loading only after the account address becomes available", async () => {
+    let resolveListOwnedKakera: ((value: OwnedKakera[]) => void) | null = null;
+    listOwnedKakeraMock.mockImplementation(
+      () =>
+        new Promise<OwnedKakera[]>((resolve) => {
+          resolveListOwnedKakera = resolve;
+        }),
+    );
+
+    const { rerender } = render(
+      <GalleryClient catalog={CATALOG} packageId="0xpkg" />,
+    );
+
+    expect(screen.queryByText(/^Loading$/i)).toBeNull();
+    expect(listOwnedKakeraMock).not.toHaveBeenCalled();
+
+    useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
+    rerender(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Loading$/i)).toBeTruthy();
+    });
+
+    expect(
+      screen.getByText(/ログインを確認できました。Sui から Kakera を読んでいます。/),
+    ).toBeTruthy();
+    expect(listOwnedKakeraMock).toHaveBeenCalledWith({
+      ownerAddress: "0xviewer",
+      packageId: "0xpkg",
+      suiClient: { network: "testnet" },
+    });
+
+    resolveListOwnedKakera?.([]);
   });
 
   it("renders demo entries without requiring a connected wallet", async () => {

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -181,7 +181,9 @@ describe("GalleryClient", () => {
 
   it("shows a retry login action when wallet connection fails", async () => {
     useConnectWalletMock.mockReturnValue({
-      mutateAsync: vi.fn().mockRejectedValue(new Error("ログインに失敗しました。")),
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(new Error("ログインに失敗しました。")),
     });
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
@@ -209,7 +211,7 @@ describe("GalleryClient", () => {
   });
 
   it("starts loading only after the account address becomes available", async () => {
-    let resolveListOwnedKakera: ((value: OwnedKakera[]) => void) | null = null;
+    let resolveListOwnedKakera: ((value: OwnedKakera[]) => void) | undefined;
     listOwnedKakeraMock.mockImplementation(
       () =>
         new Promise<OwnedKakera[]>((resolve) => {
@@ -232,7 +234,9 @@ describe("GalleryClient", () => {
     });
 
     expect(
-      screen.getByText(/ログインを確認できました。Sui から Kakera を読んでいます。/),
+      screen.getByText(
+        /ログインを確認できました。Sui から Kakera を読んでいます。/,
+      ),
     ).toBeTruthy();
     expect(listOwnedKakeraMock).toHaveBeenCalledWith({
       ownerAddress: "0xviewer",
@@ -240,7 +244,11 @@ describe("GalleryClient", () => {
       suiClient: { network: "testnet" },
     });
 
-    resolveListOwnedKakera?.([]);
+    if (!resolveListOwnedKakera) {
+      throw new Error("listOwnedKakera resolver was not set");
+    }
+
+    resolveListOwnedKakera([]);
   });
 
   it("renders demo entries without requiring a connected wallet", async () => {

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -14,7 +14,7 @@ import { getDemoModeSource, isDemoModeEnabled } from "../../lib/demo";
 import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 import { getGalleryEntry, getSuiClient, listOwnedKakera } from "../../lib/sui";
 
-type GalleryClientProps = {
+export type GalleryClientProps = {
   readonly catalog: readonly AthleteCatalogEntry[];
   readonly demoEntries?: readonly GalleryRenderableEntry[];
   readonly packageId: string;
@@ -59,6 +59,45 @@ export function GalleryClient({
   demoEntries,
   packageId,
 }: GalleryClientProps): React.ReactElement {
+  const [failedOriginalBlobIds, setFailedOriginalBlobIds] = useState<
+    readonly string[]
+  >([]);
+  if (demoEntries) {
+    return (
+      <GalleryEntriesSection
+        catalog={catalog}
+        entries={demoEntries}
+        failedOriginalBlobIds={failedOriginalBlobIds}
+        onOriginalImageError={(walrusBlobId) => {
+          setFailedOriginalBlobIds((current) => {
+            if (current.includes(walrusBlobId)) {
+              return current;
+            }
+            return [...current, walrusBlobId];
+          });
+        }}
+      />
+    );
+  }
+
+  if (!packageId) {
+    return (
+      <GalleryStatusShell
+        description="Sui 接続の公開設定が不足しているため、ギャラリーを開けません。"
+        label="Unavailable"
+        title="公開設定を確認できません。"
+        tone="warning"
+      />
+    );
+  }
+
+  return <ConnectedGalleryClient catalog={catalog} packageId={packageId} />;
+}
+
+function ConnectedGalleryClient({
+  catalog,
+  packageId,
+}: Omit<GalleryClientProps, "demoEntries">): React.ReactElement {
   const currentAccount = useCurrentAccount();
   const currentWallet = useCurrentWallet();
   const wallets = useWallets();
@@ -90,18 +129,9 @@ export function GalleryClient({
   }
 
   useEffect(() => {
-    if (demoEntries) {
+    if (!currentAccount?.address) {
       setState({
-        kind: "ready",
-        entries: demoEntries,
-      });
-      setFailedOriginalBlobIds([]);
-      return;
-    }
-
-    if (!currentAccount?.address || !packageId) {
-      setState({
-        kind: currentAccount?.address ? "error" : "idle",
+        kind: "idle",
         entries: [],
       });
       setFailedOriginalBlobIds([]);
@@ -169,9 +199,9 @@ export function GalleryClient({
     return () => {
       cancelled = true;
     };
-  }, [currentAccount?.address, demoEntries, packageId, reloadNonce]);
+  }, [currentAccount?.address, packageId, reloadNonce]);
 
-  if (!demoEntries && !currentAccount?.address) {
+  if (!currentAccount?.address) {
     return (
       <GalleryStatusShell
         description="先に Google でログインすると、あなたの Kakera 履歴を読み込めます。"
@@ -207,18 +237,7 @@ export function GalleryClient({
     );
   }
 
-  if (!demoEntries && !packageId) {
-    return (
-      <GalleryStatusShell
-        description="Sui 接続の公開設定が不足しているため、ギャラリーを開けません。"
-        label="Unavailable"
-        title="公開設定を確認できません。"
-        tone="warning"
-      />
-    );
-  }
-
-  if (!demoEntries && state.kind === "error") {
+  if (state.kind === "error") {
     return (
       <GalleryStatusShell
         description="時間をおいて、もう一度確認してください。"
@@ -276,8 +295,38 @@ export function GalleryClient({
   }
 
   return (
+    <GalleryEntriesSection
+      catalog={catalog}
+      entries={state.entries}
+      failedOriginalBlobIds={failedOriginalBlobIds}
+      onOriginalImageError={(walrusBlobId) => {
+        setFailedOriginalBlobIds((current) => {
+          if (current.includes(walrusBlobId)) {
+            return current;
+          }
+          return [...current, walrusBlobId];
+        });
+      }}
+    />
+  );
+}
+
+type GalleryEntriesSectionProps = {
+  readonly catalog: readonly AthleteCatalogEntry[];
+  readonly entries: readonly GalleryRenderableEntry[];
+  readonly failedOriginalBlobIds: readonly string[];
+  readonly onOriginalImageError: (walrusBlobId: string) => void;
+};
+
+function GalleryEntriesSection({
+  catalog,
+  entries,
+  failedOriginalBlobIds,
+  onOriginalImageError,
+}: GalleryEntriesSectionProps): React.ReactElement {
+  return (
     <section className="grid gap-6 md:grid-cols-2">
-      {state.entries.map((entry) => (
+      {entries.map((entry) => (
         <GalleryCard
           athlete={findAthlete(catalog, entry.athletePublicId)}
           entry={entry}
@@ -286,12 +335,7 @@ export function GalleryClient({
             entry.walrusBlobId,
           )}
           onOriginalImageError={() => {
-            setFailedOriginalBlobIds((current) => {
-              if (current.includes(entry.walrusBlobId)) {
-                return current;
-              }
-              return [...current, entry.walrusBlobId];
-            });
+            onOriginalImageError(entry.walrusBlobId);
           }}
         />
       ))}
@@ -341,9 +385,7 @@ function GalleryStatusShell({
           };
 
   return (
-    <section
-      className={`rounded-[1.75rem] border p-7 ${toneClasses.shell}`}
-    >
+    <section className={`rounded-[1.75rem] border p-7 ${toneClasses.shell}`}>
       <p className={`text-xs uppercase tracking-[0.3em] ${toneClasses.label}`}>
         {label}
       </p>

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -173,13 +173,11 @@ export function GalleryClient({
 
   if (!demoEntries && !currentAccount?.address) {
     return (
-      <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
-        <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
-          Wallet required
-        </p>
-        <p className="mt-3 text-slate-200">
-          先に Google でログインすると、あなたの Kakera 履歴を読み込めます。
-        </p>
+      <GalleryStatusShell
+        description="先に Google でログインすると、あなたの Kakera 履歴を読み込めます。"
+        label="Wallet required"
+        tone="info"
+      >
         <div className="mt-4 flex flex-wrap gap-3">
           <button
             className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
@@ -205,60 +203,29 @@ export function GalleryClient({
             {connectError}
           </p>
         ) : null}
-      </section>
+      </GalleryStatusShell>
     );
   }
 
-  if (!demoEntries && (!packageId || state.kind === "error")) {
+  if (!demoEntries && !packageId) {
     return (
-      <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
-        <p className="text-xs uppercase tracking-[0.3em] text-amber-200/80">
-          Unavailable
-        </p>
-        <p className="mt-3 text-slate-200">
-          Gallery unavailable right now. Check the public Sui configuration and
-          try again.
-        </p>
-        {packageId ? (
-          <div className="mt-4 flex flex-wrap gap-3">
-            <button
-              className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
-              onClick={() => {
-                setReloadNonce((current) => current + 1);
-              }}
-              type="button"
-            >
-              もう一度確認する
-            </button>
-          </div>
-        ) : null}
-      </section>
+      <GalleryStatusShell
+        description="Sui 接続の公開設定が不足しているため、ギャラリーを開けません。"
+        label="Unavailable"
+        title="公開設定を確認できません。"
+        tone="warning"
+      />
     );
   }
 
-  if (state.kind === "loading") {
+  if (!demoEntries && state.kind === "error") {
     return (
-      <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
-        <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
-          Loading
-        </p>
-        <p className="mt-3 text-slate-200">
-          ログインを確認できました。Sui から Kakera を読んでいます。
-        </p>
-      </section>
-    );
-  }
-
-  if (state.entries.length === 0) {
-    return (
-      <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-7">
-        <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
-          Empty
-        </p>
-        <p className="mt-3 text-slate-200">No Kakera found for this wallet.</p>
-        <p className="mt-2 text-sm text-slate-300">
-          投稿直後なら、少し待ってからもう一度確認してください。
-        </p>
+      <GalleryStatusShell
+        description="時間をおいて、もう一度確認してください。"
+        label="Unavailable"
+        title="履歴を読み込めませんでした。"
+        tone="warning"
+      >
         <div className="mt-4 flex flex-wrap gap-3">
           <button
             className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
@@ -270,7 +237,41 @@ export function GalleryClient({
             もう一度確認する
           </button>
         </div>
-      </section>
+      </GalleryStatusShell>
+    );
+  }
+
+  if (state.kind === "loading") {
+    return (
+      <GalleryStatusShell
+        description="ログインを確認できました。Sui から Kakera を読んでいます。"
+        label="Loading"
+        tone="info"
+      />
+    );
+  }
+
+  if (state.entries.length === 0) {
+    return (
+      <GalleryStatusShell
+        description="まだ Kakera が見つかりません。"
+        label="Empty"
+        note="投稿直後なら、少し待ってからもう一度確認してください。"
+        title="このウォレットの履歴はまだ空です。"
+        tone="empty"
+      >
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+            onClick={() => {
+              setReloadNonce((current) => current + 1);
+            }}
+            type="button"
+          >
+            もう一度確認する
+          </button>
+        </div>
+      </GalleryStatusShell>
     );
   }
 
@@ -304,6 +305,56 @@ function toMessage(error: unknown): string {
   }
 
   return "処理に失敗しました。時間をおいて、もう一度お試しください。";
+}
+
+type GalleryStatusShellProps = {
+  readonly label: string;
+  readonly description: string;
+  readonly title?: string;
+  readonly note?: string;
+  readonly tone: "info" | "warning" | "empty";
+  readonly children?: React.ReactNode;
+};
+
+function GalleryStatusShell({
+  label,
+  description,
+  title,
+  note,
+  tone,
+  children,
+}: GalleryStatusShellProps): React.ReactElement {
+  const toneClasses =
+    tone === "warning"
+      ? {
+          shell: "border-amber-300/20 bg-amber-400/10",
+          label: "text-amber-200/80",
+        }
+      : tone === "empty"
+        ? {
+            shell: "border-emerald-300/20 bg-emerald-400/10",
+            label: "text-emerald-200/80",
+          }
+        : {
+            shell: "border-cyan-300/20 bg-cyan-400/10",
+            label: "text-cyan-200/80",
+          };
+
+  return (
+    <section
+      className={`rounded-[1.75rem] border p-7 ${toneClasses.shell}`}
+    >
+      <p className={`text-xs uppercase tracking-[0.3em] ${toneClasses.label}`}>
+        {label}
+      </p>
+      {title ? (
+        <h2 className="mt-3 font-serif text-2xl text-white">{title}</h2>
+      ) : null}
+      <p className="mt-3 text-slate-100">{description}</p>
+      {note ? <p className="mt-2 text-sm text-slate-200">{note}</p> : null}
+      {children}
+    </section>
+  );
 }
 
 type GalleryCardProps = {

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -178,7 +178,7 @@ export function GalleryClient({
           Wallet required
         </p>
         <p className="mt-3 text-slate-200">
-          Connect a wallet to view your Kakera participation history.
+          先に Google でログインすると、あなたの Kakera 履歴を読み込めます。
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <button
@@ -189,7 +189,11 @@ export function GalleryClient({
             }}
             type="button"
           >
-            {connectError ? "もう一度ログイン" : "Google でログイン"}
+            {isConnecting
+              ? "ログイン中…"
+              : connectError
+                ? "もう一度ログイン"
+                : "Google でログイン"}
           </button>
         </div>
         {connectError ? (
@@ -238,7 +242,9 @@ export function GalleryClient({
         <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
           Loading
         </p>
-        <p className="mt-3 text-slate-200">Reading owned Kakera from Sui…</p>
+        <p className="mt-3 text-slate-200">
+          ログインを確認できました。Sui から Kakera を読んでいます。
+        </p>
       </section>
     );
   }

--- a/apps/web/src/app/gallery/gallery-page-client.tsx
+++ b/apps/web/src/app/gallery/gallery-page-client.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { GalleryClientProps } from "./gallery-client";
+
+const GalleryClient = dynamic<GalleryClientProps>(
+  () => import("./gallery-client").then((module) => module.GalleryClient),
+  {
+    ssr: false,
+    loading: () => (
+      <section className="rounded-[1.75rem] border border-cyan-300/20 bg-cyan-400/10 p-7">
+        <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
+          Loading
+        </p>
+        <p className="mt-3 text-slate-100">ギャラリーを準備しています。</p>
+      </section>
+    ),
+  },
+);
+
+export function GalleryPageClient(
+  props: GalleryClientProps,
+): React.ReactElement {
+  return <GalleryClient {...props} />;
+}

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -8,13 +8,13 @@ const {
   getDemoGalleryEntriesMock,
   isDemoModeEnabledMock,
   loadPublicEnvMock,
-  galleryClientMock,
+  galleryPageClientMock,
 } = vi.hoisted(() => ({
   getAthleteCatalogMock: vi.fn(),
   getDemoGalleryEntriesMock: vi.fn(),
   isDemoModeEnabledMock: vi.fn(),
   loadPublicEnvMock: vi.fn(),
-  galleryClientMock: vi.fn(),
+  galleryPageClientMock: vi.fn(),
 }));
 
 vi.mock("../../lib/catalog", () => ({
@@ -30,8 +30,8 @@ vi.mock("../../lib/demo", () => ({
   isDemoModeEnabled: isDemoModeEnabledMock,
 }));
 
-vi.mock("./gallery-client", () => ({
-  GalleryClient: ({
+vi.mock("./gallery-page-client", () => ({
+  GalleryPageClient: ({
     catalog,
     demoEntries,
     packageId,
@@ -50,7 +50,7 @@ vi.mock("./gallery-client", () => ({
       data-package-id={packageId}
       data-testid="gallery-client"
       ref={() => {
-        galleryClientMock({ catalog, demoEntries, packageId });
+        galleryPageClientMock({ catalog, demoEntries, packageId });
       }}
     >
       {catalog.length} athletes
@@ -80,7 +80,7 @@ afterEach(() => {
   getDemoGalleryEntriesMock.mockReset();
   isDemoModeEnabledMock.mockReset();
   loadPublicEnvMock.mockReset();
-  galleryClientMock.mockReset();
+  galleryPageClientMock.mockReset();
 });
 
 describe("GalleryPage", () => {
@@ -104,7 +104,7 @@ describe("GalleryPage", () => {
     expect(
       screen.getByTestId("gallery-client").getAttribute("data-package-id"),
     ).toBe("0xpkg");
-    expect(galleryClientMock).toHaveBeenCalledWith({
+    expect(galleryPageClientMock).toHaveBeenCalledWith({
       catalog: CATALOG,
       demoEntries: undefined,
       packageId: "0xpkg",
@@ -190,7 +190,7 @@ describe("GalleryPage", () => {
     expect(
       screen.getByTestId("gallery-client").getAttribute("data-package-id"),
     ).toBe("");
-    expect(galleryClientMock).toHaveBeenCalledWith({
+    expect(galleryPageClientMock).toHaveBeenCalledWith({
       catalog: CATALOG,
       demoEntries: undefined,
       packageId: "",

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -175,4 +175,25 @@ describe("GalleryPage", () => {
       screen.getByTestId("gallery-client").getAttribute("data-package-id"),
     ).toBe("");
   });
+
+  it("falls back to an empty packageId when public env loading fails", async () => {
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([]);
+    isDemoModeEnabledMock.mockReturnValue(false);
+    loadPublicEnvMock.mockImplementation(() => {
+      throw new Error("missing public env");
+    });
+
+    const ui = await GalleryPage();
+    render(ui);
+
+    expect(
+      screen.getByTestId("gallery-client").getAttribute("data-package-id"),
+    ).toBe("");
+    expect(galleryClientMock).toHaveBeenCalledWith({
+      catalog: CATALOG,
+      demoEntries: undefined,
+      packageId: "",
+    });
+  });
 });

--- a/apps/web/src/app/gallery/page.tsx
+++ b/apps/web/src/app/gallery/page.tsx
@@ -4,7 +4,7 @@ import { getAthleteCatalog } from "../../lib/catalog";
 import { getDemoGalleryEntries, isDemoModeEnabled } from "../../lib/demo";
 import { loadPublicEnv } from "../../lib/env";
 
-import { GalleryClient } from "./gallery-client";
+import { GalleryPageClient } from "./gallery-page-client";
 
 export const dynamic = "force-dynamic";
 
@@ -40,7 +40,7 @@ export default async function GalleryPage(): Promise<React.ReactElement> {
           </p>
         </header>
 
-        <GalleryClient
+        <GalleryPageClient
           catalog={catalog}
           demoEntries={demoEntries}
           packageId={packageId ?? ""}

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -54,7 +54,7 @@ test.describe("home smoke", () => {
 
     await expect(
       page.getByText(
-        /Connect a wallet to view your Kakera participation history/i,
+        /先に Google でログインすると、あなたの Kakera 履歴を読み込めます。/,
       ),
     ).toBeVisible();
     await expect(


### PR DESCRIPTION
## 概要
`/gallery` で未接続ユーザーがその場で開始できる導線を整えました。
状態ごとの見え方を分け、実機確認で見つかった `WalletContext` の runtime 500 も合わせて解消しています。

## 変更内容
- `apps/web/src/app/gallery/gallery-client.tsx`
  - 未接続、loading、empty、fetch failed、config missing の shell を分離しました
  - ログイン失敗時の retry 表示と、アカウント取得後にだけ loading が始まる導線を整理しました
  - demo / config missing を wallet hooks より先に分岐し、provider 不在時の crash を防ぎました
- `apps/web/src/app/gallery/gallery-page-client.tsx`
  - `GalleryClient` を client-only wrapper 経由で読み込むようにしました
- `apps/web/src/app/gallery/page.tsx`
  - page から wrapper を使う構成に差し替えました
- `apps/web/src/app/gallery/gallery-client.test.tsx`
  - 未接続、login 失敗、loading 開始条件、empty、fetch failed、config missing の回帰テストを追加しました
- `apps/web/src/app/gallery/page.test.tsx`
  - `packageId` 受け渡しと env 読み出し失敗時の退避経路を確認するテストに更新しました

## 関連する Issue やチケット
Close #24

## 動作確認
- `corepack pnpm run check`
- `corepack pnpm --filter web build`
- production start で `/gallery` を確認
- public env なしの build/start で config missing shell を確認
- public env を与えた build/start で 390x844 viewport の `Google でログイン` CTA と補助文言が見切れないことを確認
