### PR TITLE
test: Playwright E2Eの状態別カバレッジを広げる

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -81,6 +81,7 @@ afterEach(() => {
   isDemoModeEnabledMock.mockReset();
   loadPublicEnvMock.mockReset();
   galleryPageClientMock.mockReset();
+  delete process.env.NEXT_PUBLIC_E2E_STUB_WALLET;
 });
 
 describe("GalleryPage", () => {
@@ -194,6 +195,61 @@ describe("GalleryPage", () => {
       catalog: CATALOG,
       demoEntries: undefined,
       packageId: "",
+    });
+  });
+
+  it("uses the request-scoped gallery selector only when the E2E stub wallet is enabled", async () => {
+    process.env.NEXT_PUBLIC_E2E_STUB_WALLET = "1";
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([]);
+    isDemoModeEnabledMock.mockReturnValue(false);
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      registryObjectId: "0xregistry",
+      packageId: "0xpkg",
+    });
+
+    const ui = await GalleryPage({
+      searchParams: Promise.resolve({
+        op_e2e_gallery_state: "config-missing",
+      }),
+    });
+    render(ui);
+
+    expect(
+      screen.getByTestId("gallery-client").getAttribute("data-package-id"),
+    ).toBe("");
+    expect(galleryPageClientMock).toHaveBeenCalledWith({
+      catalog: CATALOG,
+      demoEntries: undefined,
+      packageId: "",
+    });
+  });
+
+  it("ignores the gallery selector in normal runtime", async () => {
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+    getDemoGalleryEntriesMock.mockReturnValue([]);
+    isDemoModeEnabledMock.mockReturnValue(false);
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      registryObjectId: "0xregistry",
+      packageId: "0xpkg",
+    });
+
+    const ui = await GalleryPage({
+      searchParams: Promise.resolve({
+        op_e2e_gallery_state: "config-missing",
+      }),
+    });
+    render(ui);
+
+    expect(
+      screen.getByTestId("gallery-client").getAttribute("data-package-id"),
+    ).toBe("0xpkg");
+    expect(galleryPageClientMock).toHaveBeenCalledWith({
+      catalog: CATALOG,
+      demoEntries: undefined,
+      packageId: "0xpkg",
     });
   });
 });

--- a/apps/web/src/app/gallery/page.tsx
+++ b/apps/web/src/app/gallery/page.tsx
@@ -8,9 +8,18 @@ import { GalleryPageClient } from "./gallery-page-client";
 
 export const dynamic = "force-dynamic";
 
