### PR TITLE
fix: ヘッダー経由の Sui wallet 接続を修正

### DIFF
--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -110,6 +110,7 @@ function ConnectedGalleryClient({
   });
   const [reloadNonce, setReloadNonce] = useState(0);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [suiWalletModalOpen, setSuiWalletModalOpen] = useState(false);
   const [failedOriginalBlobIds, setFailedOriginalBlobIds] = useState<
     readonly string[]
   >([]);
@@ -226,6 +227,8 @@ function ConnectedGalleryClient({
                 : "Google zkLogin"}
           </button>
           <SuiWalletConnectModal
+            onOpenChange={setSuiWalletModalOpen}
+            open={suiWalletModalOpen}
             trigger={
               <button
                 className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"

--- a/apps/web/src/app/global-wallet-entry.test.tsx
+++ b/apps/web/src/app/global-wallet-entry.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   connectModalMock,
+  connectModalWalletSelectMock,
   useEnokiConfigStateMock,
   useWalletsMock,
   useCurrentAccountMock,
@@ -19,6 +20,7 @@ const {
   useDisconnectWalletMock,
 } = vi.hoisted(() => ({
   connectModalMock: vi.fn(),
+  connectModalWalletSelectMock: vi.fn(),
   useEnokiConfigStateMock: vi.fn(),
   useWalletsMock: vi.fn(),
   useCurrentAccountMock: vi.fn(),
@@ -32,9 +34,30 @@ vi.mock("../lib/enoki/provider", () => ({
 }));
 
 vi.mock("@mysten/dapp-kit", () => ({
-  ConnectModal: (props: { readonly trigger: React.ReactNode }) => {
+  ConnectModal: (props: {
+    readonly onOpenChange?: (open: boolean) => void;
+    readonly open?: boolean;
+    readonly trigger: React.ReactNode;
+    readonly walletFilter?: (wallet: { id?: string }) => boolean;
+  }) => {
     connectModalMock(props);
-    return <>{props.trigger}</>;
+    return (
+      <>
+        {props.trigger}
+        {props.open ? (
+          <div aria-label="Connect a Wallet" role="dialog">
+            <button
+              onClick={() => {
+                connectModalWalletSelectMock();
+              }}
+              type="button"
+            >
+              ONE Portrait E2E Sui Stub
+            </button>
+          </div>
+        ) : null}
+      </>
+    );
   },
   useWallets: () => useWalletsMock(),
   useCurrentAccount: () => useCurrentAccountMock(),
@@ -75,6 +98,7 @@ beforeEach(() => {
 
 afterEach(() => {
   connectModalMock.mockReset();
+  connectModalWalletSelectMock.mockReset();
   useEnokiConfigStateMock.mockReset();
   useWalletsMock.mockReset();
   useCurrentAccountMock.mockReset();
@@ -138,6 +162,41 @@ describe("GlobalWalletEntry", () => {
         wallet: { id: "google-wallet" },
       });
     });
+  });
+
+  it("closes the login menu and keeps the Sui wallet modal open", () => {
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sui wallet" }));
+
+    expect(screen.queryByRole("button", { name: "Google zkLogin" })).toBeNull();
+    expect(
+      screen.getByRole("dialog", { name: "Connect a Wallet" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the Sui wallet modal mounted through wallet selection pointer flow", () => {
+    render(<GlobalWalletEntry />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ログイン" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sui wallet" }));
+
+    const walletOption = screen.getByRole("button", {
+      name: "ONE Portrait E2E Sui Stub",
+    });
+
+    fireEvent.mouseDown(walletOption);
+    expect(
+      screen.getByRole("dialog", { name: "Connect a Wallet" }),
+    ).toBeTruthy();
+
+    fireEvent.click(walletOption);
+
+    expect(connectModalWalletSelectMock).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("dialog", { name: "Connect a Wallet" }),
+    ).toBeTruthy();
   });
 
   it("shows copy, explorer, and disconnect actions after connection", async () => {

--- a/apps/web/src/app/global-wallet-entry.tsx
+++ b/apps/web/src/app/global-wallet-entry.tsx
@@ -49,6 +49,7 @@ function GlobalWalletEntryEnabled(): React.ReactElement {
   const connectWallet = useConnectWallet();
   const disconnectWallet = useDisconnectWallet();
   const [open, setOpen] = useState(false);
+  const [suiWalletModalOpen, setSuiWalletModalOpen] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -105,54 +106,61 @@ function GlobalWalletEntryEnabled(): React.ReactElement {
 
   if (!currentAccount) {
     return (
-      <div className="relative" ref={containerRef}>
-        <button
-          className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm font-medium text-cyan-100 transition hover:border-cyan-200 hover:text-white"
-          onClick={() => {
-            setOpen((current) => !current);
-          }}
-          type="button"
-        >
-          ログイン
-        </button>
+      <>
+        <div className="relative" ref={containerRef}>
+          <button
+            className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm font-medium text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+            onClick={() => {
+              setOpen((current) => !current);
+            }}
+            type="button"
+          >
+            ログイン
+          </button>
 
-        {open ? (
-          <div className="absolute right-0 top-[calc(100%+0.75rem)] z-50 grid min-w-56 gap-3 rounded-3xl border border-white/10 bg-slate-950/95 p-4 shadow-2xl shadow-black/40">
-            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-              Connect
-            </p>
-            <button
-              className="rounded-2xl bg-cyan-300 px-4 py-3 text-left text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
-              onClick={() => {
-                void handleGoogleLogin();
-              }}
-              type="button"
-            >
-              Google zkLogin
-            </button>
-            <SuiWalletConnectModal
-              trigger={
-                <button
-                  className="rounded-2xl border border-white/10 px-4 py-3 text-left text-sm font-medium text-white transition hover:border-cyan-200/60"
-                  type="button"
-                >
-                  Sui wallet
-                </button>
-              }
-            />
-
-            {connectError ? (
-              <p
-                aria-live="polite"
-                className="rounded-2xl border border-amber-300/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-100"
-                role="alert"
-              >
-                {connectError}
+          {open ? (
+            <div className="absolute right-0 top-[calc(100%+0.75rem)] z-50 grid min-w-56 gap-3 rounded-3xl border border-white/10 bg-slate-950/95 p-4 shadow-2xl shadow-black/40">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                Connect
               </p>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
+              <button
+                className="rounded-2xl bg-cyan-300 px-4 py-3 text-left text-sm font-medium text-slate-950 transition hover:bg-cyan-200"
+                onClick={() => {
+                  void handleGoogleLogin();
+                }}
+                type="button"
+              >
+                Google zkLogin
+              </button>
+              <button
+                className="rounded-2xl border border-white/10 px-4 py-3 text-left text-sm font-medium text-white transition hover:border-cyan-200/60"
+                onClick={() => {
+                  setConnectError(null);
+                  setOpen(false);
+                  setSuiWalletModalOpen(true);
+                }}
+                type="button"
+              >
+                Sui wallet
+              </button>
+
+              {connectError ? (
+                <p
+                  aria-live="polite"
+                  className="rounded-2xl border border-amber-300/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-100"
+                  role="alert"
+                >
+                  {connectError}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+        <SuiWalletConnectModal
+          onOpenChange={setSuiWalletModalOpen}
+          open={suiWalletModalOpen}
+        />
+      </>
     );
   }
 

--- a/apps/web/src/app/sui-wallet-connect-modal.tsx
+++ b/apps/web/src/app/sui-wallet-connect-modal.tsx
@@ -2,21 +2,40 @@
 
 import { ConnectModal } from "@mysten/dapp-kit";
 import { isGoogleWallet } from "@mysten/enoki";
-import type { ReactNode } from "react";
-import { useState } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+type ControlledModalProps = {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly defaultOpen?: never;
+};
+
+type UncontrolledModalProps = {
+  readonly defaultOpen?: boolean;
+  readonly open?: never;
+  readonly onOpenChange?: never;
+};
+
+type SuiWalletConnectModalProps = {
+  readonly trigger?: NonNullable<ReactNode>;
+} & (ControlledModalProps | UncontrolledModalProps);
+
+function HiddenTrigger(): ReactElement {
+  return (
+    <button hidden tabIndex={-1} type="button">
+      Open Sui wallet modal
+    </button>
+  );
+}
 
 export function SuiWalletConnectModal({
   trigger,
-}: {
-  readonly trigger: NonNullable<ReactNode>;
-}): React.ReactElement {
-  const [open, setOpen] = useState(false);
-
+  ...modalProps
+}: SuiWalletConnectModalProps): ReactElement {
   return (
     <ConnectModal
-      onOpenChange={setOpen}
-      open={open}
-      trigger={trigger}
+      {...modalProps}
+      trigger={trigger ?? <HiddenTrigger />}
       walletFilter={(wallet) => !isGoogleWallet(wallet)}
     />
   );

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -186,6 +186,7 @@ function ParticipationAccessEnabled({
 
   const [connectError, setConnectError] = useState<string | null>(null);
   const [consented, setConsented] = useState(false);
+  const [suiWalletModalOpen, setSuiWalletModalOpen] = useState(false);
   const [phase, setPhase] = useState<UploadPhase>({ kind: "ready" });
 
   // Tracks every object URL we have handed out so we can reliably
@@ -648,6 +649,8 @@ function ParticipationAccessEnabled({
                   : "Google zkLogin"}
             </button>
             <SuiWalletConnectModal
+              onOpenChange={setSuiWalletModalOpen}
+              open={suiWalletModalOpen}
               trigger={
                 <button
                   className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-200 hover:text-white"

--- a/apps/web/tests/e2e/wallet-connect-regression.spec.ts
+++ b/apps/web/tests/e2e/wallet-connect-regression.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+import { installDefaultMocks } from "./fixtures/mock-network";
+
+test.describe("wallet connect regression", () => {
+  test("connects a Sui wallet from the header login menu", async ({ page }) => {
+    await installDefaultMocks(page, { autoConnectWallet: false });
+
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "ログイン" }).click();
+    await page.getByRole("button", { name: "Sui wallet" }).click();
+
+    const connectDialog = page.getByRole("dialog", {
+      name: "Connect a Wallet",
+    });
+    await expect(connectDialog).toBeVisible();
+
+    await page
+      .getByRole("button", { name: "ONE Portrait E2E Sui Stub" })
+      .click();
+
+    await expect(
+      page.getByRole("button", { name: "0xe2e0...0001" }),
+    ).toBeVisible();
+  });
+
+  test("keeps the page-local gallery Sui wallet CTA working", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page, { autoConnectWallet: false });
+
+    await page.goto("/gallery");
+
+    await page.getByRole("button", { name: "Sui wallet" }).click();
+
+    const connectDialog = page.getByRole("dialog", {
+      name: "Connect a Wallet",
+    });
+    await expect(connectDialog).toBeVisible();
+
+    await page
+      .getByRole("button", { name: "ONE Portrait E2E Sui Stub" })
+      .click();
+
+    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(
+      page.getByText(/まだ Kakera が見つかりません。/),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要
ヘッダーのログインメニューから Sui wallet を選んだときに ConnectModal が途中で閉じて接続できない不具合を修正します。あわせて page-local CTA 側の controlled modal 挙動も揃え、回帰テストを追加します。

## 変更内容
- `apps/web/src/app/global-wallet-entry.tsx`
  - ヘッダードロップダウンの open state と Sui ConnectModal の open state を分離し、Sui wallet 選択時はメニューを閉じつつモーダルを維持するよう変更
- `apps/web/src/app/sui-wallet-connect-modal.tsx`
  - `open` / `onOpenChange` を親から受けられる共通 wrapper に拡張し、hidden trigger にも対応
- `apps/web/src/app/gallery/gallery-client.tsx`
  - gallery の Sui wallet CTA を controlled modal として利用するよう変更
- `apps/web/src/app/units/[unitId]/participation-access.tsx`
  - waiting room の Sui wallet CTA を controlled modal として利用するよう変更
- `apps/web/src/app/global-wallet-entry.test.tsx`
  - ヘッダーから Sui wallet を開いたあとにログインメニューが閉じても modal が残ること、wallet 選択の pointer flow で modal が巻き込まれないことを追加
- `apps/web/tests/e2e/wallet-connect-regression.spec.ts`
  - ヘッダー導線と gallery 本文 CTA 導線の Sui wallet 接続回帰を追加

## 関連する Issue やチケット
なし

## 動作確認
- `pnpm --dir apps/web exec vitest run src/app/global-wallet-entry.test.tsx src/app/gallery/gallery-client.test.tsx src/app/units/[unitId]/participation-access.test.tsx`
- `pnpm --dir apps/web exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/web exec biome check src/app/global-wallet-entry.tsx src/app/global-wallet-entry.test.tsx src/app/gallery/gallery-client.tsx src/app/units/[unitId]/participation-access.tsx src/app/sui-wallet-connect-modal.tsx tests/e2e/wallet-connect-regression.spec.ts`
- `pnpm --dir apps/web exec playwright test tests/e2e/wallet-connect-regression.spec.ts`
