### PR TITLE
fix: /admin UI を日本語化する

### DIFF
--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -96,7 +96,7 @@ describe("AdminClient", () => {
       />,
     );
 
-    const input = screen.getByLabelText(/target image/i) as HTMLInputElement;
+    const input = screen.getByLabelText(/対象画像/) as HTMLInputElement;
     const file = new File(["target"], "target.jpg", { type: "image/jpeg" });
 
     fireEvent.change(input, {
@@ -108,7 +108,9 @@ describe("AdminClient", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("target-blob-9")).toBeTruthy();
     });
-    expect(screen.getByAltText("Uploaded target preview")).toBeTruthy();
+    expect(
+      screen.getByAltText("アップロードした対象画像のプレビュー"),
+    ).toBeTruthy();
   });
 
   it("submits create-unit and records the latest action", async () => {
@@ -188,14 +190,14 @@ describe("AdminClient", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText(/target blob id/i), {
+    fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
       target: { value: "target-blob-1" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /create unit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /ユニットを作成/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("Create unit completed")).toBeTruthy();
+      expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
     });
-    expect(screen.getByText(/digest: 0xcreate/)).toBeTruthy();
+    expect(screen.getByText(/ダイジェスト: 0xcreate/)).toBeTruthy();
   });
 });

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -324,10 +324,12 @@ export function AdminClient({
 
         <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-stone-950/60 p-6">
           <div className="grid gap-1">
-            <h2 className="font-serif text-2xl text-white">ユニットを切り替え</h2>
+            <h2 className="font-serif text-2xl text-white">
+              ユニットを切り替え
+            </h2>
             <p className="text-sm leading-6 text-stone-300">
-              選択した選手の現在ユニットを切り替えます。直前に作成した
-              unit ID は自動でここに反映されます。
+              選択した選手の現在ユニットを切り替えます。直前に作成した unit ID
+              は自動でここに反映されます。
             </p>
           </div>
 
@@ -384,8 +386,8 @@ export function AdminClient({
         <div className="grid gap-1">
           <h2 className="font-serif text-2xl text-white">現在の状態</h2>
           <p className="text-sm leading-6 text-stone-300">
-            各選手の現在ユニット状態を確認し、filled のまま停止した
-            ユニットで finalize を再試行できます。
+            各選手の現在ユニット状態を確認し、filled のまま停止した ユニットで
+            finalize を再試行できます。
           </p>
         </div>
 
@@ -475,10 +477,7 @@ function AdminAthleteCard({
               value={`${currentUnit.submittedCount} / ${currentUnit.maxSlots}`}
             />
             <InfoRow label="ステータス" value={currentUnit.status} />
-            <InfoRow
-              label="対象 blob"
-              value={currentUnit.targetWalrusBlobId}
-            />
+            <InfoRow label="対象 blob" value={currentUnit.targetWalrusBlobId} />
           </dl>
           <button
             className="rounded-full border border-emerald-200/30 bg-emerald-300/20 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-300/30 disabled:cursor-not-allowed disabled:opacity-60"
@@ -530,15 +529,11 @@ async function postJson(
 
 function formatActionDetail(payload: Record<string, unknown>): string {
   const parts = [
-    typeof payload.status === "string"
-      ? `ステータス: ${payload.status}`
-      : null,
+    typeof payload.status === "string" ? `ステータス: ${payload.status}` : null,
     typeof payload.digest === "string"
       ? `ダイジェスト: ${payload.digest}`
       : null,
-    typeof payload.unitId === "string"
-      ? `ユニットID: ${payload.unitId}`
-      : null,
+    typeof payload.unitId === "string" ? `ユニットID: ${payload.unitId}` : null,
     typeof payload.mosaicBlobId === "string"
       ? `モザイク Blob ID: ${payload.mosaicBlobId}`
       : null,

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -71,7 +71,7 @@ export function AdminClient({
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "Refresh failed",
+        summary: "状態の更新に失敗しました",
       });
     } finally {
       setIsRefreshing(false);
@@ -104,12 +104,12 @@ export function AdminClient({
       setTargetBlobId(uploaded.blobId);
       setLastAction({
         detail: uploaded.blobId,
-        summary: "Target uploaded",
+        summary: "対象画像をアップロードしました",
       });
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "Target upload failed",
+        summary: "対象画像のアップロードに失敗しました",
       });
     } finally {
       setIsUploading(false);
@@ -135,13 +135,13 @@ export function AdminClient({
 
       setLastAction({
         detail: formatActionDetail(payload),
-        summary: "Create unit completed",
+        summary: "ユニットを作成しました",
       });
       await refreshAll();
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "Create unit failed",
+        summary: "ユニットの作成に失敗しました",
       });
     } finally {
       setPendingAction(null);
@@ -160,13 +160,13 @@ export function AdminClient({
 
       setLastAction({
         detail: formatActionDetail(payload),
-        summary: "Rotate unit completed",
+        summary: "ユニットを切り替えました",
       });
       await refreshAll();
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "Rotate unit failed",
+        summary: "ユニットの切り替えに失敗しました",
       });
     } finally {
       setPendingAction(null);
@@ -181,13 +181,13 @@ export function AdminClient({
 
       setLastAction({
         detail: formatActionDetail(payload),
-        summary: "Finalize retry completed",
+        summary: "finalize を再試行しました",
       });
       await refreshAll();
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "Finalize retry failed",
+        summary: "finalize の再試行に失敗しました",
       });
     } finally {
       setPendingAction(null);
@@ -203,17 +203,17 @@ export function AdminClient({
           onClick={() => void refreshAll()}
           type="button"
         >
-          {isRefreshing ? "Refreshing..." : "Refresh status"}
+          {isRefreshing ? "更新中..." : "状態を更新"}
         </button>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <HealthCard
-          label="Generator readiness"
+          label="ジェネレーター準備状態"
           value={health.generatorReadiness.status}
         />
         <HealthCard
-          label="Dispatch authorization"
+          label="ディスパッチ認可"
           value={health.dispatchAuthorization.status}
         />
       </div>
@@ -221,7 +221,7 @@ export function AdminClient({
       {lastAction ? (
         <section className="grid gap-2 rounded-[1.5rem] border border-emerald-200/20 bg-emerald-300/10 p-5">
           <h2 className="text-sm uppercase tracking-[0.25em] text-emerald-200/80">
-            Last action
+            直近の操作
           </h2>
           <p className="text-xl font-semibold text-white">
             {lastAction.summary}
@@ -235,10 +235,10 @@ export function AdminClient({
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-stone-950/60 p-6">
           <div className="grid gap-1">
-            <h2 className="font-serif text-2xl text-white">Create next unit</h2>
+            <h2 className="font-serif text-2xl text-white">ユニットを作成</h2>
             <p className="text-sm leading-6 text-stone-300">
-              Upload the target portrait, confirm the blob id, and create a new
-              unit for the selected athlete.
+              対象ポートレートをアップロードして blob ID を確認し、選択した
+              選手向けの新しいユニットを作成します。
             </p>
           </div>
 
@@ -247,7 +247,7 @@ export function AdminClient({
             onSubmit={(event) => void handleCreateUnit(event)}
           >
             <label className="grid gap-2 text-sm text-stone-200">
-              Athlete
+              選手
               <select
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
                 onChange={(event) => setSelectedAthleteId(event.target.value)}
@@ -265,7 +265,7 @@ export function AdminClient({
             </label>
 
             <label className="grid gap-2 text-sm text-stone-200">
-              Target image
+              対象画像
               <input
                 accept="image/*"
                 className="rounded-2xl border border-dashed border-white/20 bg-stone-900 px-4 py-3"
@@ -277,24 +277,24 @@ export function AdminClient({
             {targetPreviewUrl ? (
               // biome-ignore lint/performance/noImgElement: operator preview
               <img
-                alt="Uploaded target preview"
+                alt="アップロードした対象画像のプレビュー"
                 className="h-48 w-full rounded-2xl border border-white/10 object-cover"
                 src={targetPreviewUrl}
               />
             ) : null}
 
             <label className="grid gap-2 text-sm text-stone-200">
-              Target blob id
+              対象 blob ID
               <input
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3 font-mono text-xs"
                 onChange={(event) => setTargetBlobId(event.target.value)}
-                placeholder="Upload first or paste a blob id manually"
+                placeholder="先にアップロードするか、blob ID を直接入力してください"
                 value={targetBlobId}
               />
             </label>
 
             <label className="grid gap-2 text-sm text-stone-200">
-              Max slots
+              最大スロット数
               <input
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
                 inputMode="numeric"
@@ -314,22 +314,20 @@ export function AdminClient({
               type="submit"
             >
               {isUploading
-                ? "Uploading target..."
+                ? "対象画像をアップロード中..."
                 : pendingAction === "create"
-                  ? "Creating..."
-                  : "Create unit"}
+                  ? "作成中..."
+                  : "ユニットを作成"}
             </button>
           </form>
         </section>
 
         <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-stone-950/60 p-6">
           <div className="grid gap-1">
-            <h2 className="font-serif text-2xl text-white">
-              Rotate current unit
-            </h2>
+            <h2 className="font-serif text-2xl text-white">ユニットを切り替え</h2>
             <p className="text-sm leading-6 text-stone-300">
-              Switch the active unit for the selected athlete. The last created
-              unit id is copied here automatically.
+              選択した選手の現在ユニットを切り替えます。直前に作成した
+              unit ID は自動でここに反映されます。
             </p>
           </div>
 
@@ -338,7 +336,7 @@ export function AdminClient({
             onSubmit={(event) => void handleRotateUnit(event)}
           >
             <label className="grid gap-2 text-sm text-stone-200">
-              Athlete
+              選手
               <select
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
                 onChange={(event) => setRotateAthleteId(event.target.value)}
@@ -356,7 +354,7 @@ export function AdminClient({
             </label>
 
             <label className="grid gap-2 text-sm text-stone-200">
-              Next unit id
+              次のユニット ID
               <input
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3 font-mono text-xs"
                 onChange={(event) => setRotateUnitId(event.target.value)}
@@ -375,8 +373,8 @@ export function AdminClient({
               type="submit"
             >
               {pendingAction === "rotate"
-                ? "Rotating..."
-                : "Rotate current unit"}
+                ? "切り替え中..."
+                : "ユニットを切り替え"}
             </button>
           </form>
         </section>
@@ -384,12 +382,10 @@ export function AdminClient({
 
       <section className="grid gap-4">
         <div className="grid gap-1">
-          <h2 className="font-serif text-2xl text-white">
-            Current unit status
-          </h2>
+          <h2 className="font-serif text-2xl text-white">現在の状態</h2>
           <p className="text-sm leading-6 text-stone-300">
-            Check the live unit state for each athlete and retry finalize when a
-            filled unit stalls.
+            各選手の現在ユニット状態を確認し、filled のまま停止した
+            ユニットで finalize を再試行できます。
           </p>
         </div>
 
@@ -473,14 +469,14 @@ function AdminAthleteCard({
       {currentUnit ? (
         <>
           <dl className="grid gap-2 text-sm text-stone-200">
-            <InfoRow label="Unit id" value={currentUnit.unitId} />
+            <InfoRow label="ユニット ID" value={currentUnit.unitId} />
             <InfoRow
-              label="Progress"
+              label="進行状況"
               value={`${currentUnit.submittedCount} / ${currentUnit.maxSlots}`}
             />
-            <InfoRow label="Status" value={currentUnit.status} />
+            <InfoRow label="ステータス" value={currentUnit.status} />
             <InfoRow
-              label="Target blob"
+              label="対象 blob"
               value={currentUnit.targetWalrusBlobId}
             />
           </dl>
@@ -491,15 +487,15 @@ function AdminAthleteCard({
             type="button"
           >
             {pendingAction === `finalize:${currentUnit.unitId}`
-              ? "Retrying..."
-              : "Retry finalize"}
+              ? "再試行中..."
+              : "finalize を再試行"}
           </button>
         </>
       ) : (
         <p className="text-sm leading-6 text-stone-300">
           {athlete.lookupState === "missing"
-            ? "No current unit is registered for this athlete yet."
-            : "Current unit state is temporarily unavailable."}
+            ? "この選手にはまだ現在ユニットが登録されていません。"
+            : "現在ユニットの状態を一時的に取得できません。"}
         </p>
       )}
     </article>
@@ -523,7 +519,9 @@ async function postJson(
 
   if (!response.ok) {
     throw new Error(
-      typeof json.message === "string" ? json.message : "Request failed.",
+      typeof json.message === "string"
+        ? json.message
+        : "リクエストに失敗しました。",
     );
   }
 
@@ -532,11 +530,17 @@ async function postJson(
 
 function formatActionDetail(payload: Record<string, unknown>): string {
   const parts = [
-    typeof payload.status === "string" ? `status: ${payload.status}` : null,
-    typeof payload.digest === "string" ? `digest: ${payload.digest}` : null,
-    typeof payload.unitId === "string" ? `unitId: ${payload.unitId}` : null,
+    typeof payload.status === "string"
+      ? `ステータス: ${payload.status}`
+      : null,
+    typeof payload.digest === "string"
+      ? `ダイジェスト: ${payload.digest}`
+      : null,
+    typeof payload.unitId === "string"
+      ? `ユニットID: ${payload.unitId}`
+      : null,
     typeof payload.mosaicBlobId === "string"
-      ? `mosaicBlobId: ${payload.mosaicBlobId}`
+      ? `モザイク Blob ID: ${payload.mosaicBlobId}`
       : null,
   ].filter((value): value is string => value !== null);
 

--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -76,7 +76,7 @@ describe("AdminPage", () => {
     const ui = await AdminPage();
     render(ui);
 
-    expect(screen.getByText(/demo admin console/i)).toBeTruthy();
+    expect(screen.getByText(/デモ管理コンソール/)).toBeTruthy();
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -27,20 +27,20 @@ export default async function AdminPage(): Promise<React.ReactElement> {
             className="text-sm uppercase tracking-[0.3em] text-amber-200/80 hover:text-amber-100"
             href="/"
           >
-            ← Demo home
+            ← デモホームへ
           </Link>
         </nav>
 
         <header className="grid gap-4 rounded-[2rem] border border-white/10 bg-white/6 p-8 shadow-2xl shadow-black/30 backdrop-blur">
           <p className="text-xs uppercase tracking-[0.3em] text-amber-200/80">
-            Operator
+            管理者
           </p>
           <h1 className="font-serif text-4xl text-white md:text-5xl">
-            Demo admin console
+            デモ管理コンソール
           </h1>
           <p className="max-w-3xl text-base leading-7 text-stone-200">
-            Upload the target image, create the next unit, rotate the current
-            unit, and retry finalize from one page.
+            対象画像のアップロード、次のユニット作成、現在ユニットの切り替え、
+            finalize の再試行をこの 1 ページで操作できます。
           </p>
         </header>
 


### PR DESCRIPTION
## 概要
`/admin` 画面の可視 UI 文言を日本語化し、操作結果や空状態も日本語で把握できるようにします。

## 変更内容
- `apps/web/src/app/admin/page.tsx`
  - 戻りリンク、管理ラベル、ページタイトル、説明文を日本語化
- `apps/web/src/app/admin/admin-client.tsx`
  - 操作ボタン、ヘルス表示、フォームラベル、空状態、進行中表示、成功失敗メッセージを日本語化
  - `formatActionDetail` の表示ラベルと汎用エラーメッセージを日本語化
- `apps/web/src/app/admin/page.test.tsx`
  - サーバー描画ページの見出し期待値を更新
- `apps/web/src/app/admin/admin-client.test.tsx`
  - フォームラベル、プレビュー alt、アクション結果の期待値を更新

## 関連する Issue やチケット
なし

## 動作確認
- `pnpm --filter web test -- src/app/admin/page.test.tsx src/app/admin/admin-client.test.tsx`
- `pnpm --filter web typecheck`