-export default async function GalleryPage(): Promise<React.ReactElement> {
+type GalleryPageProps = {
+  readonly searchParams?: Promise<{
+    readonly op_e2e_gallery_state?: string;
+  }>;
+};
+
+export default async function GalleryPage(
+  props: GalleryPageProps = {},
+): Promise<React.ReactElement> {
   const catalog = await getAthleteCatalog();
-  const packageId = safePackageId();
+  const searchParams = (await props.searchParams) ?? {};
+  const packageId = safePackageId(searchParams.op_e2e_gallery_state);
   const demoEntries = isDemoModeEnabled(process.env)
     ? getDemoGalleryEntries()
     : undefined;
@@ -50,10 +59,25 @@ export default async function GalleryPage(): Promise<React.ReactElement> {
   );
 }
 
-function safePackageId(): string | null {
+function safePackageId(
+  e2eGalleryState: string | undefined,
+): string | null {
+  if (shouldUseE2EGalleryConfigMissing(e2eGalleryState)) {
+    return null;
+  }
+
   try {
     return loadPublicEnv(process.env).packageId;
   } catch {
     return null;
   }
+}
+
+function shouldUseE2EGalleryConfigMissing(
+  e2eGalleryState: string | undefined,
+): boolean {
+  return (
+    process.env.NEXT_PUBLIC_E2E_STUB_WALLET === "1" &&
+    e2eGalleryState === "config-missing"
+  );
 }

--- a/apps/web/src/app/gallery/page.tsx
+++ b/apps/web/src/app/gallery/page.tsx
@@ -59,9 +59,7 @@ export default async function GalleryPage(
   );
 }
 
-function safePackageId(
-  e2eGalleryState: string | undefined,
-): string | null {
+function safePackageId(e2eGalleryState: string | undefined): string | null {
   if (shouldUseE2EGalleryConfigMissing(e2eGalleryState)) {
     return null;
   }

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -389,9 +389,7 @@ describe("UnitPage", () => {
     ).toBeTruthy();
     expect(
       screen.getByText(
-        new RegExp(
-          `${unitTileCount - 1}\\s*/\\s*${unitTileCount}`,
-        ),
+        new RegExp(`${unitTileCount - 1}\\s*/\\s*${unitTileCount}`),
       ),
     ).toBeTruthy();
   });

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -366,6 +366,36 @@ describe("UnitPage", () => {
     expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
   });
 
+  it("applies the active unit bootstrap only in stub E2E mode", async () => {
+    process.env.NEXT_PUBLIC_E2E_STUB_WALLET = "1";
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      registryObjectId: "0xreg",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-active" }),
+      searchParams: Promise.resolve({
+        athleteName: "Demo Athlete One",
+        op_e2e_unit_progress: "active",
+      }),
+    });
+    render(ui);
+
+    expect(getUnitProgressMock).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { name: "Demo Athlete One" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        new RegExp(
+          `${unitTileCount - 1}\\s*/\\s*${unitTileCount}`,
+        ),
+      ),
+    ).toBeTruthy();
+  });
+
   it("ignores the degraded unit seam outside stub E2E mode", async () => {
     getUnitProgressMock.mockResolvedValue({
       unitId: "0xunit-1",

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -44,16 +44,14 @@ export default async function UnitPage(
   const { unitId } = await props.params;
   const searchParams = await props.searchParams;
   const demoMode = isDemoModeEnabled(process.env);
-  const e2eDegradedProgress = shouldUseE2EDegradedUnitProgress(
+  const e2eBootstrapProgress = resolveE2EUnitProgress(
     searchParams.op_e2e_unit_progress,
   );
 
   const packageId = safePackageId();
   const progress = demoMode
     ? safeGetDemoUnitProgress(unitId)
-    : e2eDegradedProgress
-      ? degradedProgress()
-      : await safeGetUnitProgress(unitId);
+    : e2eBootstrapProgress ?? (await safeGetUnitProgress(unitId));
   const athlete = progress.athletePublicId
     ? await safeGetAthleteByPublicId(progress.athletePublicId)
     : null;
@@ -238,10 +236,29 @@ function degradedProgress(): ResolvedProgress {
   };
 }
 
-function shouldUseE2EDegradedUnitProgress(
+function resolveE2EUnitProgress(
   rawOverride: string | undefined,
-): boolean {
-  return (
-    process.env.NEXT_PUBLIC_E2E_STUB_WALLET === "1" && rawOverride === "missing"
-  );
+): ResolvedProgress | null {
+  if (process.env.NEXT_PUBLIC_E2E_STUB_WALLET !== "1" || !rawOverride) {
+    return null;
+  }
+
+  if (rawOverride === "missing") {
+    return degradedProgress();
+  }
+
+  if (rawOverride === "active") {
+    return activeProgress();
+  }
+
+  return null;
+}
+
+function activeProgress(): ResolvedProgress {
+  return {
+    submittedCount: FALLBACK_MAX_SLOTS - 1,
+    maxSlots: FALLBACK_MAX_SLOTS,
+    athletePublicId: "1",
+    masterId: null,
+  };
 }

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -51,7 +51,7 @@ export default async function UnitPage(
   const packageId = safePackageId();
   const progress = demoMode
     ? safeGetDemoUnitProgress(unitId)
-    : e2eBootstrapProgress ?? (await safeGetUnitProgress(unitId));
+    : (e2eBootstrapProgress ?? (await safeGetUnitProgress(unitId)));
   const athlete = progress.athletePublicId
     ? await safeGetAthleteByPublicId(progress.athletePublicId)
     : null;

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -80,6 +80,7 @@ export type InstallMockOptions = {
   readonly transactionExecutionStatus?: "success" | "failed" | "unknown";
   readonly transactionBlockDelayMs?: number;
   readonly kakeraVisibleAfterExecute?: boolean;
+  readonly waitingRoomEventMode?: "idle" | "active";
 };
 
 /**
@@ -111,6 +112,7 @@ export async function installDefaultMocks(
     options.transactionExecutionStatus ?? "success";
   const transactionBlockDelayMs = options.transactionBlockDelayMs ?? 0;
   const kakeraVisibleAfterExecute = options.kakeraVisibleAfterExecute ?? true;
+  const waitingRoomEventMode = options.waitingRoomEventMode ?? "idle";
 
   if (autoConnectWallet) {
     await page.addInitScript(
@@ -141,6 +143,7 @@ export async function installDefaultMocks(
       transactionExecutionStatus,
       transactionBlockDelayMs,
       kakeraVisibleAfterExecute,
+      waitingRoomEventMode,
     }),
   );
 
@@ -244,6 +247,7 @@ async function handleSuiRpc(
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
+      | "waitingRoomEventMode"
     >
   >,
 ): Promise<void> {
@@ -288,6 +292,7 @@ async function buildRouteResponse(
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
+      | "waitingRoomEventMode"
     >
   >,
 ): Promise<Record<string, unknown> | MockHttpResponse> {
@@ -314,6 +319,7 @@ async function buildResponse(
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
+      | "waitingRoomEventMode"
     >
   >,
 ): Promise<Record<string, unknown> | MockHttpResponse> {
@@ -334,7 +340,11 @@ async function buildResponse(
       return envelope(await handleGetTransactionBlock(state, options));
     case "suix_queryEvents":
       state.eventQueries += 1;
-      return envelope({ data: [], hasNextPage: false, nextCursor: null });
+      return envelope(
+        options.waitingRoomEventMode === "active"
+          ? buildWaitingRoomEventPage(state.eventQueries)
+          : { data: [], hasNextPage: false, nextCursor: null },
+      );
     case "suix_getOwnedObjects": {
       const ownedObjects = handleOwnedObjects(params, state, options);
       if (isMockHttpResponse(ownedObjects)) {
@@ -650,4 +660,104 @@ function safeParseJson(raw: string): unknown {
   } catch {
     return null;
   }
+}
+
+function buildWaitingRoomEventPage(
+  queryIndex: number,
+): Record<string, unknown> {
+  if (queryIndex === 1) {
+    return {
+      data: [
+        makeSubmittedEvent({
+          submittedCount: unitTileCount,
+          eventSeq: "1",
+        }),
+      ],
+      hasNextPage: true,
+      nextCursor: { txDigest: STUB_DIGEST, eventSeq: "1" },
+    };
+  }
+
+  if (queryIndex === 2) {
+    return {
+      data: [
+        makeUnitFilledEvent({ eventSeq: "2" }),
+        makeMosaicReadyEvent({ eventSeq: "3" }),
+        makeUnitFilledEvent({ eventSeq: "4" }),
+      ],
+      hasNextPage: false,
+      nextCursor: null,
+    };
+  }
+
+  return { data: [], hasNextPage: false, nextCursor: null };
+}
+
+function makeSubmittedEvent(opts: {
+  readonly submittedCount: number;
+  readonly eventSeq: string;
+}): Record<string, unknown> {
+  return makeEvent({
+    eventSeq: opts.eventSeq,
+    parsedJson: {
+      unit_id: STUB_UNIT_ID,
+      athlete_id: STUB_ATHLETE_ID,
+      submitter: E2E_STUB_ACCOUNT_ADDRESS,
+      walrus_blob_id: Array.from(new TextEncoder().encode(STUB_BLOB_ID)),
+      submission_no: STUB_SUBMISSION_NO,
+      submitted_count: opts.submittedCount,
+      max_slots: unitTileCount,
+    },
+    type: `${STUB_PACKAGE_ID}::events::SubmittedEvent`,
+  });
+}
+
+function makeUnitFilledEvent(opts: {
+  readonly eventSeq: string;
+}): Record<string, unknown> {
+  return makeEvent({
+    eventSeq: opts.eventSeq,
+    parsedJson: {
+      unit_id: STUB_UNIT_ID,
+      athlete_id: STUB_ATHLETE_ID,
+      filled_count: unitTileCount,
+      max_slots: unitTileCount,
+    },
+    type: `${STUB_PACKAGE_ID}::events::UnitFilledEvent`,
+  });
+}
+
+function makeMosaicReadyEvent(opts: {
+  readonly eventSeq: string;
+}): Record<string, unknown> {
+  return makeEvent({
+    eventSeq: opts.eventSeq,
+    parsedJson: {
+      unit_id: STUB_UNIT_ID,
+      athlete_id: STUB_ATHLETE_ID,
+      master_id: STUB_MASTER_ID,
+      mosaic_walrus_blob_id: Array.from(
+        new TextEncoder().encode(STUB_MOSAIC_BLOB_ID),
+      ),
+    },
+    type: `${STUB_PACKAGE_ID}::events::MosaicReadyEvent`,
+  });
+}
+
+function makeEvent(opts: {
+  readonly eventSeq: string;
+  readonly parsedJson: Record<string, unknown>;
+  readonly type: string;
+}): Record<string, unknown> {
+  return {
+    id: { txDigest: STUB_DIGEST, eventSeq: opts.eventSeq },
+    packageId: STUB_PACKAGE_ID,
+    transactionModule: "events",
+    sender: E2E_STUB_ACCOUNT_ADDRESS,
+    type: opts.type,
+    parsedJson: opts.parsedJson,
+    bcs: "",
+    bcsEncoding: "base64",
+    timestampMs: "0",
+  };
 }

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -24,13 +24,18 @@ import {
 export const STUB_UNIT_ID =
   "0x00000000000000000000000000000000000000000000000000000000000ab1e5";
 export const STUB_ATHLETE_ID = "1";
+export const STUB_MASTER_ID =
+  "0x00000000000000000000000000000000000000000000000000000000000ab1e6";
 export const STUB_REGISTRY_TABLE_ID =
   "0x0000000000000000000000000000000000000000000000000000000000001ab1e";
+export const STUB_PLACEMENTS_TABLE_ID =
+  "0x0000000000000000000000000000000000000000000000000000000000002ab1e";
 export const STUB_PACKAGE_ID =
   "0x0000000000000000000000000000000000000000000000000000000000000001";
 export const STUB_REGISTRY_OBJECT_ID =
   "0x0000000000000000000000000000000000000000000000000000000000000002";
 export const STUB_BLOB_ID = "STUB_BLOB_ID_XYZ";
+export const STUB_MOSAIC_BLOB_ID = "STUB_MOSAIC_BLOB_ID_XYZ";
 export const STUB_DIGEST = "4q49qZdCaTzeU2BP4mfQesc2dbt3h32Qn2rLHHwrBJne";
 export const STUB_KAKERA_OBJECT_ID =
   "0x00000000000000000000000000000000000000000000000000000000000ka123";
@@ -52,6 +57,18 @@ type MockHttpResponse = {
 export type InstallMockOptions = {
   readonly autoConnectWallet?: boolean;
   readonly executeApiMode?: "success" | "recovering_http_error";
+  /**
+   * Deterministic gallery switch used by the E2E suite:
+   * - `empty` keeps the original no-Kakera path
+   * - `completed` returns one hydrated completed entry
+   * - `hydration_error` returns one Kakera but makes the Unit lookup fail
+   */
+  readonly galleryEntryMode?: "empty" | "completed" | "hydration_error";
+  /**
+   * Deterministic original-image switch for completed cards.
+   * Only the original blob request fails; the mosaic request still resolves.
+   */
+  readonly originalImageMode?: "success" | "original_blob_not_found";
   readonly ownedObjectsFailuresBeforeSuccess?: number;
   readonly transactionExecutionStatus?: "success" | "failed" | "unknown";
   readonly transactionBlockDelayMs?: number;
@@ -70,6 +87,8 @@ export async function installDefaultMocks(
   const state: MockState = { submitExecuted: false, ownedObjectsCalls: 0 };
   const autoConnectWallet = options.autoConnectWallet ?? true;
   const executeApiMode = options.executeApiMode ?? "success";
+  const galleryEntryMode = options.galleryEntryMode ?? "empty";
+  const originalImageMode = options.originalImageMode ?? "success";
   const ownedObjectsFailuresBeforeSuccess =
     options.ownedObjectsFailuresBeforeSuccess ?? 0;
   const transactionExecutionStatus =
@@ -102,6 +121,7 @@ export async function installDefaultMocks(
   await page.route(/fullnode\.[a-z]+\.sui\.io/, (route) =>
     handleSuiRpc(route, state, {
       ownedObjectsFailuresBeforeSuccess,
+      galleryEntryMode,
       transactionExecutionStatus,
       transactionBlockDelayMs,
       kakeraVisibleAfterExecute,
@@ -156,6 +176,22 @@ export async function installDefaultMocks(
   });
 
   await page.route("**/aggregator.e2e.stub/**", async (route) => {
+    const url = route.request().url();
+    if (
+      originalImageMode === "original_blob_not_found" &&
+      url.includes(`/v1/blobs/${STUB_BLOB_ID}`)
+    ) {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "blob_not_found",
+          message: "mock original image unavailable",
+        }),
+      });
+      return;
+    }
+
     await route.fulfill({
       status: 200,
       contentType: "application/octet-stream",
@@ -173,6 +209,7 @@ async function handleSuiRpc(
     Pick<
       InstallMockOptions,
       | "ownedObjectsFailuresBeforeSuccess"
+      | "galleryEntryMode"
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
@@ -216,6 +253,7 @@ async function buildRouteResponse(
     Pick<
       InstallMockOptions,
       | "ownedObjectsFailuresBeforeSuccess"
+      | "galleryEntryMode"
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
@@ -258,9 +296,9 @@ async function buildResponse(
 
   switch (method) {
     case "sui_getObject":
-      return envelope(handleGetObject(params));
+      return envelope(handleGetObject(params, options.galleryEntryMode));
     case "suix_getDynamicFieldObject":
-      return envelope(handleDynamicField(params));
+      return envelope(handleDynamicField(params, options.galleryEntryMode));
     case "sui_getTransactionBlock":
       return envelope(await handleGetTransactionBlock(state, options));
     case "suix_queryEvents":
@@ -322,7 +360,10 @@ async function handleGetTransactionBlock(
   };
 }
 
-function handleGetObject(params: readonly unknown[]): unknown {
+function handleGetObject(
+  params: readonly unknown[],
+  galleryEntryMode: Required<InstallMockOptions>["galleryEntryMode"],
+): unknown {
   const id = typeof params[0] === "string" ? params[0] : "";
   if (id === STUB_REGISTRY_OBJECT_ID) {
     return {
@@ -350,6 +391,10 @@ function handleGetObject(params: readonly unknown[]): unknown {
   }
 
   if (id === STUB_UNIT_ID) {
+    if (galleryEntryMode === "hydration_error") {
+      return { data: null };
+    }
+
     return {
       data: {
         objectId: STUB_UNIT_ID,
@@ -361,11 +406,54 @@ function handleGetObject(params: readonly unknown[]): unknown {
           type: `${STUB_PACKAGE_ID}::unit::Unit`,
           hasPublicTransfer: false,
           fields: {
-            status: 0,
+            id: { id: STUB_UNIT_ID },
+            status: galleryEntryMode === "completed" ? 2 : 0,
+            target_walrus_blob: [],
             submissions: [],
             max_slots: String(unitTileCount),
-            athlete_id: STUB_ATHLETE_ID,
-            master_id: { fields: { vec: [] } },
+            athlete_id: Number(STUB_ATHLETE_ID),
+            submitters: {
+              type: "0x2::table::Table<address, bool>",
+              fields: {
+                id: { id: "0xsubmitters" },
+                size: "1",
+              },
+            },
+            master_id:
+              galleryEntryMode === "completed"
+                ? { fields: { vec: [STUB_MASTER_ID] } }
+                : { fields: { vec: [] } },
+          },
+        },
+      },
+    };
+  }
+
+  if (id === STUB_MASTER_ID && galleryEntryMode === "completed") {
+    return {
+      data: {
+        objectId: STUB_MASTER_ID,
+        version: "1",
+        digest: "master-digest",
+        type: `${STUB_PACKAGE_ID}::master_portrait::MasterPortrait`,
+        content: {
+          dataType: "moveObject",
+          type: `${STUB_PACKAGE_ID}::master_portrait::MasterPortrait`,
+          hasPublicTransfer: true,
+          fields: {
+            id: { id: STUB_MASTER_ID },
+            unit_id: STUB_UNIT_ID,
+            athlete_id: Number(STUB_ATHLETE_ID),
+            mosaic_walrus_blob_id: Array.from(
+              new TextEncoder().encode(STUB_MOSAIC_BLOB_ID),
+            ),
+            placements: {
+              type: `0x2::table::Table<vector<u8>, ${STUB_PACKAGE_ID}::master_portrait::Placement>`,
+              fields: {
+                id: { id: STUB_PLACEMENTS_TABLE_ID },
+                size: "1",
+              },
+            },
           },
         },
       },
@@ -375,28 +463,67 @@ function handleGetObject(params: readonly unknown[]): unknown {
   return { data: null };
 }
 
-function handleDynamicField(params: readonly unknown[]): unknown {
+function handleDynamicField(
+  params: readonly unknown[],
+  galleryEntryMode: Required<InstallMockOptions>["galleryEntryMode"],
+): unknown {
   const parentId = typeof params[0] === "string" ? params[0] : "";
-  if (parentId !== STUB_REGISTRY_TABLE_ID) {
+  if (parentId === STUB_REGISTRY_TABLE_ID) {
+    return {
+      data: {
+        objectId:
+          "0x00000000000000000000000000000000000000000000000000000000000df001",
+        version: "1",
+        digest: "df-digest",
+        type: `0x2::dynamic_field::Field<u16, 0x2::object::ID>`,
+        content: {
+          dataType: "moveObject",
+          type: `0x2::dynamic_field::Field<u16, 0x2::object::ID>`,
+          hasPublicTransfer: false,
+          fields: {
+            id: {
+              id: "0x00000000000000000000000000000000000000000000000000000000000df002",
+            },
+            name: { type: "u16", value: Number(STUB_ATHLETE_ID) },
+            value: STUB_UNIT_ID,
+          },
+        },
+      },
+    };
+  }
+
+  if (
+    galleryEntryMode !== "completed" ||
+    parentId !== STUB_PLACEMENTS_TABLE_ID
+  ) {
     return { data: null };
   }
+
   return {
     data: {
       objectId:
-        "0x00000000000000000000000000000000000000000000000000000000000df001",
+        "0x00000000000000000000000000000000000000000000000000000000000df101",
       version: "1",
-      digest: "df-digest",
-      type: `0x2::dynamic_field::Field<u16, 0x2::object::ID>`,
+      digest: "placement-digest",
+      type: `0x2::dynamic_field::Field<vector<u8>, ${STUB_PACKAGE_ID}::master_portrait::Placement>`,
       content: {
         dataType: "moveObject",
-        type: `0x2::dynamic_field::Field<u16, 0x2::object::ID>`,
+        type: `0x2::dynamic_field::Field<vector<u8>, ${STUB_PACKAGE_ID}::master_portrait::Placement>`,
         hasPublicTransfer: false,
         fields: {
           id: {
-            id: "0x00000000000000000000000000000000000000000000000000000000000df002",
+            id: "0x00000000000000000000000000000000000000000000000000000000000df102",
           },
-          name: { type: "u16", value: Number(STUB_ATHLETE_ID) },
-          value: STUB_UNIT_ID,
+          name: Array.from(new TextEncoder().encode(STUB_BLOB_ID)),
+          value: {
+            type: `${STUB_PACKAGE_ID}::master_portrait::Placement`,
+            fields: {
+              x: "12",
+              y: "8",
+              submitter: E2E_STUB_ACCOUNT_ADDRESS,
+              submission_no: String(STUB_SUBMISSION_NO),
+            },
+          },
         },
       },
     },
@@ -426,11 +553,13 @@ function handleOwnedObjects(
       };
     }
   }
-  if (
-    owner !== E2E_STUB_ACCOUNT_ADDRESS ||
-    !state.submitExecuted ||
-    !options.kakeraVisibleAfterExecute
-  ) {
+
+  const shouldExposeKakera =
+    owner === E2E_STUB_ACCOUNT_ADDRESS &&
+    (options.galleryEntryMode !== "empty" ||
+      (state.submitExecuted && options.kakeraVisibleAfterExecute));
+
+  if (!shouldExposeKakera) {
     return { data: [], hasNextPage: false, nextCursor: null };
   }
 

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -47,6 +47,9 @@ export const KAKERA_TYPE = `${STUB_PACKAGE_ID}::kakera::Kakera`;
 export type MockState = {
   submitExecuted: boolean;
   ownedObjectsCalls: number;
+  sponsorRequests: number;
+  executeRequests: number;
+  publisherRequests: number;
 };
 
 type MockHttpResponse = {
@@ -84,7 +87,13 @@ export async function installDefaultMocks(
   page: Page,
   options: InstallMockOptions = {},
 ): Promise<MockState> {
-  const state: MockState = { submitExecuted: false, ownedObjectsCalls: 0 };
+  const state: MockState = {
+    submitExecuted: false,
+    ownedObjectsCalls: 0,
+    sponsorRequests: 0,
+    executeRequests: 0,
+    publisherRequests: 0,
+  };
   const autoConnectWallet = options.autoConnectWallet ?? true;
   const executeApiMode = options.executeApiMode ?? "success";
   const galleryEntryMode = options.galleryEntryMode ?? "empty";
@@ -129,6 +138,7 @@ export async function installDefaultMocks(
   );
 
   await page.route("**/api/enoki/submit-photo/sponsor", async (route) => {
+    state.sponsorRequests += 1;
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -141,6 +151,7 @@ export async function installDefaultMocks(
   });
 
   await page.route("**/api/enoki/submit-photo/execute", async (route) => {
+    state.executeRequests += 1;
     state.submitExecuted = true;
     if (executeApiMode === "recovering_http_error") {
       await route.fulfill({
@@ -162,6 +173,7 @@ export async function installDefaultMocks(
   });
 
   await page.route("**/publisher.e2e.stub/**", async (route) => {
+    state.publisherRequests += 1;
     await route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -316,6 +316,7 @@ async function buildResponse(
     Pick<
       InstallMockOptions,
       | "ownedObjectsFailuresBeforeSuccess"
+      | "galleryEntryMode"
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
@@ -578,7 +579,9 @@ function handleOwnedObjects(
   options: Required<
     Pick<
       InstallMockOptions,
-      "ownedObjectsFailuresBeforeSuccess" | "kakeraVisibleAfterExecute"
+      | "ownedObjectsFailuresBeforeSuccess"
+      | "galleryEntryMode"
+      | "kakeraVisibleAfterExecute"
     >
   >,
 ): Record<string, unknown> | MockHttpResponse {

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -10,6 +10,7 @@
  * - Sui JSON-RPC (fullnode.testnet.sui.io) — dispatched by `method`.
  * - `/api/enoki/submit-photo/sponsor` / `/execute` — configurable success or
  *   recovery failure.
+ * - `/api/finalize` — observation stub for the later finalize bridge.
  * - Walrus Publisher `PUT /v1/blobs` — return stub `blobId`.
  */
 
@@ -50,6 +51,9 @@ export type MockState = {
   sponsorRequests: number;
   executeRequests: number;
   publisherRequests: number;
+  eventQueries: number;
+  finalizeRequests: number;
+  lastFinalizeUnitId: string | null;
 };
 
 type MockHttpResponse = {
@@ -93,6 +97,9 @@ export async function installDefaultMocks(
     sponsorRequests: 0,
     executeRequests: 0,
     publisherRequests: 0,
+    eventQueries: 0,
+    finalizeRequests: 0,
+    lastFinalizeUnitId: null,
   };
   const autoConnectWallet = options.autoConnectWallet ?? true;
   const executeApiMode = options.executeApiMode ?? "success";
@@ -169,6 +176,18 @@ export async function installDefaultMocks(
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({ digest: STUB_DIGEST }),
+    });
+  });
+
+  await page.route("**/api/finalize", async (route) => {
+    state.finalizeRequests += 1;
+    state.lastFinalizeUnitId = extractFinalizeUnitId(
+      safeParseJson(route.request().postData() ?? ""),
+    );
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
     });
   });
 
@@ -314,6 +333,7 @@ async function buildResponse(
     case "sui_getTransactionBlock":
       return envelope(await handleGetTransactionBlock(state, options));
     case "suix_queryEvents":
+      state.eventQueries += 1;
       return envelope({ data: [], hasNextPage: false, nextCursor: null });
     case "suix_getOwnedObjects": {
       const ownedObjects = handleOwnedObjects(params, state, options);
@@ -614,6 +634,14 @@ function isMockHttpResponse(
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractFinalizeUnitId(value: unknown): string | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  return typeof value.unitId === "string" ? value.unitId : null;
 }
 
 function safeParseJson(raw: string): unknown {

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -41,11 +41,18 @@ export const KAKERA_TYPE = `${STUB_PACKAGE_ID}::kakera::Kakera`;
 
 export type MockState = {
   submitExecuted: boolean;
+  ownedObjectsCalls: number;
+};
+
+type MockHttpResponse = {
+  readonly __mockHttpStatus: number;
+  readonly __mockHttpBody: unknown;
 };
 
 export type InstallMockOptions = {
   readonly autoConnectWallet?: boolean;
   readonly executeApiMode?: "success" | "recovering_http_error";
+  readonly ownedObjectsFailuresBeforeSuccess?: number;
   readonly transactionExecutionStatus?: "success" | "failed" | "unknown";
   readonly transactionBlockDelayMs?: number;
   readonly kakeraVisibleAfterExecute?: boolean;
@@ -60,9 +67,11 @@ export async function installDefaultMocks(
   page: Page,
   options: InstallMockOptions = {},
 ): Promise<MockState> {
-  const state: MockState = { submitExecuted: false };
+  const state: MockState = { submitExecuted: false, ownedObjectsCalls: 0 };
   const autoConnectWallet = options.autoConnectWallet ?? true;
   const executeApiMode = options.executeApiMode ?? "success";
+  const ownedObjectsFailuresBeforeSuccess =
+    options.ownedObjectsFailuresBeforeSuccess ?? 0;
   const transactionExecutionStatus =
     options.transactionExecutionStatus ?? "success";
   const transactionBlockDelayMs = options.transactionBlockDelayMs ?? 0;
@@ -92,6 +101,7 @@ export async function installDefaultMocks(
 
   await page.route(/fullnode\.[a-z]+\.sui\.io/, (route) =>
     handleSuiRpc(route, state, {
+      ownedObjectsFailuresBeforeSuccess,
       transactionExecutionStatus,
       transactionBlockDelayMs,
       kakeraVisibleAfterExecute,
@@ -162,6 +172,7 @@ async function handleSuiRpc(
   options: Required<
     Pick<
       InstallMockOptions,
+      | "ownedObjectsFailuresBeforeSuccess"
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
@@ -175,6 +186,15 @@ async function handleSuiRpc(
     const responses = await Promise.all(
       payload.map((single) => buildResponse(single, state, options)),
     );
+    const httpResponse = responses.find(isMockHttpResponse);
+    if (httpResponse) {
+      await route.fulfill({
+        status: httpResponse.__mockHttpStatus,
+        contentType: "application/json",
+        body: JSON.stringify(httpResponse.__mockHttpBody),
+      });
+      return;
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -184,10 +204,35 @@ async function handleSuiRpc(
   }
 
   await route.fulfill({
-    status: 200,
     contentType: "application/json",
-    body: JSON.stringify(await buildResponse(payload, state, options)),
+    ...(await buildRouteResponse(payload, state, options)),
   });
+}
+
+async function buildRouteResponse(
+  payload: unknown,
+  state: MockState,
+  options: Required<
+    Pick<
+      InstallMockOptions,
+      | "ownedObjectsFailuresBeforeSuccess"
+      | "transactionExecutionStatus"
+      | "transactionBlockDelayMs"
+      | "kakeraVisibleAfterExecute"
+    >
+  >,
+): Promise<Record<string, unknown> | MockHttpResponse> {
+  const response = await buildResponse(payload, state, options);
+  if (isMockHttpResponse(response)) {
+    return {
+      status: response.__mockHttpStatus,
+      body: JSON.stringify(response.__mockHttpBody),
+    };
+  }
+  return {
+    status: 200,
+    body: JSON.stringify(response),
+  };
 }
 
 async function buildResponse(
@@ -196,12 +241,13 @@ async function buildResponse(
   options: Required<
     Pick<
       InstallMockOptions,
+      | "ownedObjectsFailuresBeforeSuccess"
       | "transactionExecutionStatus"
       | "transactionBlockDelayMs"
       | "kakeraVisibleAfterExecute"
     >
   >,
-): Promise<Record<string, unknown>> {
+): Promise<Record<string, unknown> | MockHttpResponse> {
   const id = isObject(call) ? call.id : null;
   const method =
     isObject(call) && typeof call.method === "string" ? call.method : "";
@@ -219,8 +265,13 @@ async function buildResponse(
       return envelope(await handleGetTransactionBlock(state, options));
     case "suix_queryEvents":
       return envelope({ data: [], hasNextPage: false, nextCursor: null });
-    case "suix_getOwnedObjects":
-      return envelope(handleOwnedObjects(params, state, options));
+    case "suix_getOwnedObjects": {
+      const ownedObjects = handleOwnedObjects(params, state, options);
+      if (isMockHttpResponse(ownedObjects)) {
+        return ownedObjects;
+      }
+      return envelope(ownedObjects);
+    }
     case "sui_getLatestCheckpointSequenceNumber":
       return envelope("1");
     case "sui_dryRunTransactionBlock":
@@ -355,9 +406,26 @@ function handleDynamicField(params: readonly unknown[]): unknown {
 function handleOwnedObjects(
   params: readonly unknown[],
   state: MockState,
-  options: Required<Pick<InstallMockOptions, "kakeraVisibleAfterExecute">>,
-): unknown {
+  options: Required<
+    Pick<
+      InstallMockOptions,
+      "ownedObjectsFailuresBeforeSuccess" | "kakeraVisibleAfterExecute"
+    >
+  >,
+): Record<string, unknown> | MockHttpResponse {
   const owner = typeof params[0] === "string" ? params[0] : "";
+  if (owner === E2E_STUB_ACCOUNT_ADDRESS) {
+    state.ownedObjectsCalls += 1;
+    if (state.ownedObjectsCalls <= options.ownedObjectsFailuresBeforeSuccess) {
+      return {
+        __mockHttpStatus: 503,
+        __mockHttpBody: {
+          code: "owned_objects_unavailable",
+          message: "mock owned objects unavailable",
+        },
+      };
+    }
+  }
   if (
     owner !== E2E_STUB_ACCOUNT_ADDRESS ||
     !state.submitExecuted ||
@@ -395,6 +463,12 @@ function handleOwnedObjects(
     hasNextPage: false,
     nextCursor: null,
   };
+}
+
+function isMockHttpResponse(
+  value: Record<string, unknown> | MockHttpResponse,
+): value is MockHttpResponse {
+  return "__mockHttpStatus" in value && "__mockHttpBody" in value;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/apps/web/tests/e2e/gallery-states.spec.ts
+++ b/apps/web/tests/e2e/gallery-states.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+import { installDefaultMocks } from "./fixtures/mock-network";
+
+test.describe("gallery states", () => {
+  test("shows the empty gallery state", async ({ page }) => {
+    await installDefaultMocks(page);
+
+    await page.goto("/gallery");
+
+    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(
+      page.getByText(/まだ Kakera が見つかりません。/),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "もう一度確認する" }),
+    ).toBeVisible();
+  });
+
+  test("retries a temporary gallery failure and recovers to empty", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { ownedObjectsFailuresBeforeSuccess: 2 });
+
+    await page.goto("/gallery");
+
+    await expect(page.getByText("Unavailable")).toBeVisible();
+    await expect(
+      page.getByText(/履歴を読み込めませんでした。/),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "もう一度確認する" }).click();
+
+    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(
+      page.getByText(/まだ Kakera が見つかりません。/),
+    ).toBeVisible();
+  });
+
+  test("shows the config-missing gallery shell from the request selector", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+
+    await page.goto("/gallery?op_e2e_gallery_state=config-missing");
+
+    await expect(page.getByText("Unavailable")).toBeVisible();
+    await expect(
+      page.getByText(/公開設定を確認できません。/),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "もう一度確認する" }),
+    ).toHaveCount(0);
+  });
+});

--- a/apps/web/tests/e2e/gallery-states.spec.ts
+++ b/apps/web/tests/e2e/gallery-states.spec.ts
@@ -27,7 +27,9 @@ test.describe("gallery states", () => {
     await expect(
       page.getByAltText(/Demo Athlete One completed mosaic/i),
     ).toBeVisible();
-    await expect(page.getByText("Completed", { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByText("Completed", { exact: true }).first(),
+    ).toBeVisible();
     await expect(page.getByText(/Placed at 12, 8/i)).toBeVisible();
     await expect(page.getByText(`Master ${STUB_MASTER_ID}`)).toBeVisible();
   });
@@ -42,7 +44,9 @@ test.describe("gallery states", () => {
 
     await page.goto("/gallery");
 
-    await expect(page.getByText("Completed", { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByText("Completed", { exact: true }).first(),
+    ).toBeVisible();
     await expect(page.getByText(/Original photo unavailable/i)).toBeVisible();
     await expect(
       page.getByAltText(/Demo Athlete One completed mosaic/i),
@@ -60,9 +64,7 @@ test.describe("gallery states", () => {
     await expect(
       page.getByText("Unavailable", { exact: true }).first(),
     ).toBeVisible();
-    await expect(
-      page.getByText(/Entry unavailable right now/i),
-    ).toBeVisible();
+    await expect(page.getByText(/Entry unavailable right now/i)).toBeVisible();
     await expect(page.getByText(/Submission #1/i)).toBeVisible();
     await expect(
       page.getByRole("heading", { level: 1, name: /Participation gallery/i }),
@@ -77,9 +79,7 @@ test.describe("gallery states", () => {
     await page.goto("/gallery");
 
     await expect(page.getByText("Unavailable")).toBeVisible();
-    await expect(
-      page.getByText(/履歴を読み込めませんでした。/),
-    ).toBeVisible();
+    await expect(page.getByText(/履歴を読み込めませんでした。/)).toBeVisible();
 
     await page.getByRole("button", { name: "もう一度確認する" }).click();
 
@@ -97,9 +97,7 @@ test.describe("gallery states", () => {
     await page.goto("/gallery?op_e2e_gallery_state=config-missing");
 
     await expect(page.getByText("Unavailable")).toBeVisible();
-    await expect(
-      page.getByText(/公開設定を確認できません。/),
-    ).toBeVisible();
+    await expect(page.getByText(/公開設定を確認できません。/)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "もう一度確認する" }),
     ).toHaveCount(0);

--- a/apps/web/tests/e2e/gallery-states.spec.ts
+++ b/apps/web/tests/e2e/gallery-states.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { installDefaultMocks } from "./fixtures/mock-network";
+import { installDefaultMocks, STUB_MASTER_ID } from "./fixtures/mock-network";
 
 test.describe("gallery states", () => {
   test("shows the empty gallery state", async ({ page }) => {
@@ -14,6 +14,58 @@ test.describe("gallery states", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "もう一度確認する" }),
+    ).toBeVisible();
+  });
+
+  test("shows a completed gallery entry with mosaic and metadata", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { galleryEntryMode: "completed" });
+
+    await page.goto("/gallery");
+
+    await expect(
+      page.getByAltText(/Demo Athlete One completed mosaic/i),
+    ).toBeVisible();
+    await expect(page.getByText("Completed", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText(/Placed at 12, 8/i)).toBeVisible();
+    await expect(page.getByText(`Master ${STUB_MASTER_ID}`)).toBeVisible();
+  });
+
+  test("keeps a completed card visible when the original image fails", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, {
+      galleryEntryMode: "completed",
+      originalImageMode: "original_blob_not_found",
+    });
+
+    await page.goto("/gallery");
+
+    await expect(page.getByText("Completed", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText(/Original photo unavailable/i)).toBeVisible();
+    await expect(
+      page.getByAltText(/Demo Athlete One completed mosaic/i),
+    ).toBeVisible();
+    await expect(page.getByText(/Placed at 12, 8/i)).toBeVisible();
+  });
+
+  test("renders an entry unavailable gallery card when hydration fails", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { galleryEntryMode: "hydration_error" });
+
+    await page.goto("/gallery");
+
+    await expect(
+      page.getByText("Unavailable", { exact: true }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Entry unavailable right now/i),
+    ).toBeVisible();
+    await expect(page.getByText(/Submission #1/i)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 1, name: /Participation gallery/i }),
     ).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/waiting-room-events.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-events.spec.ts
@@ -1,17 +1,30 @@
 import { unitTileCount } from "@one-portrait/shared";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+
+async function openActiveWaitingRoom(
+  page: Page,
+  options: Parameters<typeof installDefaultMocks>[1] = {},
+): Promise<Awaited<ReturnType<typeof installDefaultMocks>>> {
+  const state = await installDefaultMocks(page, options);
+
+  await page.goto(
+    `/units/${STUB_UNIT_ID}?athleteName=${encodeURIComponent("Demo Athlete One")}&op_e2e_unit_progress=active`,
+  );
+
+  await expect(
+    page.getByRole("heading", { name: "Demo Athlete One" }),
+  ).toBeVisible();
+
+  return state;
+}
 
 test.describe("waiting room events", () => {
   test("bootstrap renders the active waiting room deterministically", async ({
     page,
   }) => {
-    await installDefaultMocks(page);
-
-    await page.goto(
-      `/units/${STUB_UNIT_ID}?athleteName=${encodeURIComponent("Demo Athlete One")}&op_e2e_unit_progress=active`,
-    );
+    await openActiveWaitingRoom(page);
 
     await expect(
       page.getByRole("heading", { name: "Demo Athlete One" }),
@@ -20,6 +33,40 @@ test.describe("waiting room events", () => {
       page.getByText(
         new RegExp(`${unitTileCount - 1}\\s*/\\s*${unitTileCount}`),
       ),
+    ).toBeVisible();
+  });
+
+  test("SubmittedEvent increments the counter and UnitFilledEvent finalizes only once", async ({
+    page,
+  }) => {
+    const state = await openActiveWaitingRoom(page, {
+      waitingRoomEventMode: "active",
+    });
+
+    await expect(
+      page.getByText(new RegExp(`${unitTileCount}\\s*/\\s*${unitTileCount}`)),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Filled")).toBeVisible();
+    await expect.poll(() => state.finalizeRequests).toBe(1);
+    await expect.poll(() => state.lastFinalizeUnitId).toBe(STUB_UNIT_ID);
+  });
+
+  test("MosaicReadyEvent reveals the panel and highlights the owned Kakera placement", async ({
+    page,
+  }) => {
+    await openActiveWaitingRoom(page, {
+      galleryEntryMode: "completed",
+      waitingRoomEventMode: "active",
+    });
+
+    await expect(page.getByTestId("reveal-panel")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("placement-highlight")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText(/Your Kakera is highlighted at \(12, 8\) as #1\./),
     ).toBeVisible();
   });
 });

--- a/apps/web/tests/e2e/waiting-room-events.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-events.spec.ts
@@ -1,0 +1,25 @@
+import { unitTileCount } from "@one-portrait/shared";
+import { expect, test } from "@playwright/test";
+
+import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+
+test.describe("waiting room events", () => {
+  test("bootstrap renders the active waiting room deterministically", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+
+    await page.goto(
+      `/units/${STUB_UNIT_ID}?athleteName=${encodeURIComponent("Demo Athlete One")}&op_e2e_unit_progress=active`,
+    );
+
+    await expect(
+      page.getByRole("heading", { name: "Demo Athlete One" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        new RegExp(`${unitTileCount - 1}\\s*/\\s*${unitTileCount}`),
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/tests/e2e/waiting-room-submit.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-submit.spec.ts
@@ -1,6 +1,44 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+import {
+  TINY_JPEG_BUFFER,
+  TINY_JPEG_MIME,
+  TINY_JPEG_NAME,
+} from "./fixtures/tiny-jpeg";
+
+async function prepareSubmission(page: Page): Promise<string> {
+  await page.goto(`/units/${STUB_UNIT_ID}`);
+
+  await expect(
+    page.getByText(/zkLogin アドレスを確認できました/),
+  ).toBeVisible();
+
+  await page
+    .getByRole("checkbox", {
+      name: /投稿した原画像は Walrus に保存され/,
+    })
+    .check();
+
+  const fileInput = page.locator('input[type="file"]');
+  await expect(fileInput).toBeEnabled();
+  await fileInput.setInputFiles({
+    name: TINY_JPEG_NAME,
+    mimeType: TINY_JPEG_MIME,
+    buffer: TINY_JPEG_BUFFER,
+  });
+
+  const preview = page.getByAltText("投稿プレビュー").first();
+  await expect(preview).toBeVisible();
+
+  const previewSrc = await preview.getAttribute("src");
+  if (!previewSrc) {
+    throw new Error("expected preview image src");
+  }
+
+  await page.getByRole("button", { name: "投稿を確定" }).click();
+  return previewSrc;
+}
 
 test.describe("waiting room submit guards", () => {
   test("disables the file input until consent is checked", async ({ page }) => {
@@ -44,5 +82,40 @@ test.describe("waiting room submit guards", () => {
     expect(state.sponsorRequests).toBe(0);
     expect(state.executeRequests).toBe(0);
     expect(state.publisherRequests).toBe(0);
+  });
+
+  test("retry keeps the same preview image without re-selecting the file", async ({
+    page,
+  }) => {
+    const state = await installDefaultMocks(page, {
+      executeApiMode: "recovering_http_error",
+      transactionExecutionStatus: "failed",
+      transactionBlockDelayMs: 800,
+      kakeraVisibleAfterExecute: false,
+    });
+    const previewSrc = await prepareSubmission(page);
+
+    await expect(
+      page.getByText("投稿結果を確認しています。しばらくお待ちください。"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "もう一度送信する" }),
+    ).toBeHidden();
+    await expect(
+      page.getByText("投稿を完了できませんでした。もう一度送信してください。"),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const retryButton = page.getByRole("button", { name: "もう一度送信する" });
+    await expect(retryButton).toBeVisible();
+
+    await retryButton.click();
+
+    await expect(page.getByAltText("投稿プレビュー").first()).toHaveAttribute(
+      "src",
+      previewSrc,
+    );
+    await expect.poll(() => state.executeRequests).toBe(2);
   });
 });

--- a/apps/web/tests/e2e/waiting-room-submit.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-submit.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+import { installDefaultMocks, STUB_UNIT_ID } from "./fixtures/mock-network";
+
+test.describe("waiting room submit guards", () => {
+  test("disables the file input until consent is checked", async ({ page }) => {
+    await installDefaultMocks(page);
+
+    await page.goto(`/units/${STUB_UNIT_ID}`);
+
+    await expect(
+      page.getByText(/zkLogin アドレスを確認できました/),
+    ).toBeVisible();
+
+    const consent = page.getByRole("checkbox", { name: /同意/ });
+    const fileInput = page.locator('input[type="file"]');
+
+    await expect(consent).not.toBeChecked();
+    await expect(fileInput).toBeDisabled();
+
+    await consent.check();
+
+    await expect(fileInput).toBeEnabled();
+  });
+
+  test("keeps the submit button absent until a file is selected", async ({
+    page,
+  }) => {
+    const state = await installDefaultMocks(page);
+
+    await page.goto(`/units/${STUB_UNIT_ID}`);
+
+    await expect(
+      page.getByText(/zkLogin アドレスを確認できました/),
+    ).toBeVisible();
+    await page.getByRole("checkbox", { name: /同意/ }).check();
+
+    await expect(page.locator('input[type="file"]')).toBeEnabled();
+    await expect(page.getByRole("button", { name: "投稿を確定" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByAltText("投稿プレビュー")).toHaveCount(0);
+
+    expect(state.sponsorRequests).toBe(0);
+    expect(state.executeRequests).toBe(0);
+    expect(state.publisherRequests).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要
Playwright E2E の状態別カバレッジを広げました。
デモ前に、ギャラリーと待機室の回帰を早く見つけるためです。

server 側でしか決まらない初期 props は、E2E stub 実行時だけ request 単位の query param で固定します。
client 側の RPC / Enoki / Walrus / finalize 観測は `mock-network.ts` に集約しました。

## 変更内容
- `apps/web/src/app/gallery/page.tsx`
  - E2E stub 時だけ有効な request 単位の gallery bootstrap を追加
- `apps/web/src/app/gallery/page.test.tsx`
  - gallery bootstrap が通常実行へ漏れないことを追加検証
- `apps/web/src/app/units/[unitId]/page.tsx`
  - waiting room の active bootstrap を request 単位で追加
- `apps/web/src/app/units/[unitId]/page.test.tsx`
  - waiting room bootstrap が通常実行へ漏れないことを追加検証
- `apps/web/tests/e2e/fixtures/mock-network.ts`
  - gallery state、original fallback、request counter、finalize 観測、event stream を追加
- `apps/web/tests/e2e/gallery-states.spec.ts`
  - empty / unavailable / completed / original fallback / entry unavailable を追加
- `apps/web/tests/e2e/waiting-room-submit.spec.ts`
  - consent/file guard と retry 後の preview 維持を追加
- `apps/web/tests/e2e/waiting-room-events.spec.ts`
  - counter 更新、finalize 1 回、reveal、placement highlight を追加

## 関連する Issue やチケット
Close #35

## 動作確認
- `corepack pnpm --filter web run typecheck`
- `corepack pnpm --filter web test`
- `corepack pnpm --filter web run test:e2e`
- `corepack pnpm --filter web run build`
- `corepack pnpm --filter web run check`
