### PR TITLE
fix: GitHub Actions の Node 20 warning を解消する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ on:
       - "pnpm-workspace.yaml"
       - ".github/workflows/e2e.yml"
 
+permissions:
+  contents: read
+
 jobs:
   playwright:
     runs-on: ubuntu-latest
@@ -17,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.33.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: apps/web/playwright-report/
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test-results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: apps/web/test-results/

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,6 +17,9 @@ on:
       - "biome.json"
       - ".github/workflows/**"
 
+permissions:
+  contents: read
+
 jobs:
   static-check:
     runs-on: ubuntu-latest
@@ -32,15 +35,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.33.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/move-ci.yml
+++ b/.github/workflows/move-ci.yml
@@ -6,6 +6,9 @@ on:
       - "contracts/**"
       - ".github/workflows/**"
 
+permissions:
+  contents: read
+
 jobs:
   move-check:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Sui CLI
         run: |


### PR DESCRIPTION
## 概要
GitHub Actions で出ている Node 20 deprecation warning を解消します。
workflow 内で使う JavaScript action を Node 24 対応版へ上げ、既定権限への依存もなくします。

## 変更内容
- `.github/workflows/frontend-ci.yml`
  - `actions/checkout`、`pnpm/action-setup`、`actions/setup-node` を `v5` に更新
  - `permissions: contents: read` を追加
- `.github/workflows/e2e.yml`
  - `actions/checkout`、`pnpm/action-setup`、`actions/setup-node` を `v5` に更新
  - `actions/upload-artifact` を `v6` に更新
  - `permissions: contents: read` を追加
- `.github/workflows/move-ci.yml`
  - `actions/checkout` を `v5` に更新
  - `permissions: contents: read` を追加

## 関連する Issue やチケット
Close #59

## 動作確認
- `corepack pnpm run check`
- `corepack pnpm run typecheck`
- `corepack pnpm test`
- PR 上で `frontend-ci` / `e2e` / `move-ci` を確認
