### PR TITLE
[refactor] 外部参照のない定数を module-private に降格する

### DIFF
--- a/apps/web/src/lib/image/preprocess.ts
+++ b/apps/web/src/lib/image/preprocess.ts
@@ -15,10 +15,10 @@
  * jsdom）でもロジックを検証できるようにしている。
  */
 
-export const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
-export const MAX_LONG_EDGE_PX = 1024;
-export const JPEG_QUALITY = 0.85;
-export const OUTPUT_CONTENT_TYPE = "image/jpeg";
+const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+const MAX_LONG_EDGE_PX = 1024;
+const JPEG_QUALITY = 0.85;
+const OUTPUT_CONTENT_TYPE = "image/jpeg";
 
 export type ImagePreprocessErrorCode =
   | "file_too_large"

--- a/apps/web/src/lib/walrus/put.ts
+++ b/apps/web/src/lib/walrus/put.ts
@@ -21,13 +21,13 @@ import type { PreprocessedPhoto } from "../image/preprocess";
  * する。
  */
 
-export const WALRUS_EPOCHS = 5;
-export const WALRUS_MAX_ATTEMPTS = 3;
+const WALRUS_EPOCHS = 5;
+const WALRUS_MAX_ATTEMPTS = 3;
 /** Base delay for exponential backoff. Kept small – retries are cheap. */
-export const WALRUS_BASE_BACKOFF_MS = 200;
+const WALRUS_BASE_BACKOFF_MS = 200;
 /** Per-attempt request timeout. 30s covers mobile uploads; beyond that we
  * abort and classify as transient so the retry loop / final error kicks in. */
-export const WALRUS_REQUEST_TIMEOUT_MS = 30_000;
+const WALRUS_REQUEST_TIMEOUT_MS = 30_000;
 
 export type WalrusPutErrorKind = "transient" | "final" | "config_missing";
 

--- a/generator/src/walrus-write.ts
+++ b/generator/src/walrus-write.ts
@@ -1,4 +1,4 @@
-export const MOSAIC_WALRUS_EPOCHS = 100;
+const MOSAIC_WALRUS_EPOCHS = 100;
 
 export class WalrusWriteError extends Error {
   readonly status: number | null;


### PR DESCRIPTION
## 概要

knip による未使用 export 検出を受け、外部モジュールから参照されていない定数を `export const` から module-private な `const` に降格した。公開 API 表面を狭めて意図せぬ外部参照の発生を防ぐ。

barrel ([apps/web/src/lib/sui/index.ts](apps/web/src/lib/sui/index.ts) / [apps/web/src/lib/sui/react.ts](apps/web/src/lib/sui/react.ts)) で再公開されているものや、E2E fixture の STUB_* 群、`open-next.config.ts` のようなビルド規約ファイル、`generator/src/server.ts` のような Dockerfile のエントリポイントには手を付けていない。

## 変更内容

- `apps/web/src/lib/image/preprocess.ts`
    - `MAX_PHOTO_BYTES` / `MAX_LONG_EDGE_PX` / `JPEG_QUALITY` / `OUTPUT_CONTENT_TYPE` から `export` を外し内部定数化
- `apps/web/src/lib/walrus/put.ts`
    - `WALRUS_EPOCHS` / `WALRUS_MAX_ATTEMPTS` / `WALRUS_BASE_BACKOFF_MS` / `WALRUS_REQUEST_TIMEOUT_MS` から `export` を外し内部定数化
- `generator/src/walrus-write.ts`
    - `MOSAIC_WALRUS_EPOCHS` から `export` を外し内部定数化

## 動作確認

- `pnpm run check` (lint + typecheck + test) 全緑
    - workspace vitest: 4 tests
    - generator vitest: 22 tests
    - apps/web vitest: 233 tests