### PR TITLE
feat: Google zkLogin と通常 Sui wallet の二系統ログインに対応する

### DIFF
--- a/apps/web/src/app/api/enoki/submit-photo/execute/route.ts
+++ b/apps/web/src/app/api/enoki/submit-photo/execute/route.ts
@@ -9,13 +9,17 @@ import {
 export async function POST(request: Request): Promise<Response> {
   try {
     const input = parseExecuteSponsoredInput(await request.json());
-    const jwt = readZkLoginJwt(request.headers);
     const env = resolveRuntimeEnv(process.env);
     const result = await executeSponsoredSubmitPhoto(
-      {
-        ...input,
-        jwt,
-      },
+      input.sender
+        ? {
+            ...input,
+            sender: input.sender,
+          }
+        : {
+            ...input,
+            jwt: readZkLoginJwt(request.headers),
+          },
       env,
     );
 

--- a/apps/web/src/app/api/enoki/submit-photo/sponsor/route.ts
+++ b/apps/web/src/app/api/enoki/submit-photo/sponsor/route.ts
@@ -12,13 +12,17 @@ import {
 export async function POST(request: Request): Promise<Response> {
   try {
     const input = parseSubmitPhotoInput(await request.json());
-    const jwt = readZkLoginJwt(request.headers);
     const env = resolveRuntimeEnv(process.env);
     const result = await sponsorSubmitPhoto(
-      {
-        ...input,
-        jwt,
-      },
+      "sender" in input && typeof input.sender === "string"
+        ? {
+            ...input,
+            sender: input.sender,
+          }
+        : {
+            ...input,
+            jwt: readZkLoginJwt(request.headers),
+          },
       env,
     );
 

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
+import { GlobalWalletEntry } from "./global-wallet-entry";
+
 type AppShellProps = {
   readonly children: ReactNode;
 };
@@ -37,6 +39,7 @@ function GlobalHeader(): React.ReactElement {
             Gallery
           </Link>
         </nav>
+        <GlobalWalletEntry />
       </div>
     </header>
   );

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+type AppShellProps = {
+  readonly children: ReactNode;
+};
+
+const HIDDEN_HEADER_PATHS = new Set(["/auth/enoki/callback"]);
+
+export function AppShell({ children }: AppShellProps): React.ReactElement {
+  const pathname = usePathname();
+  const showHeader = !HIDDEN_HEADER_PATHS.has(pathname);
+
+  return (
+    <>
+      {showHeader ? <GlobalHeader /> : null}
+      {children}
+    </>
+  );
+}
+
+function GlobalHeader(): React.ReactElement {
+  return (
+    <header className="sticky top-0 z-40 border-b border-white/10 bg-slate-950/70 backdrop-blur">
+      <div className="mx-auto flex min-h-16 max-w-6xl items-center justify-between gap-4 px-6 py-3 text-slate-50">
+        <Link
+          className="text-sm uppercase tracking-[0.35em] text-cyan-200/90 hover:text-cyan-100"
+          href="/"
+        >
+          one portrait
+        </Link>
+        <nav className="flex items-center gap-4 text-sm text-slate-200">
+          <Link className="hover:text-white" href="/gallery">
+            Gallery
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -24,6 +24,9 @@ const {
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
+  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
+    <>{trigger}</>
+  ),
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
   useWallets: () => useWalletsMock(),
@@ -112,7 +115,10 @@ beforeEach(() => {
   useCurrentWalletMock.mockReturnValue({
     connectionStatus: "disconnected",
   });
-  useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
+  useWalletsMock.mockReturnValue([
+    { id: "google-wallet" },
+    { id: "sui-wallet" },
+  ]);
   useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
   getSuiClientMock.mockReturnValue({ network: "testnet" });
   listOwnedKakeraMock.mockResolvedValue([]);
@@ -137,12 +143,11 @@ describe("GalleryClient", () => {
 
     expect(
       screen.getByText(
-        /先に Google でログインすると、あなたの Kakera 履歴を読み込めます。/,
+        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
       ),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Google でログイン" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
   });
 
@@ -152,7 +157,7 @@ describe("GalleryClient", () => {
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
 
     await waitFor(() => {
       expect(mutateAsync).toHaveBeenCalledWith({
@@ -170,7 +175,7 @@ describe("GalleryClient", () => {
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
 
     await waitFor(() => {
       expect(mutateAsync).toHaveBeenCalledWith({
@@ -188,13 +193,13 @@ describe("GalleryClient", () => {
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
 
     expect((await screen.findByRole("alert")).textContent).toContain(
       "ログインに失敗しました。",
     );
     expect(
-      screen.getByRole("button", { name: "もう一度ログイン" }),
+      screen.getByRole("button", { name: "Google zkLogin をやり直す" }),
     ).toBeTruthy();
   });
 
@@ -205,7 +210,9 @@ describe("GalleryClient", () => {
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
-    const button = screen.getByRole("button", { name: "ログイン中…" });
+    const button = screen.getByRole("button", {
+      name: "Google zkLogin 接続中…",
+    });
 
     expect(button.getAttribute("disabled")).not.toBeNull();
   });

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ConnectModal,
   useConnectWallet,
   useCurrentAccount,
   useCurrentWallet,
@@ -204,7 +205,7 @@ function ConnectedGalleryClient({
   if (!currentAccount?.address) {
     return (
       <GalleryStatusShell
-        description="先に Google でログインすると、あなたの Kakera 履歴を読み込めます。"
+        description="Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。"
         label="Wallet required"
         tone="info"
       >
@@ -218,11 +219,22 @@ function ConnectedGalleryClient({
             type="button"
           >
             {isConnecting
-              ? "ログイン中…"
+              ? "Google zkLogin 接続中…"
               : connectError
-                ? "もう一度ログイン"
-                : "Google でログイン"}
+                ? "Google zkLogin をやり直す"
+                : "Google zkLogin"}
           </button>
+          <ConnectModal
+            trigger={
+              <button
+                className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+                type="button"
+              >
+                Sui wallet
+              </button>
+            }
+            walletFilter={(wallet) => !isGoogleWallet(wallet)}
+          />
         </div>
         {connectError ? (
           <p

--- a/apps/web/src/app/global-wallet-entry.test.tsx
+++ b/apps/web/src/app/global-wallet-entry.test.tsx
@@ -4,12 +4,14 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  useEnokiConfigStateMock,
   useWalletsMock,
   useCurrentAccountMock,
   useCurrentWalletMock,
   useConnectWalletMock,
   useDisconnectWalletMock,
 } = vi.hoisted(() => ({
+  useEnokiConfigStateMock: vi.fn(),
   useWalletsMock: vi.fn(),
   useCurrentAccountMock: vi.fn(),
   useCurrentWalletMock: vi.fn(),
@@ -17,12 +19,14 @@ const {
   useDisconnectWalletMock: vi.fn(),
 }));
 
+vi.mock("../lib/enoki/provider", () => ({
+  useEnokiConfigState: () => useEnokiConfigStateMock(),
+}));
+
 vi.mock("@mysten/dapp-kit", () => ({
-  ConnectModal: ({
-    trigger,
-  }: {
-    readonly trigger: React.ReactNode;
-  }) => <>{trigger}</>,
+  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
+    <>{trigger}</>
+  ),
   useWallets: () => useWalletsMock(),
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
@@ -37,6 +41,10 @@ vi.mock("@mysten/enoki", () => ({
 import { GlobalWalletEntry } from "./global-wallet-entry";
 
 beforeEach(() => {
+  useEnokiConfigStateMock.mockReturnValue({
+    submitEnabled: true,
+    config: {},
+  });
   useWalletsMock.mockReturnValue([
     { id: "google-wallet" },
     { id: "sui-wallet" },
@@ -57,6 +65,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  useEnokiConfigStateMock.mockReset();
   useWalletsMock.mockReset();
   useCurrentAccountMock.mockReset();
   useCurrentWalletMock.mockReset();
@@ -65,14 +74,24 @@ afterEach(() => {
 });
 
 describe("GlobalWalletEntry", () => {
+  it("renders a disabled placeholder when submit config is unavailable", () => {
+    useEnokiConfigStateMock.mockReturnValue({
+      submitEnabled: false,
+      reason: "submit-env-missing",
+    });
+
+    render(<GlobalWalletEntry />);
+
+    const button = screen.getByRole("button", { name: "ログイン準備中" });
+    expect(button.getAttribute("disabled")).not.toBeNull();
+  });
+
   it("shows Google zkLogin and Sui wallet choices from the login menu", () => {
     render(<GlobalWalletEntry />);
 
     fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
 
-    expect(
-      screen.getByRole("button", { name: "Google zkLogin" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
   });
 

--- a/apps/web/src/app/global-wallet-entry.test.tsx
+++ b/apps/web/src/app/global-wallet-entry.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  useWalletsMock,
+  useCurrentAccountMock,
+  useCurrentWalletMock,
+  useConnectWalletMock,
+  useDisconnectWalletMock,
+} = vi.hoisted(() => ({
+  useWalletsMock: vi.fn(),
+  useCurrentAccountMock: vi.fn(),
+  useCurrentWalletMock: vi.fn(),
+  useConnectWalletMock: vi.fn(),
+  useDisconnectWalletMock: vi.fn(),
+}));
+
+vi.mock("@mysten/dapp-kit", () => ({
+  ConnectModal: ({
+    trigger,
+  }: {
+    readonly trigger: React.ReactNode;
+  }) => <>{trigger}</>,
+  useWallets: () => useWalletsMock(),
+  useCurrentAccount: () => useCurrentAccountMock(),
+  useCurrentWallet: () => useCurrentWalletMock(),
+  useConnectWallet: () => useConnectWalletMock(),
+  useDisconnectWallet: () => useDisconnectWalletMock(),
+}));
+
+vi.mock("@mysten/enoki", () => ({
+  isGoogleWallet: (wallet: { id?: string }) => wallet.id === "google-wallet",
+}));
+
+import { GlobalWalletEntry } from "./global-wallet-entry";
+
+beforeEach(() => {
+  useWalletsMock.mockReturnValue([
+    { id: "google-wallet" },
+    { id: "sui-wallet" },
+  ]);
+  useCurrentAccountMock.mockReturnValue(null);
+  useCurrentWalletMock.mockReturnValue({
+    connectionStatus: "disconnected",
+    currentWallet: null,
+  });
+  useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+  useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+});
+
+afterEach(() => {
+  useWalletsMock.mockReset();
+  useCurrentAccountMock.mockReset();
+  useCurrentWalletMock.mockReset();
+  useConnectWalletMock.mockReset();
+  useDisconnectWalletMock.mockReset();
+});
+
+describe("GlobalWalletEntry", () => {
+  it("shows Google zkLogin and Sui wallet choices from the login menu", () => {
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      screen.getByRole("button", { name: "Google zkLogin" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
+  });
+
+  it("starts Google login from the shared menu", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useConnectWalletMock.mockReturnValue({ mutateAsync });
+
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        wallet: { id: "google-wallet" },
+      });
+    });
+  });
+
+  it("shows copy, explorer, and disconnect actions after connection", async () => {
+    const disconnectMutate = vi.fn();
+    useCurrentAccountMock.mockReturnValue({ address: "0x1234567890abcdef" });
+    useCurrentWalletMock.mockReturnValue({
+      connectionStatus: "connected",
+      currentWallet: { id: "sui-wallet" },
+    });
+    useDisconnectWalletMock.mockReturnValue({ mutate: disconnectMutate });
+
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: /0x1234/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "0x1234567890abcdef",
+      );
+    });
+
+    expect(
+      screen.getByRole("link", { name: "Explorer" }).getAttribute("href"),
+    ).toBe("https://suiexplorer.com/address/0x1234567890abcdef");
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+    expect(disconnectMutate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/global-wallet-entry.tsx
+++ b/apps/web/src/app/global-wallet-entry.tsx
@@ -11,6 +11,8 @@ import {
 import { isGoogleWallet } from "@mysten/enoki";
 import { useEffect, useRef, useState } from "react";
 
+import { useEnokiConfigState } from "../lib/enoki/provider";
+
 function shortenAddress(address: string): string {
   if (address.length <= 12) {
     return address;
@@ -23,6 +25,24 @@ function buildExplorerUrl(address: string): string {
 }
 
 export function GlobalWalletEntry(): React.ReactElement {
+  const state = useEnokiConfigState();
+
+  if (!state.submitEnabled) {
+    return (
+      <button
+        className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-300"
+        disabled
+        type="button"
+      >
+        ログイン準備中
+      </button>
+    );
+  }
+
+  return <GlobalWalletEntryEnabled />;
+}
+
+function GlobalWalletEntryEnabled(): React.ReactElement {
   const wallets = useWallets();
   const currentAccount = useCurrentAccount();
   const currentWallet = useCurrentWallet();

--- a/apps/web/src/app/global-wallet-entry.tsx
+++ b/apps/web/src/app/global-wallet-entry.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import {
+  ConnectModal,
+  useConnectWallet,
+  useCurrentAccount,
+  useCurrentWallet,
+  useDisconnectWallet,
+  useWallets,
+} from "@mysten/dapp-kit";
+import { isGoogleWallet } from "@mysten/enoki";
+import { useEffect, useRef, useState } from "react";
+
+function shortenAddress(address: string): string {
+  if (address.length <= 12) {
+    return address;
+  }
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function buildExplorerUrl(address: string): string {
+  return `https://suiexplorer.com/address/${address}`;
+}
+
+export function GlobalWalletEntry(): React.ReactElement {
+  const wallets = useWallets();
+  const currentAccount = useCurrentAccount();
+  const currentWallet = useCurrentWallet();
+  const connectWallet = useConnectWallet();
+  const disconnectWallet = useDisconnectWallet();
+  const [open, setOpen] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const googleWallet = wallets.find(isGoogleWallet) ?? null;
+  const connectedWallet = currentWallet.currentWallet ?? null;
+  const isGoogleConnected =
+    connectedWallet !== null && isGoogleWallet(connectedWallet);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handlePointerDown(event: MouseEvent): void {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, [open]);
+
+  async function handleGoogleLogin(): Promise<void> {
+    if (!googleWallet) {
+      setConnectError("Google zkLogin の設定が見つかりません。");
+      return;
+    }
+
+    setConnectError(null);
+
+    try {
+      await connectWallet.mutateAsync({ wallet: googleWallet });
+      setOpen(false);
+    } catch (error) {
+      setConnectError(toMessage(error));
+    }
+  }
+
+  async function handleCopy(address: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  if (!currentAccount) {
+    return (
+      <div className="relative" ref={containerRef}>
+        <button
+          className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm font-medium text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+          onClick={() => {
+            setOpen((current) => !current);
+          }}
+          type="button"
+        >
+          ログイン
+        </button>
+
+        {open ? (
+          <div className="absolute right-0 top-[calc(100%+0.75rem)] z-50 grid min-w-56 gap-3 rounded-3xl border border-white/10 bg-slate-950/95 p-4 shadow-2xl shadow-black/40">
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              Connect
+            </p>
+            <button
+              className="rounded-2xl bg-cyan-300 px-4 py-3 text-left text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
+              onClick={() => {
+                void handleGoogleLogin();
+              }}
+              type="button"
+            >
+              Google zkLogin
+            </button>
+            <ConnectModal
+              trigger={
+                <button
+                  className="rounded-2xl border border-white/10 px-4 py-3 text-left text-sm font-medium text-white transition hover:border-cyan-200/60"
+                  type="button"
+                >
+                  Sui wallet
+                </button>
+              }
+              walletFilter={(wallet) => !isGoogleWallet(wallet)}
+            />
+
+            {connectError ? (
+              <p
+                aria-live="polite"
+                className="rounded-2xl border border-amber-300/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-100"
+                role="alert"
+              >
+                {connectError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:border-cyan-200/60"
+        onClick={() => {
+          setOpen((current) => !current);
+        }}
+        type="button"
+      >
+        {shortenAddress(currentAccount.address)}
+      </button>
+
+      {open ? (
+        <div className="absolute right-0 top-[calc(100%+0.75rem)] z-50 grid min-w-72 gap-3 rounded-3xl border border-white/10 bg-slate-950/95 p-4 shadow-2xl shadow-black/40">
+          <div className="grid gap-1">
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              {isGoogleConnected ? "Google zkLogin" : "Sui wallet"}
+            </p>
+            <p className="font-mono text-xs break-all text-cyan-100">
+              {currentAccount.address}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              className="rounded-full border border-white/10 px-3 py-2 text-sm text-white transition hover:border-cyan-200/60"
+              onClick={() => {
+                void handleCopy(currentAccount.address);
+              }}
+              type="button"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+            <a
+              className="rounded-full border border-white/10 px-3 py-2 text-sm text-white transition hover:border-cyan-200/60"
+              href={buildExplorerUrl(currentAccount.address)}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Explorer
+            </a>
+            <button
+              className="rounded-full border border-white/10 px-3 py-2 text-sm text-white transition hover:border-cyan-200/60"
+              onClick={() => {
+                disconnectWallet.mutate();
+                setOpen(false);
+              }}
+              type="button"
+            >
+              Disconnect
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "接続に失敗しました。時間をおいて、もう一度お試しください。";
+}

--- a/apps/web/src/app/layout.test.tsx
+++ b/apps/web/src/app/layout.test.tsx
@@ -17,6 +17,10 @@ vi.mock("../lib/enoki/provider", () => ({
   },
 }));
 
+vi.mock("./global-wallet-entry", () => ({
+  GlobalWalletEntry: () => <div>wallet entry</div>,
+}));
+
 import { AppShell } from "./app-shell";
 import RootLayout from "./layout";
 

--- a/apps/web/src/app/layout.test.tsx
+++ b/apps/web/src/app/layout.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { usePathnameMock } = vi.hoisted(() => ({
+  usePathnameMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathnameMock(),
+}));
+
+vi.mock("../lib/enoki/provider", () => ({
+  AppWalletProvider: ({ children }: { readonly children: React.ReactNode }) => {
+    return <>{children}</>;
+  },
+}));
+
+import { AppShell } from "./app-shell";
+import RootLayout from "./layout";
+
+afterEach(() => {
+  usePathnameMock.mockReset();
+});
+
+describe("AppShell", () => {
+  it("renders the global header on regular pages", () => {
+    usePathnameMock.mockReturnValue("/");
+
+    render(<AppShell>page body</AppShell>);
+
+    expect(
+      screen.getByRole("link", { name: /one portrait/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: /gallery/i }).getAttribute("href")).toBe(
+      "/gallery",
+    );
+    expect(screen.getByText("page body")).toBeTruthy();
+  });
+
+  it("hides the global header on the Enoki callback page", () => {
+    usePathnameMock.mockReturnValue("/auth/enoki/callback");
+
+    render(<AppShell>callback body</AppShell>);
+
+    expect(
+      screen.queryByRole("link", { name: /one portrait/i }),
+    ).toBeNull();
+    expect(screen.getByText("callback body")).toBeTruthy();
+  });
+});
+
+describe("RootLayout", () => {
+  it("mounts AppShell inside the body element", () => {
+    usePathnameMock.mockReturnValue("/");
+
+    const ui = RootLayout({
+      children: <div>page body</div>,
+    });
+
+    expect(ui.type).toBe("html");
+    expect(ui.props.children.type).toBe("body");
+    expect(ui.props.children.props.children.props.children.type).toBe(AppShell);
+  });
+});

--- a/apps/web/src/app/layout.test.tsx
+++ b/apps/web/src/app/layout.test.tsx
@@ -34,12 +34,10 @@ describe("AppShell", () => {
 
     render(<AppShell>page body</AppShell>);
 
+    expect(screen.getByRole("link", { name: /one portrait/i })).toBeTruthy();
     expect(
-      screen.getByRole("link", { name: /one portrait/i }),
-    ).toBeTruthy();
-    expect(screen.getByRole("link", { name: /gallery/i }).getAttribute("href")).toBe(
-      "/gallery",
-    );
+      screen.getByRole("link", { name: /gallery/i }).getAttribute("href"),
+    ).toBe("/gallery");
     expect(screen.getByText("page body")).toBeTruthy();
   });
 
@@ -48,9 +46,7 @@ describe("AppShell", () => {
 
     render(<AppShell>callback body</AppShell>);
 
-    expect(
-      screen.queryByRole("link", { name: /one portrait/i }),
-    ).toBeNull();
+    expect(screen.queryByRole("link", { name: /one portrait/i })).toBeNull();
     expect(screen.getByText("callback body")).toBeTruthy();
   });
 });

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import { appMeta } from "@one-portrait/shared";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-
-import { AppShell } from "./app-shell";
 import { AppWalletProvider } from "../lib/enoki/provider";
+import { AppShell } from "./app-shell";
 
 import "./globals.css";
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { appMeta } from "@one-portrait/shared";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { AppShell } from "./app-shell";
 import { AppWalletProvider } from "../lib/enoki/provider";
 
 import "./globals.css";
@@ -24,7 +25,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="ja">
       <body>
-        <AppWalletProvider>{children}</AppWalletProvider>
+        <AppWalletProvider>
+          <AppShell>{children}</AppShell>
+        </AppWalletProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -336,9 +336,8 @@ describe("UnitPage", () => {
     expect(screen.getByTestId("unit-reveal-client").textContent).toContain(
       "347 /",
     );
-    expect(
-      screen.getByRole("button", { name: "Google でログイン" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
     expect(getUnitProgressMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -163,7 +163,13 @@ function DemoParticipationPreview(): React.ReactElement {
           className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950"
           type="button"
         >
-          Google でログイン
+          Google zkLogin
+        </button>
+        <button
+          className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100"
+          type="button"
+        >
+          Sui wallet
         </button>
       </div>
     </section>

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -80,6 +80,9 @@ vi.mock("@mysten/enoki", () => ({
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
+  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
+    <>{trigger}</>
+  ),
   useWallets: () => useWalletsMock(),
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
@@ -108,14 +111,26 @@ function makeFile(name = "photo.jpg", size = 1024): File {
   return new File([blob], name, { type: "image/jpeg" });
 }
 
-function setupSignedInEnv(): void {
+function setupSignedInEnv({
+  accountAddress = "0xabc123",
+  currentWalletId = "google-wallet",
+}: {
+  readonly accountAddress?: string;
+  readonly currentWalletId?: string;
+} = {}): void {
   useEnokiConfigStateMock.mockReturnValue({
     submitEnabled: true,
     config: {},
   });
-  useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
-  useCurrentAccountMock.mockReturnValue({ address: "0xabc123" });
-  useCurrentWalletMock.mockReturnValue({ connectionStatus: "connected" });
+  useWalletsMock.mockReturnValue([
+    { id: "google-wallet" },
+    { id: "sui-wallet" },
+  ]);
+  useCurrentAccountMock.mockReturnValue({ address: accountAddress });
+  useCurrentWalletMock.mockReturnValue({
+    connectionStatus: "connected",
+    currentWallet: { id: currentWalletId },
+  });
   useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
   useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
   useSubmitPhotoMock.mockReturnValue({
@@ -154,12 +169,15 @@ describe("ParticipationAccess", () => {
     expect(screen.getByText(/進捗の確認だけ使えます/)).toBeTruthy();
   });
 
-  it("shows the Google login button when the user is not signed in", () => {
+  it("shows both wallet choices when the user is not signed in", () => {
     useEnokiConfigStateMock.mockReturnValue({
       submitEnabled: true,
       config: {},
     });
-    useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
+    useWalletsMock.mockReturnValue([
+      { id: "google-wallet" },
+      { id: "sui-wallet" },
+    ]);
     useCurrentAccountMock.mockReturnValue(null);
     useCurrentWalletMock.mockReturnValue({
       connectionStatus: "disconnected",
@@ -174,11 +192,32 @@ describe("ParticipationAccess", () => {
     render(<ParticipationAccess unitId="0xunit-1" />);
 
     expect(
-      screen.getByRole("button", { name: "Google でログイン" }),
+      screen.getByText(
+        /Google zkLogin または Sui wallet を接続すると、この待機室から投稿できます。/,
+      ),
     ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
   });
 
-  it("shows a safe waiting-room message for a non-Google wallet", () => {
+  it("allows a connected Sui wallet to continue into the submit form", () => {
+    setupSignedInEnv({
+      accountAddress: "0xsui123",
+      currentWalletId: "sui-wallet",
+    });
+
+    render(<ParticipationAccess unitId="0xunit-1" />);
+
+    expect(
+      screen.getByText(/Sui wallet アドレスを確認できました/),
+    ).toBeTruthy();
+    expect(screen.getByLabelText(FILE_INPUT_LABEL)).toBeTruthy();
+    expect(
+      screen.queryByText(/履歴ギャラリーの確認だけ利用できます。/),
+    ).toBeNull();
+  });
+
+  it("shows a retry message when login fails", async () => {
     useEnokiConfigStateMock.mockReturnValue({
       submitEnabled: true,
       config: {},
@@ -187,35 +226,6 @@ describe("ParticipationAccess", () => {
       { id: "google-wallet" },
       { id: "sui-wallet" },
     ]);
-    useCurrentAccountMock.mockReturnValue({ address: "0xsui123" });
-    useCurrentWalletMock.mockReturnValue({
-      connectionStatus: "connected",
-      currentWallet: { id: "sui-wallet" },
-    });
-    useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
-    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
-    useSubmitPhotoMock.mockReturnValue({
-      isSubmitting: false,
-      submitPhoto: vi.fn(),
-    });
-
-    render(<ParticipationAccess unitId="0xunit-1" />);
-
-    expect(
-      screen.getByText(/Sui wallet 接続を確認できました/),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("link", { name: "履歴ギャラリーを見る" }),
-    ).toBeTruthy();
-    expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
-  });
-
-  it("shows a retry message when login fails", async () => {
-    useEnokiConfigStateMock.mockReturnValue({
-      submitEnabled: true,
-      config: {},
-    });
-    useWalletsMock.mockReturnValue([{ id: "google-wallet" }]);
     useCurrentAccountMock.mockReturnValue(null);
     useCurrentWalletMock.mockReturnValue({
       connectionStatus: "disconnected",
@@ -231,7 +241,7 @@ describe("ParticipationAccess", () => {
 
     render(<ParticipationAccess unitId="0xunit-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Google でログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
 
     await waitFor(() => {
       expect(screen.getByRole("alert").textContent).toContain(
@@ -239,7 +249,7 @@ describe("ParticipationAccess", () => {
       );
     });
     expect(
-      screen.getByRole("button", { name: "もう一度ログイン" }),
+      screen.getByRole("button", { name: "Google zkLogin をやり直す" }),
     ).toBeTruthy();
   });
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -178,6 +178,38 @@ describe("ParticipationAccess", () => {
     ).toBeTruthy();
   });
 
+  it("shows a safe waiting-room message for a non-Google wallet", () => {
+    useEnokiConfigStateMock.mockReturnValue({
+      submitEnabled: true,
+      config: {},
+    });
+    useWalletsMock.mockReturnValue([
+      { id: "google-wallet" },
+      { id: "sui-wallet" },
+    ]);
+    useCurrentAccountMock.mockReturnValue({ address: "0xsui123" });
+    useCurrentWalletMock.mockReturnValue({
+      connectionStatus: "connected",
+      currentWallet: { id: "sui-wallet" },
+    });
+    useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
+    useSubmitPhotoMock.mockReturnValue({
+      isSubmitting: false,
+      submitPhoto: vi.fn(),
+    });
+
+    render(<ParticipationAccess unitId="0xunit-1" />);
+
+    expect(
+      screen.getByText(/Sui wallet 接続を確認できました/),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "履歴ギャラリーを見る" }),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
+  });
+
   it("shows a retry message when login fails", async () => {
     useEnokiConfigStateMock.mockReturnValue({
       submitEnabled: true,

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ConnectModal,
   useConnectWallet,
   useCurrentAccount,
   useCurrentWallet,
@@ -216,7 +217,8 @@ function ParticipationAccessEnabled({
 
   const googleWallet = wallets.find(isGoogleWallet) ?? null;
   const isConnecting = currentWallet.connectionStatus === "connecting";
-  const connectedWallet = currentWallet.currentWallet ?? (currentAccount ? googleWallet : null);
+  const connectedWallet =
+    currentWallet.currentWallet ?? (currentAccount ? googleWallet : null);
   const isGoogleConnected =
     connectedWallet !== null && isGoogleWallet(connectedWallet);
 
@@ -423,6 +425,10 @@ function ParticipationAccessEnabled({
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
   const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
+  const connectedWalletLabel = isGoogleConnected ? "zkLogin" : "Sui wallet";
+  const connectedWalletMessage = isGoogleConnected
+    ? "zkLogin アドレスを確認できました。投稿の署名に使うのはこの住所です。"
+    : "Sui wallet アドレスを確認できました。Sponsored Tx の署名に使うのはこの住所です。";
 
   return (
     <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
@@ -430,213 +436,180 @@ function ParticipationAccessEnabled({
         <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
           Submit access
         </p>
-        <h2 className="font-serif text-2xl text-white">Google login</h2>
+        <h2 className="font-serif text-2xl text-white">Participation wallet</h2>
       </div>
 
       {currentAccount ? (
         <>
-          {!isGoogleConnected ? (
-            <div className="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 px-4 py-4 text-sm text-slate-200">
-              <p>
-                Sui wallet 接続を確認できました。投稿の Sponsored
-                対応をこの画面へつなぐ準備中です。
+          <p className="text-sm text-slate-200">{connectedWalletMessage}</p>
+          <p className="font-mono text-xs break-all text-cyan-100">
+            {currentAccount.address}
+          </p>
+
+          {showConsentAndFilePicker ? (
+            <>
+              <label className="flex items-start gap-2 text-sm text-slate-200">
+                <input
+                  checked={consented}
+                  className="mt-1"
+                  onChange={(event) => {
+                    setConsented(event.target.checked);
+                  }}
+                  type="checkbox"
+                />
+                <span>
+                  投稿した原画像は Walrus に保存され、blob_id
+                  を知る人は誰でも取得できます。 また、参加の証として
+                  Soulbound（譲渡不可）の Kakera NFT
+                  が自分のウォレットに発行されることに同意します。
+                </span>
+              </label>
+
+              <label className="grid gap-2 text-sm text-slate-200">
+                <span>写真を選択</span>
+                <input
+                  accept="image/*"
+                  disabled={fileInputDisabled}
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleFileChange(file);
+                    }
+                  }}
+                  type="file"
+                />
+              </label>
+            </>
+          ) : null}
+
+          {isProcessing ? (
+            <p className="text-sm text-slate-300" role="status">
+              処理中…
+            </p>
+          ) : null}
+
+          {previewPhoto ? (
+            // biome-ignore lint: client-side object URL preview, next/image not applicable.
+            <img
+              alt="投稿プレビュー"
+              className="max-w-full rounded-2xl border border-white/10"
+              src={previewPhoto.previewUrl}
+            />
+          ) : null}
+
+          {isUploading ? (
+            <p className="text-sm text-slate-300" role="status">
+              Walrus に保存しています…
+            </p>
+          ) : null}
+
+          {isSubmitting ? (
+            <p className="text-sm text-slate-300" role="status">
+              オンチェーンに投稿しています…
+            </p>
+          ) : null}
+
+          {isRecovering ? (
+            <p className="text-sm text-slate-300" role="status">
+              投稿結果を確認しています。しばらくお待ちください。
+            </p>
+          ) : null}
+
+          {showSubmitButton ? (
+            <div className="flex flex-wrap gap-3">
+              <button
+                className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
+                disabled={submitButtonDisabled}
+                onClick={() => {
+                  if (phase.kind === "previewing") {
+                    void handleSubmit(phase.photo);
+                  }
+                }}
+                type="button"
+              >
+                投稿を確定
+              </button>
+            </div>
+          ) : null}
+
+          {donePhase ? (
+            <div
+              className="grid gap-3 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100"
+              role="status"
+            >
+              <p className="text-base">投稿が完了しました。</p>
+              <p className="text-sm text-emerald-50">
+                次は履歴ギャラリーで参加記録を確認できます。
               </p>
-              <p className="font-mono text-xs break-all text-cyan-100">
-                {currentAccount.address}
+
+              {/* biome-ignore lint: local object URL preview, next/image N/A. */}
+              <img
+                alt="投稿プレビュー"
+                className="max-w-full rounded-xl border border-white/10"
+                src={donePhase.photo.previewUrl}
+              />
+
+              <dl className="grid gap-2">
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    送信アドレス
+                  </dt>
+                  <dd className="font-mono text-xs break-all">
+                    {donePhase.result.sender}
+                  </dd>
+                </div>
+
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    submission_no
+                  </dt>
+                  <dd className="font-mono text-sm">
+                    {ownedKakera.kakera
+                      ? `#${ownedKakera.kakera.submissionNo}`
+                      : "確認中…"}
+                  </dd>
+                </div>
+
+                <div className="grid gap-0.5">
+                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                    digest
+                  </dt>
+                  <dd className="font-mono text-xs break-all">
+                    {donePhase.result.digest}
+                  </dd>
+                </div>
+              </dl>
+
+              <p aria-live="polite" className="text-xs text-emerald-100/90">
+                {describeKakeraStatus(ownedKakera.status)}
               </p>
-              <p className="text-sm text-slate-300">
-                この段階では履歴ギャラリーの確認だけ利用できます。
-              </p>
+
               <div className="flex flex-wrap gap-3">
                 <Link
-                  className="inline-flex items-center rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
+                  className="inline-flex items-center rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-white"
                   href="/gallery"
                 >
                   履歴ギャラリーを見る
                 </Link>
-                <button
-                  className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
-                  onClick={() => disconnectWallet.mutate()}
-                  type="button"
-                >
-                  接続を解除する
-                </button>
               </div>
             </div>
-          ) : (
-            <>
-              <p className="text-sm text-slate-200">
-                zkLogin アドレスを確認できました。投稿の署名に使うのはこの住所です。
-              </p>
-              <p className="font-mono text-xs break-all text-cyan-100">
-                {currentAccount.address}
-              </p>
+          ) : null}
 
-              {showConsentAndFilePicker ? (
-                <>
-                  <label className="flex items-start gap-2 text-sm text-slate-200">
-                    <input
-                      checked={consented}
-                      className="mt-1"
-                      onChange={(event) => {
-                        setConsented(event.target.checked);
-                      }}
-                      type="checkbox"
-                    />
-                    <span>
-                      投稿した原画像は Walrus に保存され、blob_id
-                      を知る人は誰でも取得できます。 また、参加の証として
-                      Soulbound（譲渡不可）の Kakera NFT
-                      が自分のウォレットに発行されることに同意します。
-                    </span>
-                  </label>
-
-                  <label className="grid gap-2 text-sm text-slate-200">
-                    <span>写真を選択</span>
-                    <input
-                      accept="image/*"
-                      disabled={fileInputDisabled}
-                      onChange={(event) => {
-                        const file = event.target.files?.[0];
-                        if (file) {
-                          void handleFileChange(file);
-                        }
-                      }}
-                      type="file"
-                    />
-                  </label>
-                </>
-              ) : null}
-
-              {isProcessing ? (
-                <p className="text-sm text-slate-300" role="status">
-                  処理中…
-                </p>
-              ) : null}
-
-              {previewPhoto ? (
-                // biome-ignore lint: client-side object URL preview, next/image not applicable.
-                <img
-                  alt="投稿プレビュー"
-                  className="max-w-full rounded-2xl border border-white/10"
-                  src={previewPhoto.previewUrl}
-                />
-              ) : null}
-
-              {isUploading ? (
-                <p className="text-sm text-slate-300" role="status">
-                  Walrus に保存しています…
-                </p>
-              ) : null}
-
-              {isSubmitting ? (
-                <p className="text-sm text-slate-300" role="status">
-                  オンチェーンに投稿しています…
-                </p>
-              ) : null}
-
-              {isRecovering ? (
-                <p className="text-sm text-slate-300" role="status">
-                  投稿結果を確認しています。しばらくお待ちください。
-                </p>
-              ) : null}
-
-              {showSubmitButton ? (
-                <div className="flex flex-wrap gap-3">
-                  <button
-                    className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
-                    disabled={submitButtonDisabled}
-                    onClick={() => {
-                      if (phase.kind === "previewing") {
-                        void handleSubmit(phase.photo);
-                      }
-                    }}
-                    type="button"
-                  >
-                    投稿を確定
-                  </button>
-                </div>
-              ) : null}
-
-              {donePhase ? (
-                <div
-                  className="grid gap-3 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100"
-                  role="status"
-                >
-                  <p className="text-base">投稿が完了しました。</p>
-                  <p className="text-sm text-emerald-50">
-                    次は履歴ギャラリーで参加記録を確認できます。
-                  </p>
-
-                  {/* biome-ignore lint: local object URL preview, next/image N/A. */}
-                  <img
-                    alt="投稿プレビュー"
-                    className="max-w-full rounded-xl border border-white/10"
-                    src={donePhase.photo.previewUrl}
-                  />
-
-                  <dl className="grid gap-2">
-                    <div className="grid gap-0.5">
-                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                        送信アドレス
-                      </dt>
-                      <dd className="font-mono text-xs break-all">
-                        {donePhase.result.sender}
-                      </dd>
-                    </div>
-
-                    <div className="grid gap-0.5">
-                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                        submission_no
-                      </dt>
-                      <dd className="font-mono text-sm">
-                        {ownedKakera.kakera
-                          ? `#${ownedKakera.kakera.submissionNo}`
-                          : "確認中…"}
-                      </dd>
-                    </div>
-
-                    <div className="grid gap-0.5">
-                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                        digest
-                      </dt>
-                      <dd className="font-mono text-xs break-all">
-                        {donePhase.result.digest}
-                      </dd>
-                    </div>
-                  </dl>
-
-                  <p aria-live="polite" className="text-xs text-emerald-100/90">
-                    {describeKakeraStatus(ownedKakera.status)}
-                  </p>
-
-                  <div className="flex flex-wrap gap-3">
-                    <Link
-                      className="inline-flex items-center rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-white"
-                      href="/gallery"
-                    >
-                      履歴ギャラリーを見る
-                    </Link>
-                  </div>
-                </div>
-              ) : null}
-
-              <div className="flex flex-wrap gap-3">
-                <button
-                  className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
-                  onClick={() => disconnectWallet.mutate()}
-                  type="button"
-                >
-                  ログイン解除
-                </button>
-              </div>
-            </>
-          )}
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+              onClick={() => disconnectWallet.mutate()}
+              type="button"
+            >
+              {connectedWalletLabel} を解除する
+            </button>
+          </div>
         </>
       ) : (
         <>
           <p className="text-sm text-slate-300">
-            先に Google でログインすると、zkLogin の参加用アドレスを作れます。
+            Google zkLogin または Sui wallet
+            を接続すると、この待機室から投稿できます。
           </p>
           <div className="flex flex-wrap gap-3">
             <button
@@ -647,8 +620,23 @@ function ParticipationAccessEnabled({
               }}
               type="button"
             >
-              {connectError ? "もう一度ログイン" : "Google でログイン"}
+              {isConnecting
+                ? "Google zkLogin 接続中…"
+                : connectError
+                  ? "Google zkLogin をやり直す"
+                  : "Google zkLogin"}
             </button>
+            <ConnectModal
+              trigger={
+                <button
+                  className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+                  type="button"
+                >
+                  Sui wallet
+                </button>
+              }
+              walletFilter={(wallet) => !isGoogleWallet(wallet)}
+            />
           </div>
         </>
       )}

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -216,6 +216,9 @@ function ParticipationAccessEnabled({
 
   const googleWallet = wallets.find(isGoogleWallet) ?? null;
   const isConnecting = currentWallet.connectionStatus === "connecting";
+  const connectedWallet = currentWallet.currentWallet ?? (currentAccount ? googleWallet : null);
+  const isGoogleConnected =
+    connectedWallet !== null && isGoogleWallet(connectedWallet);
 
   // Kakera polling kicks in only once we know the Walrus blob id and the
   // zkLogin address. The hook stays idle while any of the inputs are
@@ -432,171 +435,203 @@ function ParticipationAccessEnabled({
 
       {currentAccount ? (
         <>
-          <p className="text-sm text-slate-200">
-            zkLogin アドレスを確認できました。投稿の署名に使うのはこの住所です。
-          </p>
-          <p className="font-mono text-xs break-all text-cyan-100">
-            {currentAccount.address}
-          </p>
-
-          {showConsentAndFilePicker ? (
-            <>
-              <label className="flex items-start gap-2 text-sm text-slate-200">
-                <input
-                  checked={consented}
-                  className="mt-1"
-                  onChange={(event) => {
-                    setConsented(event.target.checked);
-                  }}
-                  type="checkbox"
-                />
-                <span>
-                  投稿した原画像は Walrus に保存され、blob_id
-                  を知る人は誰でも取得できます。 また、参加の証として
-                  Soulbound（譲渡不可）の Kakera NFT
-                  が自分のウォレットに発行されることに同意します。
-                </span>
-              </label>
-
-              <label className="grid gap-2 text-sm text-slate-200">
-                <span>写真を選択</span>
-                <input
-                  accept="image/*"
-                  disabled={fileInputDisabled}
-                  onChange={(event) => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleFileChange(file);
-                    }
-                  }}
-                  type="file"
-                />
-              </label>
-            </>
-          ) : null}
-
-          {isProcessing ? (
-            <p className="text-sm text-slate-300" role="status">
-              処理中…
-            </p>
-          ) : null}
-
-          {previewPhoto ? (
-            // biome-ignore lint: client-side object URL preview, next/image not applicable.
-            <img
-              alt="投稿プレビュー"
-              className="max-w-full rounded-2xl border border-white/10"
-              src={previewPhoto.previewUrl}
-            />
-          ) : null}
-
-          {isUploading ? (
-            <p className="text-sm text-slate-300" role="status">
-              Walrus に保存しています…
-            </p>
-          ) : null}
-
-          {isSubmitting ? (
-            <p className="text-sm text-slate-300" role="status">
-              オンチェーンに投稿しています…
-            </p>
-          ) : null}
-
-          {isRecovering ? (
-            <p className="text-sm text-slate-300" role="status">
-              投稿結果を確認しています。しばらくお待ちください。
-            </p>
-          ) : null}
-
-          {showSubmitButton ? (
-            <div className="flex flex-wrap gap-3">
-              <button
-                className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
-                disabled={submitButtonDisabled}
-                onClick={() => {
-                  if (phase.kind === "previewing") {
-                    void handleSubmit(phase.photo);
-                  }
-                }}
-                type="button"
-              >
-                投稿を確定
-              </button>
-            </div>
-          ) : null}
-
-          {donePhase ? (
-            <div
-              className="grid gap-3 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100"
-              role="status"
-            >
-              <p className="text-base">投稿が完了しました。</p>
-              <p className="text-sm text-emerald-50">
-                次は履歴ギャラリーで参加記録を確認できます。
+          {!isGoogleConnected ? (
+            <div className="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 px-4 py-4 text-sm text-slate-200">
+              <p>
+                Sui wallet 接続を確認できました。投稿の Sponsored
+                対応をこの画面へつなぐ準備中です。
               </p>
-
-              {/* biome-ignore lint: local object URL preview, next/image N/A. */}
-              <img
-                alt="投稿プレビュー"
-                className="max-w-full rounded-xl border border-white/10"
-                src={donePhase.photo.previewUrl}
-              />
-
-              <dl className="grid gap-2">
-                <div className="grid gap-0.5">
-                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                    送信アドレス
-                  </dt>
-                  <dd className="font-mono text-xs break-all">
-                    {donePhase.result.sender}
-                  </dd>
-                </div>
-
-                <div className="grid gap-0.5">
-                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                    submission_no
-                  </dt>
-                  <dd className="font-mono text-sm">
-                    {ownedKakera.kakera
-                      ? `#${ownedKakera.kakera.submissionNo}`
-                      : "確認中…"}
-                  </dd>
-                </div>
-
-                <div className="grid gap-0.5">
-                  <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
-                    digest
-                  </dt>
-                  <dd className="font-mono text-xs break-all">
-                    {donePhase.result.digest}
-                  </dd>
-                </div>
-              </dl>
-
-              <p aria-live="polite" className="text-xs text-emerald-100/90">
-                {describeKakeraStatus(ownedKakera.status)}
+              <p className="font-mono text-xs break-all text-cyan-100">
+                {currentAccount.address}
               </p>
-
+              <p className="text-sm text-slate-300">
+                この段階では履歴ギャラリーの確認だけ利用できます。
+              </p>
               <div className="flex flex-wrap gap-3">
                 <Link
-                  className="inline-flex items-center rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-white"
+                  className="inline-flex items-center rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
                   href="/gallery"
                 >
                   履歴ギャラリーを見る
                 </Link>
+                <button
+                  className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+                  onClick={() => disconnectWallet.mutate()}
+                  type="button"
+                >
+                  接続を解除する
+                </button>
               </div>
             </div>
-          ) : null}
+          ) : (
+            <>
+              <p className="text-sm text-slate-200">
+                zkLogin アドレスを確認できました。投稿の署名に使うのはこの住所です。
+              </p>
+              <p className="font-mono text-xs break-all text-cyan-100">
+                {currentAccount.address}
+              </p>
 
-          <div className="flex flex-wrap gap-3">
-            <button
-              className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
-              onClick={() => disconnectWallet.mutate()}
-              type="button"
-            >
-              ログイン解除
-            </button>
-          </div>
+              {showConsentAndFilePicker ? (
+                <>
+                  <label className="flex items-start gap-2 text-sm text-slate-200">
+                    <input
+                      checked={consented}
+                      className="mt-1"
+                      onChange={(event) => {
+                        setConsented(event.target.checked);
+                      }}
+                      type="checkbox"
+                    />
+                    <span>
+                      投稿した原画像は Walrus に保存され、blob_id
+                      を知る人は誰でも取得できます。 また、参加の証として
+                      Soulbound（譲渡不可）の Kakera NFT
+                      が自分のウォレットに発行されることに同意します。
+                    </span>
+                  </label>
+
+                  <label className="grid gap-2 text-sm text-slate-200">
+                    <span>写真を選択</span>
+                    <input
+                      accept="image/*"
+                      disabled={fileInputDisabled}
+                      onChange={(event) => {
+                        const file = event.target.files?.[0];
+                        if (file) {
+                          void handleFileChange(file);
+                        }
+                      }}
+                      type="file"
+                    />
+                  </label>
+                </>
+              ) : null}
+
+              {isProcessing ? (
+                <p className="text-sm text-slate-300" role="status">
+                  処理中…
+                </p>
+              ) : null}
+
+              {previewPhoto ? (
+                // biome-ignore lint: client-side object URL preview, next/image not applicable.
+                <img
+                  alt="投稿プレビュー"
+                  className="max-w-full rounded-2xl border border-white/10"
+                  src={previewPhoto.previewUrl}
+                />
+              ) : null}
+
+              {isUploading ? (
+                <p className="text-sm text-slate-300" role="status">
+                  Walrus に保存しています…
+                </p>
+              ) : null}
+
+              {isSubmitting ? (
+                <p className="text-sm text-slate-300" role="status">
+                  オンチェーンに投稿しています…
+                </p>
+              ) : null}
+
+              {isRecovering ? (
+                <p className="text-sm text-slate-300" role="status">
+                  投稿結果を確認しています。しばらくお待ちください。
+                </p>
+              ) : null}
+
+              {showSubmitButton ? (
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-200"
+                    disabled={submitButtonDisabled}
+                    onClick={() => {
+                      if (phase.kind === "previewing") {
+                        void handleSubmit(phase.photo);
+                      }
+                    }}
+                    type="button"
+                  >
+                    投稿を確定
+                  </button>
+                </div>
+              ) : null}
+
+              {donePhase ? (
+                <div
+                  className="grid gap-3 rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100"
+                  role="status"
+                >
+                  <p className="text-base">投稿が完了しました。</p>
+                  <p className="text-sm text-emerald-50">
+                    次は履歴ギャラリーで参加記録を確認できます。
+                  </p>
+
+                  {/* biome-ignore lint: local object URL preview, next/image N/A. */}
+                  <img
+                    alt="投稿プレビュー"
+                    className="max-w-full rounded-xl border border-white/10"
+                    src={donePhase.photo.previewUrl}
+                  />
+
+                  <dl className="grid gap-2">
+                    <div className="grid gap-0.5">
+                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                        送信アドレス
+                      </dt>
+                      <dd className="font-mono text-xs break-all">
+                        {donePhase.result.sender}
+                      </dd>
+                    </div>
+
+                    <div className="grid gap-0.5">
+                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                        submission_no
+                      </dt>
+                      <dd className="font-mono text-sm">
+                        {ownedKakera.kakera
+                          ? `#${ownedKakera.kakera.submissionNo}`
+                          : "確認中…"}
+                      </dd>
+                    </div>
+
+                    <div className="grid gap-0.5">
+                      <dt className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">
+                        digest
+                      </dt>
+                      <dd className="font-mono text-xs break-all">
+                        {donePhase.result.digest}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <p aria-live="polite" className="text-xs text-emerald-100/90">
+                    {describeKakeraStatus(ownedKakera.status)}
+                  </p>
+
+                  <div className="flex flex-wrap gap-3">
+                    <Link
+                      className="inline-flex items-center rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-white"
+                      href="/gallery"
+                    >
+                      履歴ギャラリーを見る
+                    </Link>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 hover:border-cyan-200"
+                  onClick={() => disconnectWallet.mutate()}
+                  type="button"
+                >
+                  ログイン解除
+                </button>
+              </div>
+            </>
+          )}
         </>
       ) : (
         <>

--- a/apps/web/src/lib/enoki/client-submit.test.ts
+++ b/apps/web/src/lib/enoki/client-submit.test.ts
@@ -38,7 +38,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction,
         },
       ),
@@ -79,7 +79,7 @@ describe("submitPhotoWithEnoki", () => {
           blobId: "walrus-blob_1",
         },
         {
-          getJwt: async () => null,
+          getAuth: async () => null,
           signTransaction: vi.fn(),
         },
       ),
@@ -87,6 +87,79 @@ describe("submitPhotoWithEnoki", () => {
       code: "auth_expired",
       status: 401,
     });
+  });
+
+  it("supports sender-based sponsorship for a normal wallet", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            bytes: "sponsored-bytes",
+            digest: "sponsor-digest",
+            sender: "0xsender",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            digest: "final-digest",
+          }),
+          { status: 200 },
+        ),
+      );
+
+    await expect(
+      submitPhotoWithEnoki(
+        {
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+        },
+        {
+          fetchFn,
+          getAuth: async () => ({
+            kind: "sender",
+            sender: "0xsender",
+          }),
+          signTransaction: vi.fn(async () => ({
+            signature: "wallet-signature",
+          })),
+        },
+      ),
+    ).resolves.toEqual({
+      digest: "final-digest",
+      sender: "0xsender",
+    });
+
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      1,
+      "/api/enoki/submit-photo/sponsor",
+      expect.objectContaining({
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          unitId:
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          blobId: "walrus-blob_1",
+          sender: "0xsender",
+        }),
+      }),
+    );
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      "/api/enoki/submit-photo/execute",
+      expect.objectContaining({
+        body: JSON.stringify({
+          digest: "sponsor-digest",
+          signature: "wallet-signature",
+          sender: "0xsender",
+        }),
+      }),
+    );
   });
 
   it("passes through structured API errors", async () => {
@@ -109,7 +182,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(),
         },
       ),
@@ -150,7 +223,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(async () => ({
             signature: "wallet-signature",
           })),
@@ -192,7 +265,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(async () => ({
             signature: "wallet-signature",
           })),
@@ -242,7 +315,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(async () => ({
             signature: "wallet-signature",
           })),
@@ -288,7 +361,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(async () => ({
             signature: "wallet-signature",
           })),
@@ -334,7 +407,7 @@ describe("submitPhotoWithEnoki", () => {
         },
         {
           fetchFn,
-          getJwt: async () => "header.jwt.value",
+          getAuth: async () => ({ kind: "jwt", jwt: "header.jwt.value" }),
           signTransaction: vi.fn(async () => ({
             signature: "wallet-signature",
           })),

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -61,12 +61,11 @@ export class EnokiSubmitClientError extends Error {
 
 type SubmitPhotoDeps = {
   readonly fetchFn?: typeof fetch;
-  readonly getAuth: () =>
-    Promise<
-      | { readonly kind: "jwt"; readonly jwt: string }
-      | { readonly kind: "sender"; readonly sender: string }
-      | null
-    >;
+  readonly getAuth: () => Promise<
+    | { readonly kind: "jwt"; readonly jwt: string }
+    | { readonly kind: "sender"; readonly sender: string }
+    | null
+  >;
   readonly signTransaction: (
     transactionBytes: string,
   ) => Promise<{ readonly signature: string }>;

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useCurrentWallet, useSignTransaction } from "@mysten/dapp-kit";
-import { getSession } from "@mysten/enoki";
+import {
+  useCurrentAccount,
+  useCurrentWallet,
+  useSignTransaction,
+} from "@mysten/dapp-kit";
+import { getSession, isGoogleWallet } from "@mysten/enoki";
 import { useState } from "react";
 
 import { ENOKI_JWT_HEADER, type EnokiApiErrorCode } from "./api";
@@ -57,7 +61,12 @@ export class EnokiSubmitClientError extends Error {
 
 type SubmitPhotoDeps = {
   readonly fetchFn?: typeof fetch;
-  readonly getJwt: () => Promise<string | null>;
+  readonly getAuth: () =>
+    Promise<
+      | { readonly kind: "jwt"; readonly jwt: string }
+      | { readonly kind: "sender"; readonly sender: string }
+      | null
+    >;
   readonly signTransaction: (
     transactionBytes: string,
   ) => Promise<{ readonly signature: string }>;
@@ -70,9 +79,9 @@ export async function submitPhotoWithEnoki(
   },
   deps: SubmitPhotoDeps,
 ): Promise<SubmitPhotoSuccess> {
-  const jwt = await deps.getJwt();
+  const auth = await deps.getAuth();
 
-  if (!jwt) {
+  if (!auth) {
     throw new EnokiSubmitClientError(
       401,
       "auth_expired",
@@ -84,7 +93,7 @@ export async function submitPhotoWithEnoki(
   const sponsor = await postJson<SponsorSubmitPhotoResponse>(
     fetchFn,
     "/api/enoki/submit-photo/sponsor",
-    jwt,
+    auth,
     input,
   );
   const signed = await deps.signTransaction(sponsor.bytes);
@@ -94,7 +103,7 @@ export async function submitPhotoWithEnoki(
     executed = await postJson<ExecuteSponsoredResponse>(
       fetchFn,
       "/api/enoki/submit-photo/execute",
-      jwt,
+      auth,
       {
         digest: sponsor.digest,
         signature: signed.signature,
@@ -118,6 +127,7 @@ export function useSubmitPhoto(unitId: string): {
   readonly isSubmitting: boolean;
   readonly submitPhoto: (blobId: string) => Promise<SubmitPhotoSuccess>;
 } {
+  const currentAccount = useCurrentAccount();
   const currentWallet = useCurrentWallet();
   const signTransaction = useSignTransaction();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -134,13 +144,25 @@ export function useSubmitPhoto(unitId: string): {
             blobId,
           },
           {
-            getJwt: async () => {
-              if (!currentWallet.isConnected || !currentWallet.currentWallet) {
+            getAuth: async () => {
+              if (
+                !currentWallet.isConnected ||
+                !currentWallet.currentWallet ||
+                !currentAccount?.address
+              ) {
                 return null;
               }
 
-              const session = await getSession(currentWallet.currentWallet);
-              return session?.jwt?.trim() ?? null;
+              if (isGoogleWallet(currentWallet.currentWallet)) {
+                const session = await getSession(currentWallet.currentWallet);
+                const jwt = session?.jwt?.trim() ?? null;
+                return jwt ? { kind: "jwt", jwt } : null;
+              }
+
+              return {
+                kind: "sender",
+                sender: currentAccount.address,
+              };
             },
             signTransaction: async (transactionBytes) => {
               const signed = await signTransaction.mutateAsync({
@@ -163,16 +185,25 @@ export function useSubmitPhoto(unitId: string): {
 async function postJson<T>(
   fetchFn: typeof fetch,
   url: string,
-  jwt: string,
+  auth:
+    | { readonly kind: "jwt"; readonly jwt: string }
+    | { readonly kind: "sender"; readonly sender: string },
   body: Record<string, string>,
 ): Promise<T> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  const requestBody =
+    auth.kind === "sender" ? { ...body, sender: auth.sender } : body;
+
+  if (auth.kind === "jwt") {
+    headers[ENOKI_JWT_HEADER] = auth.jwt;
+  }
+
   const response = await fetchFn(url, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      [ENOKI_JWT_HEADER]: jwt,
-    },
-    body: JSON.stringify(body),
+    headers,
+    body: JSON.stringify(requestBody),
   });
   const payload = (await response.json().catch(() => null)) as unknown;
 

--- a/apps/web/src/lib/enoki/stub-wallet.ts
+++ b/apps/web/src/lib/enoki/stub-wallet.ts
@@ -22,6 +22,7 @@ import type {
 import { getWallets, SUI_TESTNET_CHAIN } from "@mysten/wallet-standard";
 
 export const E2E_STUB_WALLET_NAME = "ONE Portrait E2E Stub";
+export const E2E_STUB_SUI_WALLET_NAME = "ONE Portrait E2E Sui Stub";
 export const E2E_STUB_ACCOUNT_ADDRESS =
   "0xe2e0000000000000000000000000000000000000000000000000000000000001";
 /** Opaque JWT shipped with the intercepted sponsor/execute requests. */
@@ -89,17 +90,56 @@ type StubFeatures = StandardConnectFeature &
   EnokiGetMetadataFeature &
   EnokiGetSessionFeature;
 
+type PlainStubFeatures = StandardConnectFeature &
+  StandardDisconnectFeature &
+  StandardEventsFeature &
+  SuiSignTransactionFeature &
+  SuiSignPersonalMessageFeature;
+
 type EventListeners = {
   [K in keyof StandardEventsListeners]: Set<StandardEventsListeners[K]>;
 };
 
 function makeStubWallet(): Wallet {
+  return makeWallet({
+    features: makeGoogleFeatures(),
+    name: E2E_STUB_WALLET_NAME,
+  });
+}
+
+function makePlainStubWallet(): Wallet {
+  return makeWallet({
+    features: makePlainFeatures(),
+    name: E2E_STUB_SUI_WALLET_NAME,
+  });
+}
+
+function makeWallet({
+  features,
+  name,
+}: {
+  readonly features: StubFeatures | PlainStubFeatures;
+  readonly name: string;
+}): Wallet {
+  const account = makeStubAccount();
+
+  return {
+    version: "1.0.0",
+    name,
+    icon: ICON_DATA_URL,
+    chains: [SUI_TESTNET_CHAIN],
+    accounts: [account],
+    features,
+  };
+}
+
+function makeGoogleFeatures(): StubFeatures {
   const account = makeStubAccount();
   const listeners: EventListeners = {
     change: new Set(),
   };
 
-  const features: StubFeatures = {
+  return {
     "standard:connect": {
       version: "1.0.0",
       connect: async () => ({ accounts: [account] }),
@@ -144,14 +184,50 @@ function makeStubWallet(): Wallet {
       getSession: async () => ({ jwt: E2E_STUB_JWT }),
     },
   };
+}
+
+function makePlainFeatures(): PlainStubFeatures {
+  const account = makeStubAccount();
+  const listeners: EventListeners = {
+    change: new Set(),
+  };
 
   return {
-    version: "1.0.0",
-    name: E2E_STUB_WALLET_NAME,
-    icon: ICON_DATA_URL,
-    chains: [SUI_TESTNET_CHAIN],
-    accounts: [account],
-    features,
+    "standard:connect": {
+      version: "1.0.0",
+      connect: async () => ({ accounts: [account] }),
+    },
+    "standard:disconnect": {
+      version: "1.0.0",
+      disconnect: async () => {},
+    },
+    "standard:events": {
+      version: "1.0.0",
+      on: (event, listener) => {
+        const bucket = listeners[event];
+        if (!bucket) {
+          return () => {};
+        }
+        bucket.add(listener);
+        return () => {
+          bucket.delete(listener);
+        };
+      },
+    },
+    "sui:signTransaction": {
+      version: "2.0.0",
+      signTransaction: async ({ transaction }) => {
+        const bytes = await transaction.toJSON().catch(() => "AAAA");
+        return { bytes, signature: DUMMY_SIGNATURE };
+      },
+    },
+    "sui:signPersonalMessage": {
+      version: "1.1.0",
+      signPersonalMessage: async ({ message }) => ({
+        bytes: toBase64(message),
+        signature: DUMMY_SIGNATURE,
+      }),
+    },
   };
 }
 
@@ -164,7 +240,12 @@ export function registerE2EStubWallet(): () => void {
     return () => {};
   }
   const api = getWallets();
-  return api.register(makeStubWallet());
+  const unregisterGoogle = api.register(makeStubWallet());
+  const unregisterSui = api.register(makePlainStubWallet());
+  return () => {
+    unregisterSui();
+    unregisterGoogle();
+  };
 }
 
 function toBase64(bytes: Uint8Array): string {

--- a/apps/web/src/lib/enoki/submit-photo.test.ts
+++ b/apps/web/src/lib/enoki/submit-photo.test.ts
@@ -37,6 +37,20 @@ describe("parseSubmitPhotoInput", () => {
       }),
     ).toThrow(EnokiApiError);
   });
+
+  it("accepts a sender override for backend-sponsored wallets", () => {
+    expect(
+      parseSubmitPhotoInput({
+        unitId: VALID_UNIT_ID,
+        blobId: "walrus-blob_1",
+        sender: "0xsender",
+      }),
+    ).toEqual({
+      unitId: VALID_UNIT_ID,
+      blobId: "walrus-blob_1",
+      sender: "0xsender",
+    });
+  });
 });
 
 describe("parseExecuteSponsoredInput", () => {
@@ -49,6 +63,20 @@ describe("parseExecuteSponsoredInput", () => {
     ).toEqual({
       digest: "digest",
       signature: "signature",
+    });
+  });
+
+  it("accepts sender when execute is re-entered from a normal wallet path", () => {
+    expect(
+      parseExecuteSponsoredInput({
+        digest: "digest",
+        signature: "signature",
+        sender: "0xsender",
+      }),
+    ).toEqual({
+      digest: "digest",
+      signature: "signature",
+      sender: "0xsender",
     });
   });
 });
@@ -178,6 +206,47 @@ describe("sponsorSubmitPhoto", () => {
       status: 401,
     });
   });
+
+  it("supports sender-based sponsorship without resolving zkLogin", async () => {
+    const getZkLogin = vi.fn();
+    const createSponsoredTransaction = vi.fn(async () => ({
+      bytes: "sponsored-bytes",
+      digest: "digest",
+    }));
+
+    const result = await sponsorSubmitPhoto(
+      {
+        sender: "0xsender",
+        unitId: VALID_UNIT_ID,
+        blobId: "walrus-blob_1",
+      },
+      {
+        network: "testnet",
+        packageId: "0xpkg",
+        privateApiKey: "private-key",
+      },
+      {
+        enokiClient: {
+          getZkLogin,
+          createSponsoredTransaction,
+        },
+        buildTransactionKind: vi.fn(async () => "kind-bytes"),
+      },
+    );
+
+    expect(getZkLogin).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      bytes: "sponsored-bytes",
+      digest: "digest",
+      sender: "0xsender",
+    });
+    expect(createSponsoredTransaction).toHaveBeenCalledWith({
+      network: "testnet",
+      sender: "0xsender",
+      transactionKindBytes: "kind-bytes",
+      allowedMoveCallTargets: [submitPhotoTarget("0xpkg")],
+    });
+  });
 });
 
 describe("executeSponsoredSubmitPhoto", () => {
@@ -215,6 +284,42 @@ describe("executeSponsoredSubmitPhoto", () => {
     });
 
     expect(getZkLogin).toHaveBeenCalledWith({ jwt: "jwt" });
+    expect(executeSponsoredTransaction).toHaveBeenCalledWith({
+      digest: "digest",
+      signature: "signature",
+    });
+  });
+
+  it("supports sender-based execute without revalidating zkLogin", async () => {
+    const getZkLogin = vi.fn();
+    const executeSponsoredTransaction = vi.fn(async () => ({
+      digest: "digest",
+    }));
+
+    await expect(
+      executeSponsoredSubmitPhoto(
+        {
+          sender: "0xsender",
+          digest: "digest",
+          signature: "signature",
+        },
+        {
+          network: "testnet",
+          packageId: "0xpkg",
+          privateApiKey: "private-key",
+        },
+        {
+          enokiClient: {
+            getZkLogin,
+            executeSponsoredTransaction,
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      digest: "digest",
+    });
+
+    expect(getZkLogin).not.toHaveBeenCalled();
     expect(executeSponsoredTransaction).toHaveBeenCalledWith({
       digest: "digest",
       signature: "signature",

--- a/apps/web/src/lib/enoki/submit-photo.ts
+++ b/apps/web/src/lib/enoki/submit-photo.ts
@@ -127,7 +127,9 @@ export function parseExecuteSponsoredInput(
     keys.length > 3 ||
     !keys.includes("digest") ||
     !keys.includes("signature") ||
-    keys.some((key) => key !== "digest" && key !== "signature" && key !== "sender")
+    keys.some(
+      (key) => key !== "digest" && key !== "signature" && key !== "sender",
+    )
   ) {
     throw invalidArgs(
       "`digest` と `signature`、必要なら `sender` だけを送ってください。",

--- a/apps/web/src/lib/enoki/submit-photo.ts
+++ b/apps/web/src/lib/enoki/submit-photo.ts
@@ -22,11 +22,18 @@ const WALRUS_BLOB_ID_PATTERN = /^[A-Za-z0-9._:-]{1,512}$/;
 export type SubmitPhotoInput = {
   readonly unitId: string;
   readonly blobId: string;
+  readonly sender?: string;
 };
 
 export type ExecuteSponsoredInput = {
   readonly digest: string;
   readonly signature: string;
+  readonly sender?: string;
+};
+
+export type SubmitPhotoAuth = {
+  readonly jwt?: string;
+  readonly sender?: string;
 };
 
 export type SponsorSubmitPhotoResult = {
@@ -68,11 +75,15 @@ export function parseSubmitPhotoInput(input: unknown): SubmitPhotoInput {
 
   const keys = Object.keys(input);
   if (
-    keys.length !== 2 ||
+    keys.length < 2 ||
+    keys.length > 3 ||
     !keys.includes("unitId") ||
-    !keys.includes("blobId")
+    !keys.includes("blobId") ||
+    keys.some((key) => key !== "unitId" && key !== "blobId" && key !== "sender")
   ) {
-    throw invalidArgs("`unitId` と `blobId` だけを送ってください。");
+    throw invalidArgs(
+      "`unitId` と `blobId`、必要なら `sender` だけを送ってください。",
+    );
   }
 
   const unitId = typeof input.unitId === "string" ? input.unitId.trim() : "";
@@ -86,10 +97,21 @@ export function parseSubmitPhotoInput(input: unknown): SubmitPhotoInput {
     throw invalidArgs("`blobId` の形式が不正です。");
   }
 
-  return {
-    unitId,
-    blobId,
-  };
+  const sender =
+    typeof input.sender === "string" && input.sender.trim().length > 0
+      ? input.sender.trim()
+      : undefined;
+
+  return sender
+    ? {
+        unitId,
+        blobId,
+        sender,
+      }
+    : {
+        unitId,
+        blobId,
+      };
 }
 
 export function parseExecuteSponsoredInput(
@@ -101,11 +123,15 @@ export function parseExecuteSponsoredInput(
 
   const keys = Object.keys(input);
   if (
-    keys.length !== 2 ||
+    keys.length < 2 ||
+    keys.length > 3 ||
     !keys.includes("digest") ||
-    !keys.includes("signature")
+    !keys.includes("signature") ||
+    keys.some((key) => key !== "digest" && key !== "signature" && key !== "sender")
   ) {
-    throw invalidArgs("`digest` と `signature` だけを送ってください。");
+    throw invalidArgs(
+      "`digest` と `signature`、必要なら `sender` だけを送ってください。",
+    );
   }
 
   const digest = typeof input.digest === "string" ? input.digest.trim() : "";
@@ -116,10 +142,21 @@ export function parseExecuteSponsoredInput(
     throw invalidArgs("`digest` と `signature` は必須です。");
   }
 
-  return {
-    digest,
-    signature,
-  };
+  const sender =
+    typeof input.sender === "string" && input.sender.trim().length > 0
+      ? input.sender.trim()
+      : undefined;
+
+  return sender
+    ? {
+        digest,
+        signature,
+        sender,
+      }
+    : {
+        digest,
+        signature,
+      };
 }
 
 export function readZkLoginJwt(headers: Headers): string {
@@ -166,14 +203,26 @@ export function resolveRuntimeEnv(
 }
 
 export async function sponsorSubmitPhoto(
-  input: SubmitPhotoInput & { readonly jwt: string },
+  input: SubmitPhotoInput & SubmitPhotoAuth,
   env: RuntimeEnv,
   deps: SponsorDeps = createSponsorDeps(env.privateApiKey),
 ): Promise<SponsorSubmitPhotoResult> {
   try {
-    const zkLogin = await deps.enokiClient.getZkLogin({
-      jwt: input.jwt,
-    });
+    const sender = input.jwt
+      ? (
+          await deps.enokiClient.getZkLogin({
+            jwt: input.jwt,
+          })
+        ).address
+      : input.sender;
+
+    if (!sender) {
+      throw new EnokiApiError(
+        401,
+        "auth_expired",
+        "ログイン情報を確認できません。もう一度お試しください。",
+      );
+    }
     const transactionKindBytes = await deps.buildTransactionKind({
       network: env.network,
       packageId: env.packageId,
@@ -183,7 +232,7 @@ export async function sponsorSubmitPhoto(
 
     const sponsored = await deps.enokiClient.createSponsoredTransaction({
       network: env.network,
-      sender: zkLogin.address,
+      sender,
       transactionKindBytes,
       allowedMoveCallTargets: [submitPhotoTarget(env.packageId)],
     });
@@ -191,7 +240,7 @@ export async function sponsorSubmitPhoto(
     return {
       bytes: sponsored.bytes,
       digest: sponsored.digest,
-      sender: zkLogin.address,
+      sender,
     };
   } catch (error) {
     throw mapEnokiError(error);
@@ -199,14 +248,16 @@ export async function sponsorSubmitPhoto(
 }
 
 export async function executeSponsoredSubmitPhoto(
-  input: ExecuteSponsoredInput & { readonly jwt: string },
+  input: ExecuteSponsoredInput & SubmitPhotoAuth,
   env: RuntimeEnv,
   deps: ExecuteDeps = createExecuteDeps(env.privateApiKey),
 ): Promise<{ digest: string }> {
   try {
-    await deps.enokiClient.getZkLogin({
-      jwt: input.jwt,
-    });
+    if (input.jwt) {
+      await deps.enokiClient.getZkLogin({
+        jwt: input.jwt,
+      });
+    }
 
     return await deps.enokiClient.executeSponsoredTransaction({
       digest: input.digest,

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -19,6 +19,7 @@ import type { Page, Route } from "@playwright/test";
 
 import {
   E2E_STUB_ACCOUNT_ADDRESS,
+  E2E_STUB_SUI_WALLET_NAME,
   E2E_STUB_WALLET_NAME,
 } from "../../../src/lib/enoki/stub-wallet";
 
@@ -63,6 +64,7 @@ type MockHttpResponse = {
 
 export type InstallMockOptions = {
   readonly autoConnectWallet?: boolean;
+  readonly autoConnectWalletKind?: "google" | "sui";
   readonly executeApiMode?: "success" | "recovering_http_error";
   /**
    * Deterministic gallery switch used by the E2E suite:
@@ -103,6 +105,7 @@ export async function installDefaultMocks(
     lastFinalizeUnitId: null,
   };
   const autoConnectWallet = options.autoConnectWallet ?? true;
+  const autoConnectWalletKind = options.autoConnectWalletKind ?? "google";
   const executeApiMode = options.executeApiMode ?? "success";
   const galleryEntryMode = options.galleryEntryMode ?? "empty";
   const originalImageMode = options.originalImageMode ?? "success";
@@ -132,7 +135,13 @@ export async function installDefaultMocks(
           // localStorage may be unavailable (iframe / privacy mode); swallow.
         }
       },
-      { walletName: E2E_STUB_WALLET_NAME, address: E2E_STUB_ACCOUNT_ADDRESS },
+      {
+        walletName:
+          autoConnectWalletKind === "sui"
+            ? E2E_STUB_SUI_WALLET_NAME
+            : E2E_STUB_WALLET_NAME,
+        address: E2E_STUB_ACCOUNT_ADDRESS,
+      },
     );
   }
 

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -54,11 +54,14 @@ test.describe("home smoke", () => {
 
     await expect(
       page.getByText(
-        /先に Google でログインすると、あなたの Kakera 履歴を読み込めます。/,
+        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
       ),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Google でログイン" }),
+      page.getByRole("button", { name: "Google zkLogin" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sui wallet" }),
     ).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -70,11 +70,14 @@ test.describe("readiness regression", () => {
 
     await expect(
       page.getByText(
-        /先に Google でログインすると、あなたの Kakera 履歴を読み込めます。/,
+        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
       ),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Google でログイン" }),
+      page.getByRole("button", { name: "Google zkLogin" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sui wallet" }),
     ).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -35,6 +35,31 @@ async function submitPhoto(page: Page): Promise<void> {
   await page.getByRole("button", { name: "投稿を確定" }).click();
 }
 
+async function submitPhotoWithExpectedWallet(
+  page: Page,
+  connectedCopy: RegExp,
+): Promise<void> {
+  await page.goto(`/units/${STUB_UNIT_ID}`);
+
+  await expect(page.getByText(connectedCopy)).toBeVisible();
+
+  await page
+    .getByRole("checkbox", {
+      name: /投稿した原画像は Walrus に保存され/,
+    })
+    .check();
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: TINY_JPEG_NAME,
+    mimeType: TINY_JPEG_MIME,
+    buffer: TINY_JPEG_BUFFER,
+  });
+
+  await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "投稿を確定" }).click();
+}
+
 test.describe("submit happy path", () => {
   test("signs in via stub wallet and posts a photo through to Kakera", async ({
     page,
@@ -145,5 +170,23 @@ test.describe("submit happy path", () => {
     await expect(
       page.getByRole("button", { name: "もう一度送信する" }),
     ).toBeVisible();
+  });
+
+  test("submits successfully from a normal Sui wallet through the sponsored sender flow", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { autoConnectWalletKind: "sui" });
+    await submitPhotoWithExpectedWallet(
+      page,
+      /Sui wallet アドレスを確認できました/,
+    );
+
+    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("#1")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- add a shared header + wallet entry so home, waiting room, and gallery expose both Google zkLogin and standard Sui wallet entry points
- extend the sponsored submit flow to support sender-based sponsorship for standard Sui wallets while preserving the existing Google zkLogin path
- update waiting-room/gallery copy plus E2E stub coverage so the normal wallet path is exercised end-to-end

## Test Plan
- pnpm run check
- pnpm run build
- pnpm --filter web exec playwright test tests/e2e/home-smoke.spec.ts tests/e2e/readiness-regression.spec.ts tests/e2e/gallery-states.spec.ts tests/e2e/waiting-room-smoke.spec.ts tests/e2e/waiting-room-submit.spec.ts tests/e2e/submit-happy.spec.ts

Closes #47