### PR TITLE
fix: Sui ConnectModal が画面外に出る不具合を修正

### DIFF
--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -1,11 +1,18 @@
 // @vitest-environment happy-dom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 
 const {
+  connectModalMock,
   useCurrentAccountMock,
   useCurrentWalletMock,
   useWalletsMock,
@@ -14,6 +21,7 @@ const {
   listOwnedKakeraMock,
   getGalleryEntryMock,
 } = vi.hoisted(() => ({
+  connectModalMock: vi.fn(),
   useCurrentAccountMock: vi.fn(),
   useCurrentWalletMock: vi.fn(),
   useWalletsMock: vi.fn(),
@@ -24,9 +32,10 @@ const {
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
-  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
-    <>{trigger}</>
-  ),
+  ConnectModal: (props: { readonly trigger: React.ReactNode }) => {
+    connectModalMock(props);
+    return <>{props.trigger}</>;
+  },
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
   useWallets: () => useWalletsMock(),
@@ -129,6 +138,7 @@ afterEach(() => {
   delete process.env.NEXT_PUBLIC_DEMO_MODE;
   delete process.env.NEXT_PUBLIC_E2E_STUB_WALLET;
   delete process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR;
+  connectModalMock.mockReset();
   useCurrentAccountMock.mockReset();
   useCurrentWalletMock.mockReset();
   useWalletsMock.mockReset();
@@ -150,6 +160,21 @@ describe("GalleryClient", () => {
     expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
     expect(listOwnedKakeraMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the signed-out Sui wallet modal controlled", async () => {
+    render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
+
+    const initialProps = connectModalMock.mock.calls.at(-1)?.[0];
+    expect(initialProps?.open).toBe(false);
+
+    act(() => {
+      initialProps?.onOpenChange(true);
+    });
+
+    await waitFor(() => {
+      expect(connectModalMock.mock.calls.at(-1)?.[0]?.open).toBe(true);
+    });
   });
 
   it("keeps the signed-out shell until an account becomes available", async () => {

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ConnectModal,
   useConnectWallet,
   useCurrentAccount,
   useCurrentWallet,
@@ -15,6 +14,7 @@ import type { AthleteCatalogEntry } from "../../lib/catalog";
 import { getDemoModeSource, isDemoModeEnabled } from "../../lib/demo";
 import type { GalleryEntryView, OwnedKakera } from "../../lib/sui";
 import { getGalleryEntry, getSuiClient, listOwnedKakera } from "../../lib/sui";
+import { SuiWalletConnectModal } from "../sui-wallet-connect-modal";
 
 export type GalleryClientProps = {
   readonly catalog: readonly AthleteCatalogEntry[];
@@ -225,7 +225,7 @@ function ConnectedGalleryClient({
                 ? "Google zkLogin をやり直す"
                 : "Google zkLogin"}
           </button>
-          <ConnectModal
+          <SuiWalletConnectModal
             trigger={
               <button
                 className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"
@@ -234,7 +234,6 @@ function ConnectedGalleryClient({
                 Sui wallet
               </button>
             }
-            walletFilter={(wallet) => !isGoogleWallet(wallet)}
           />
         </div>
         {connectError ? (

--- a/apps/web/src/app/global-wallet-entry.test.tsx
+++ b/apps/web/src/app/global-wallet-entry.test.tsx
@@ -1,9 +1,16 @@
 // @vitest-environment happy-dom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  connectModalMock,
   useEnokiConfigStateMock,
   useWalletsMock,
   useCurrentAccountMock,
@@ -11,6 +18,7 @@ const {
   useConnectWalletMock,
   useDisconnectWalletMock,
 } = vi.hoisted(() => ({
+  connectModalMock: vi.fn(),
   useEnokiConfigStateMock: vi.fn(),
   useWalletsMock: vi.fn(),
   useCurrentAccountMock: vi.fn(),
@@ -24,9 +32,10 @@ vi.mock("../lib/enoki/provider", () => ({
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
-  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
-    <>{trigger}</>
-  ),
+  ConnectModal: (props: { readonly trigger: React.ReactNode }) => {
+    connectModalMock(props);
+    return <>{props.trigger}</>;
+  },
   useWallets: () => useWalletsMock(),
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
@@ -65,6 +74,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  connectModalMock.mockReset();
   useEnokiConfigStateMock.mockReset();
   useWalletsMock.mockReset();
   useCurrentAccountMock.mockReset();
@@ -93,6 +103,25 @@ describe("GlobalWalletEntry", () => {
 
     expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
+  });
+
+  it("keeps the Sui wallet connect modal controlled", async () => {
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
+
+    const initialProps = connectModalMock.mock.calls.at(-1)?.[0];
+    expect(initialProps?.open).toBe(false);
+    expect(initialProps?.walletFilter({ id: "google-wallet" })).toBe(false);
+    expect(initialProps?.walletFilter({ id: "sui-wallet" })).toBe(true);
+
+    act(() => {
+      initialProps?.onOpenChange(true);
+    });
+
+    await waitFor(() => {
+      expect(connectModalMock.mock.calls.at(-1)?.[0]?.open).toBe(true);
+    });
   });
 
   it("starts Google login from the shared menu", async () => {

--- a/apps/web/src/app/global-wallet-entry.tsx
+++ b/apps/web/src/app/global-wallet-entry.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ConnectModal,
   useConnectWallet,
   useCurrentAccount,
   useCurrentWallet,
@@ -12,6 +11,7 @@ import { isGoogleWallet } from "@mysten/enoki";
 import { useEffect, useRef, useState } from "react";
 
 import { useEnokiConfigState } from "../lib/enoki/provider";
+import { SuiWalletConnectModal } from "./sui-wallet-connect-modal";
 
 function shortenAddress(address: string): string {
   if (address.length <= 12) {
@@ -130,7 +130,7 @@ function GlobalWalletEntryEnabled(): React.ReactElement {
             >
               Google zkLogin
             </button>
-            <ConnectModal
+            <SuiWalletConnectModal
               trigger={
                 <button
                   className="rounded-2xl border border-white/10 px-4 py-3 text-left text-sm font-medium text-white transition hover:border-cyan-200/60"
@@ -139,7 +139,6 @@ function GlobalWalletEntryEnabled(): React.ReactElement {
                   Sui wallet
                 </button>
               }
-              walletFilter={(wallet) => !isGoogleWallet(wallet)}
             />
 
             {connectError ? (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { AppWalletProvider } from "../lib/enoki/provider";
 import { AppShell } from "./app-shell";
 
+import "@mysten/dapp-kit/dist/index.css";
 import "./globals.css";
 
 export const metadata: Metadata = {

--- a/apps/web/src/app/sui-wallet-connect-modal.tsx
+++ b/apps/web/src/app/sui-wallet-connect-modal.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ConnectModal } from "@mysten/dapp-kit";
+import { isGoogleWallet } from "@mysten/enoki";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+export function SuiWalletConnectModal({
+  trigger,
+}: {
+  readonly trigger: NonNullable<ReactNode>;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ConnectModal
+      onOpenChange={setOpen}
+      open={open}
+      trigger={trigger}
+      walletFilter={(wallet) => !isGoogleWallet(wallet)}
+    />
+  );
+}

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -14,6 +14,7 @@ import type { SubmittedEvent } from "../../../lib/sui";
 import type { UseUnitEventsArgs } from "../../../lib/sui/react";
 
 const {
+  connectModalMock,
   useEnokiConfigStateMock,
   useSubmitPhotoMock,
   useWalletsMock,
@@ -26,6 +27,7 @@ const {
   useUnitEventsMock,
   checkSubmissionExecutionMock,
 } = vi.hoisted(() => ({
+  connectModalMock: vi.fn(),
   useEnokiConfigStateMock: vi.fn(),
   useSubmitPhotoMock: vi.fn(),
   useWalletsMock: vi.fn(),
@@ -82,9 +84,10 @@ vi.mock("@mysten/enoki", () => ({
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
-  ConnectModal: ({ trigger }: { readonly trigger: React.ReactNode }) => (
-    <>{trigger}</>
-  ),
+  ConnectModal: (props: { readonly trigger: React.ReactNode }) => {
+    connectModalMock(props);
+    return <>{props.trigger}</>;
+  },
   useWallets: () => useWalletsMock(),
   useCurrentAccount: () => useCurrentAccountMock(),
   useCurrentWallet: () => useCurrentWalletMock(),
@@ -147,6 +150,7 @@ function setupSignedInEnv({
 
 afterEach(() => {
   vi.useRealTimers();
+  connectModalMock.mockReset();
   useEnokiConfigStateMock.mockReset();
   useSubmitPhotoMock.mockReset();
   useWalletsMock.mockReset();
@@ -227,6 +231,40 @@ describe("ParticipationAccess", () => {
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
+  });
+
+  it("keeps the signed-out Sui wallet modal controlled", async () => {
+    useEnokiConfigStateMock.mockReturnValue({
+      submitEnabled: true,
+      config: {},
+    });
+    useWalletsMock.mockReturnValue([
+      { id: "google-wallet" },
+      { id: "sui-wallet" },
+    ]);
+    useCurrentAccountMock.mockReturnValue(null);
+    useCurrentWalletMock.mockReturnValue({
+      connectionStatus: "disconnected",
+    });
+    useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
+    useSubmitPhotoMock.mockReturnValue({
+      isSubmitting: false,
+      submitPhoto: vi.fn(),
+    });
+
+    render(<ParticipationAccess unitId="0xunit-1" />);
+
+    const initialProps = connectModalMock.mock.calls.at(-1)?.[0];
+    expect(initialProps?.open).toBe(false);
+
+    act(() => {
+      initialProps?.onOpenChange(true);
+    });
+
+    await waitFor(() => {
+      expect(connectModalMock.mock.calls.at(-1)?.[0]?.open).toBe(true);
+    });
   });
 
   it("allows a connected Sui wallet to continue into the submit form", () => {

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ConnectModal,
   useConnectWallet,
   useCurrentAccount,
   useCurrentWallet,
@@ -35,6 +34,7 @@ import {
   WalrusPutError,
   type WalrusPutResult,
 } from "../../../lib/walrus/put";
+import { SuiWalletConnectModal } from "../../sui-wallet-connect-modal";
 
 /**
  * Waiting-room submission access.
@@ -647,7 +647,7 @@ function ParticipationAccessEnabled({
                   ? "Google zkLogin をやり直す"
                   : "Google zkLogin"}
             </button>
-            <ConnectModal
+            <SuiWalletConnectModal
               trigger={
                 <button
                   className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"
@@ -656,7 +656,6 @@ function ParticipationAccessEnabled({
                   Sui wallet
                 </button>
               }
-              walletFilter={(wallet) => !isGoogleWallet(wallet)}
             />
           </div>
         </>

--- a/apps/web/src/lib/enoki/provider.tsx
+++ b/apps/web/src/lib/enoki/provider.tsx
@@ -6,6 +6,7 @@ import {
   WalletProvider,
 } from "@mysten/dapp-kit";
 import { isEnokiNetwork, registerEnokiWallets } from "@mysten/enoki";
+import { appMeta } from "@one-portrait/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   createContext,
@@ -107,7 +108,14 @@ export function AppWalletProvider({
           networks={networks}
         >
           <EnokiWalletRegistrar state={state} />
-          <WalletProvider autoConnect>{children}</WalletProvider>
+          <WalletProvider
+            autoConnect
+            slushWallet={{
+              name: appMeta.name,
+            }}
+          >
+            {children}
+          </WalletProvider>
         </SuiClientProvider>
       </QueryClientProvider>
     </EnokiConfigContext.Provider>

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -81,6 +81,35 @@ test.describe("readiness regression", () => {
     ).toBeVisible();
   });
 
+  test("keeps the Sui wallet connect dialog inside the gallery viewport", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { autoConnectWallet: false });
+
+    await page.goto("/gallery");
+    await page.getByRole("button", { name: "Sui wallet" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Connect a Wallet" });
+    await expect(dialog).toBeVisible();
+
+    const box = await dialog.boundingBox();
+    const viewport = page.viewportSize();
+
+    expect(box).not.toBeNull();
+    expect(viewport).not.toBeNull();
+
+    if (!box || !viewport) {
+      throw new Error(
+        "Connect dialog bounding box or viewport was unavailable",
+      );
+    }
+
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+  });
+
   test("keeps the post-submit gallery CTA", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await installDefaultMocks(page);


### PR DESCRIPTION
## 概要
`/gallery` で signed-out 状態から `Sui wallet` を押しても ConnectModal が画面外に落ち、見た目上は何も起きていないように見える不具合を修正します。あわせて `ConnectModal` の uncontrolled/controlled 警告と Slush fallback 未設定も解消します。

## 変更内容
- `apps/web/src/app/layout.tsx`
  - `@mysten/dapp-kit/dist/index.css` をグローバル読込して ConnectModal の overlay/content スタイルを有効化
- `apps/web/src/lib/enoki/provider.tsx`
  - `WalletProvider` に `slushWallet` 設定を追加し、アプリ名付きで Slush fallback を有効化
- `apps/web/src/app/sui-wallet-connect-modal.tsx`
  - Google wallet 除外と controlled open を内包した共通 `ConnectModal` ラッパを追加
- `apps/web/src/app/global-wallet-entry.tsx`
  - ヘッダーの `Sui wallet` 導線を共通ラッパ経由へ統一
- `apps/web/src/app/gallery/gallery-client.tsx`
  - ギャラリーの signed-out 導線を共通ラッパ経由へ統一
- `apps/web/src/app/units/[unitId]/participation-access.tsx`
  - 待機室の signed-out 導線を共通ラッパ経由へ統一
- `apps/web/src/app/global-wallet-entry.test.tsx`
  - ConnectModal が controlled で開閉することを検証
- `apps/web/src/app/gallery/gallery-client.test.tsx`
  - ギャラリーの Sui wallet modal が controlled であることを検証
- `apps/web/src/app/units/[unitId]/participation-access.test.tsx`
  - 待機室の Sui wallet modal が controlled であることを検証
- `apps/web/tests/e2e/readiness-regression.spec.ts`
  - `Connect a Wallet` dialog の bounding box が viewport 内に収まる回帰テストを追加

## 関連する Issue やチケット
- なし

## 動作確認
### 再現手順
1. `/gallery` を signed-out 状態で開く
2. `Sui wallet` を押す
3. 修正前は dialog が viewport 外に落ち、見た目上何も出ない
4. 修正後は `Connect a Wallet` dialog が viewport 内で可視になる

### 根本原因
- `@mysten/dapp-kit` の CSS が読み込まれておらず、`ConnectModal` の overlay/content positioning が無効になっていた
- 3 箇所の `ConnectModal` が uncontrolled 利用になっており、Radix dialog 由来の uncontrolled/controlled 警告が出ていた

### 検証結果
- `corepack pnpm exec vitest run src/app/global-wallet-entry.test.tsx src/app/gallery/gallery-client.test.tsx 'src/app/units/[unitId]/participation-access.test.tsx'`
- `corepack pnpm --filter web typecheck`
- `node --test scripts/check-build-public-env.test.mjs`
- `corepack pnpm exec playwright test tests/e2e/readiness-regression.spec.ts`
- `corepack pnpm --filter web build`
  - `NEXT_PUBLIC_SUI_NETWORK`, `NEXT_PUBLIC_REGISTRY_OBJECT_ID` がローカル未設定のため事前 env check で停止することを確認
