### PR TITLE
feat: Quick Tunnel の generator URL を Worker KV で共有

### DIFF
--- a/apps/web/scripts/generator-runtime-remote.mjs
+++ b/apps/web/scripts/generator-runtime-remote.mjs
@@ -106,14 +106,10 @@ export async function writeRemoteGeneratorRuntime({
 }
 
 async function runWranglerKvCommand({ args, cwd, env, runCommand }) {
-  return runCommand(
-    "corepack",
-    ["pnpm", "exec", "wrangler", "kv", ...args],
-    {
-      cwd,
-      env,
-    },
-  );
+  return runCommand("corepack", ["pnpm", "exec", "wrangler", "kv", ...args], {
+    cwd,
+    env,
+  });
 }
 
 async function defaultRunCommand(command, args, options = {}) {

--- a/apps/web/scripts/generator-runtime-remote.mjs
+++ b/apps/web/scripts/generator-runtime-remote.mjs
@@ -1,0 +1,178 @@
+import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, "..");
+
+const GENERATOR_RUNTIME_KV_BINDING = "OP_GENERATOR_RUNTIME_KV";
+const GENERATOR_RUNTIME_KV_KEY = "generator-runtime/current";
+const RUNTIME_STATE_VERSION = 1;
+
+export async function readRemoteGeneratorRuntime({
+  cwd = webRoot,
+  env = process.env,
+  logger = console,
+  runCommand = defaultRunCommand,
+} = {}) {
+  try {
+    const { stdout } = await runWranglerKvCommand({
+      args: [
+        "key",
+        "get",
+        GENERATOR_RUNTIME_KV_KEY,
+        "--binding",
+        GENERATOR_RUNTIME_KV_BINDING,
+        "--remote",
+        "--text",
+      ],
+      cwd,
+      env,
+      runCommand,
+    });
+    const payload = typeof stdout === "string" ? stdout.trim() : "";
+    if (!payload) {
+      return null;
+    }
+
+    const normalized = normalizeRuntimeState(JSON.parse(payload));
+    if (normalized !== null) {
+      return normalized;
+    }
+
+    logger?.warn?.("[generator-runtime][remote-kv][invalid-payload]");
+    return null;
+  } catch (error) {
+    logger?.warn?.(
+      `[generator-runtime][remote-kv][read-failed] message=${formatError(error)}`,
+    );
+    return null;
+  }
+}
+
+export async function writeRemoteGeneratorRuntime({
+  cwd = webRoot,
+  env = process.env,
+  logger = console,
+  mode,
+  runCommand = defaultRunCommand,
+  updatedAt = new Date().toISOString(),
+  url,
+} = {}) {
+  const normalizedUrl = normalizeUrl(url);
+  if (normalizedUrl === null || (mode !== "named" && mode !== "quick")) {
+    throw new Error("generator runtime state requires a valid mode and URL");
+  }
+
+  try {
+    await runWranglerKvCommand({
+      args: [
+        "key",
+        "put",
+        GENERATOR_RUNTIME_KV_KEY,
+        JSON.stringify({
+          mode,
+          updatedAt,
+          url: normalizedUrl,
+          version: RUNTIME_STATE_VERSION,
+        }),
+        "--binding",
+        GENERATOR_RUNTIME_KV_BINDING,
+        "--remote",
+      ],
+      cwd,
+      env,
+      runCommand,
+    });
+    logger?.info?.(
+      `[generator-runtime][remote-kv][written] url=${normalizedUrl}`,
+    );
+    return {
+      marker: "[generator-runtime][remote-kv][written]",
+      ok: true,
+    };
+  } catch (error) {
+    logger?.warn?.(
+      `[generator-runtime][remote-kv][write-failed] message=${formatError(error)}`,
+    );
+    return {
+      marker: "[generator-runtime][remote-kv][write-failed]",
+      ok: false,
+    };
+  }
+}
+
+async function runWranglerKvCommand({ args, cwd, env, runCommand }) {
+  return runCommand(
+    "corepack",
+    ["pnpm", "exec", "wrangler", "kv", ...args],
+    {
+      cwd,
+      env,
+    },
+  );
+}
+
+async function defaultRunCommand(command, args, options = {}) {
+  const { stdout, stderr } = await execFile(command, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    ...options,
+  });
+
+  return {
+    stderr: stderr ?? "",
+    stdout: stdout ?? "",
+  };
+}
+
+function normalizeRuntimeState(input) {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+
+  const mode = input.mode;
+  const updatedAt = input.updatedAt;
+  const url = normalizeUrl(typeof input.url === "string" ? input.url : "");
+  const version = input.version;
+
+  if (
+    version !== RUNTIME_STATE_VERSION ||
+    (mode !== "named" && mode !== "quick") ||
+    typeof updatedAt !== "string" ||
+    url === null
+  ) {
+    return null;
+  }
+
+  return {
+    mode,
+    updatedAt,
+    url,
+    version,
+  };
+}
+
+function normalizeUrl(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (!parsed.protocol || !parsed.hostname) {
+      return null;
+    }
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/web/scripts/generator-runtime-remote.mjs
+++ b/apps/web/scripts/generator-runtime-remote.mjs
@@ -10,12 +10,14 @@ const webRoot = path.resolve(__dirname, "..");
 
 const GENERATOR_RUNTIME_KV_BINDING = "OP_GENERATOR_RUNTIME_KV";
 const GENERATOR_RUNTIME_KV_KEY = "generator-runtime/current";
+const REMOTE_RUNTIME_MAX_AGE_MS = 15 * 60 * 1000;
 const RUNTIME_STATE_VERSION = 1;
 
 export async function readRemoteGeneratorRuntime({
   cwd = webRoot,
   env = process.env,
   logger = console,
+  now = Date.now(),
   runCommand = defaultRunCommand,
 } = {}) {
   try {
@@ -26,6 +28,8 @@ export async function readRemoteGeneratorRuntime({
         GENERATOR_RUNTIME_KV_KEY,
         "--binding",
         GENERATOR_RUNTIME_KV_BINDING,
+        "--preview",
+        "false",
         "--remote",
         "--text",
       ],
@@ -38,7 +42,9 @@ export async function readRemoteGeneratorRuntime({
       return null;
     }
 
-    const normalized = normalizeRuntimeState(JSON.parse(payload));
+    const normalized = normalizeRuntimeState(JSON.parse(payload), {
+      now,
+    });
     if (normalized !== null) {
       return normalized;
     }
@@ -50,6 +56,44 @@ export async function readRemoteGeneratorRuntime({
       `[generator-runtime][remote-kv][read-failed] message=${formatError(error)}`,
     );
     return null;
+  }
+}
+
+export async function deleteRemoteGeneratorRuntime({
+  cwd = webRoot,
+  env = process.env,
+  logger = console,
+  runCommand = defaultRunCommand,
+} = {}) {
+  try {
+    await runWranglerKvCommand({
+      args: [
+        "key",
+        "delete",
+        GENERATOR_RUNTIME_KV_KEY,
+        "--binding",
+        GENERATOR_RUNTIME_KV_BINDING,
+        "--preview",
+        "false",
+        "--remote",
+      ],
+      cwd,
+      env,
+      runCommand,
+    });
+    logger?.info?.("[generator-runtime][remote-kv][deleted]");
+    return {
+      marker: "[generator-runtime][remote-kv][deleted]",
+      ok: true,
+    };
+  } catch (error) {
+    logger?.warn?.(
+      `[generator-runtime][remote-kv][delete-failed] message=${formatError(error)}`,
+    );
+    return {
+      marker: "[generator-runtime][remote-kv][delete-failed]",
+      ok: false,
+    };
   }
 }
 
@@ -81,6 +125,8 @@ export async function writeRemoteGeneratorRuntime({
         }),
         "--binding",
         GENERATOR_RUNTIME_KV_BINDING,
+        "--preview",
+        "false",
         "--remote",
       ],
       cwd,
@@ -125,7 +171,7 @@ async function defaultRunCommand(command, args, options = {}) {
   };
 }
 
-function normalizeRuntimeState(input) {
+function normalizeRuntimeState(input, { now }) {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return null;
   }
@@ -140,6 +186,14 @@ function normalizeRuntimeState(input) {
     (mode !== "named" && mode !== "quick") ||
     typeof updatedAt !== "string" ||
     url === null
+  ) {
+    return null;
+  }
+
+  const updatedAtMs = Date.parse(updatedAt);
+  if (
+    !Number.isFinite(updatedAtMs) ||
+    now - updatedAtMs > REMOTE_RUNTIME_MAX_AGE_MS
   ) {
     return null;
   }

--- a/apps/web/scripts/generator-runtime-remote.test.ts
+++ b/apps/web/scripts/generator-runtime-remote.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  readRemoteGeneratorRuntime,
+  writeRemoteGeneratorRuntime,
+} from "./generator-runtime-remote.mjs";
+
+describe("generator-runtime-remote", () => {
+  it("reads the current runtime from remote kv", async () => {
+    const runCommand = vi.fn().mockResolvedValue({
+      stderr: "",
+      stdout: JSON.stringify({
+        mode: "quick",
+        updatedAt: "2026-04-23T00:00:00.000Z",
+        url: "https://remote-kv.example.com/",
+        version: 1,
+      }),
+    });
+
+    await expect(
+      readRemoteGeneratorRuntime({
+        env: {
+          CLOUDFLARED_CONFIG: "/tmp/unused",
+        },
+        logger: createLogger(),
+        runCommand,
+      }),
+    ).resolves.toEqual({
+      mode: "quick",
+      updatedAt: "2026-04-23T00:00:00.000Z",
+      url: "https://remote-kv.example.com",
+      version: 1,
+    });
+    expect(runCommand).toHaveBeenCalledWith(
+      "corepack",
+      [
+        "pnpm",
+        "exec",
+        "wrangler",
+        "kv",
+        "key",
+        "get",
+        "generator-runtime/current",
+        "--binding",
+        "OP_GENERATOR_RUNTIME_KV",
+        "--remote",
+        "--text",
+      ],
+      expect.objectContaining({
+        cwd: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns null and warns when the remote payload is invalid", async () => {
+    const logger = createLogger();
+
+    await expect(
+      readRemoteGeneratorRuntime({
+        logger,
+        runCommand: vi.fn().mockResolvedValue({
+          stderr: "",
+          stdout: '{"bad":true}',
+        }),
+      }),
+    ).resolves.toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[generator-runtime][remote-kv][invalid-payload]",
+    );
+  });
+
+  it("writes the current runtime to remote kv", async () => {
+    const logger = createLogger();
+    const runCommand = vi.fn().mockResolvedValue({
+      stderr: "",
+      stdout: "",
+    });
+
+    await expect(
+      writeRemoteGeneratorRuntime({
+        logger,
+        mode: "quick",
+        runCommand,
+        updatedAt: "2026-04-23T00:00:00.000Z",
+        url: "https://remote-kv.example.com/",
+      }),
+    ).resolves.toEqual({
+      marker: "[generator-runtime][remote-kv][written]",
+      ok: true,
+    });
+    expect(runCommand).toHaveBeenCalledWith(
+      "corepack",
+      [
+        "pnpm",
+        "exec",
+        "wrangler",
+        "kv",
+        "key",
+        "put",
+        "generator-runtime/current",
+        JSON.stringify({
+          mode: "quick",
+          updatedAt: "2026-04-23T00:00:00.000Z",
+          url: "https://remote-kv.example.com",
+          version: 1,
+        }),
+        "--binding",
+        "OP_GENERATOR_RUNTIME_KV",
+        "--remote",
+      ],
+      expect.objectContaining({
+        cwd: expect.any(String),
+      }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "[generator-runtime][remote-kv][written] url=https://remote-kv.example.com",
+    );
+  });
+});
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}

--- a/apps/web/scripts/generator-runtime-remote.test.ts
+++ b/apps/web/scripts/generator-runtime-remote.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  deleteRemoteGeneratorRuntime,
   readRemoteGeneratorRuntime,
   writeRemoteGeneratorRuntime,
 } from "./generator-runtime-remote.mjs";
@@ -23,6 +24,7 @@ describe("generator-runtime-remote", () => {
           CLOUDFLARED_CONFIG: "/tmp/unused",
         },
         logger: createLogger(),
+        now: Date.parse("2026-04-23T00:00:00.000Z"),
         runCommand,
       }),
     ).resolves.toEqual({
@@ -43,6 +45,8 @@ describe("generator-runtime-remote", () => {
         "generator-runtime/current",
         "--binding",
         "OP_GENERATOR_RUNTIME_KV",
+        "--preview",
+        "false",
         "--remote",
         "--text",
       ],
@@ -67,6 +71,23 @@ describe("generator-runtime-remote", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "[generator-runtime][remote-kv][invalid-payload]",
     );
+  });
+
+  it("ignores stale remote runtime payloads", async () => {
+    await expect(
+      readRemoteGeneratorRuntime({
+        now: Date.parse("2026-04-23T00:20:00.000Z"),
+        runCommand: vi.fn().mockResolvedValue({
+          stderr: "",
+          stdout: JSON.stringify({
+            mode: "quick",
+            updatedAt: "2026-04-23T00:00:00.000Z",
+            url: "https://remote-kv.example.com/",
+            version: 1,
+          }),
+        }),
+      }),
+    ).resolves.toBeNull();
   });
 
   it("writes the current runtime to remote kv", async () => {
@@ -106,6 +127,8 @@ describe("generator-runtime-remote", () => {
         }),
         "--binding",
         "OP_GENERATOR_RUNTIME_KV",
+        "--preview",
+        "false",
         "--remote",
       ],
       expect.objectContaining({
@@ -114,6 +137,47 @@ describe("generator-runtime-remote", () => {
     );
     expect(logger.info).toHaveBeenCalledWith(
       "[generator-runtime][remote-kv][written] url=https://remote-kv.example.com",
+    );
+  });
+
+  it("deletes the current runtime from remote kv", async () => {
+    const logger = createLogger();
+    const runCommand = vi.fn().mockResolvedValue({
+      stderr: "",
+      stdout: "",
+    });
+
+    await expect(
+      deleteRemoteGeneratorRuntime({
+        logger,
+        runCommand,
+      }),
+    ).resolves.toEqual({
+      marker: "[generator-runtime][remote-kv][deleted]",
+      ok: true,
+    });
+    expect(runCommand).toHaveBeenCalledWith(
+      "corepack",
+      [
+        "pnpm",
+        "exec",
+        "wrangler",
+        "kv",
+        "key",
+        "delete",
+        "generator-runtime/current",
+        "--binding",
+        "OP_GENERATOR_RUNTIME_KV",
+        "--preview",
+        "false",
+        "--remote",
+      ],
+      expect.objectContaining({
+        cwd: expect.any(String),
+      }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "[generator-runtime][remote-kv][deleted]",
     );
   });
 });

--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -5,11 +5,14 @@ import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { writeRemoteGeneratorRuntimeMock } = vi.hoisted(() => ({
-  writeRemoteGeneratorRuntimeMock: vi.fn(),
-}));
+const { deleteRemoteGeneratorRuntimeMock, writeRemoteGeneratorRuntimeMock } =
+  vi.hoisted(() => ({
+    deleteRemoteGeneratorRuntimeMock: vi.fn(),
+    writeRemoteGeneratorRuntimeMock: vi.fn(),
+  }));
 
 vi.mock("./generator-runtime-remote.mjs", () => ({
+  deleteRemoteGeneratorRuntime: deleteRemoteGeneratorRuntimeMock,
   writeRemoteGeneratorRuntime: writeRemoteGeneratorRuntimeMock,
 }));
 
@@ -17,7 +20,12 @@ import { runGeneratorStackTunnel } from "./run-generator-stack-tunnel.mjs";
 
 describe("runGeneratorStackTunnel", () => {
   beforeEach(() => {
+    deleteRemoteGeneratorRuntimeMock.mockReset();
     writeRemoteGeneratorRuntimeMock.mockReset();
+    deleteRemoteGeneratorRuntimeMock.mockResolvedValue({
+      marker: "[generator-runtime][remote-kv][deleted]",
+      ok: true,
+    });
     writeRemoteGeneratorRuntimeMock.mockResolvedValue({
       marker: "[generator-runtime][remote-kv][written]",
       ok: true,
@@ -290,6 +298,16 @@ describe("runGeneratorStackTunnel", () => {
       ok: true,
     });
     await settle();
+    expect(deleteRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          OP_FINALIZE_DISPATCH_URL: "https://generator.example",
+          OP_LOCAL_TUNNEL_CONFIG_PATH: "/tmp/custom-cloudflared.yml",
+          OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
+        }),
+        logger,
+      }),
+    );
 
     expect(spawnImpl).toHaveBeenCalledWith(
       "cloudflared",
@@ -624,6 +642,12 @@ describe("runGeneratorStackTunnel", () => {
         marker: "[generator-stack][child-exit][tunnel]",
         ok: false,
       });
+      expect(deleteRemoteGeneratorRuntimeMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          env: {},
+          logger,
+        }),
+      );
       expect(fs.existsSync(runtimeStatePath)).toBe(false);
     } finally {
       fs.rmSync(appRootPath, { force: true, recursive: true });
@@ -703,6 +727,112 @@ describe("runGeneratorStackTunnel", () => {
     } finally {
       fs.rmSync(appRootPath, { force: true, recursive: true });
     }
+  });
+
+  it("fails before startup when remote kv cleanup fails", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      publicBaseUrl: "https://generator.example",
+      publicHostname: "generator.example",
+      tunnelName: "one-portrait-generator",
+      tunnelMode: "named",
+    });
+    const startLocalGenerator = vi.fn();
+    const spawnImpl = vi.fn();
+    const waitForHealth = vi.fn();
+
+    deleteRemoteGeneratorRuntimeMock.mockResolvedValueOnce({
+      marker: "[generator-runtime][remote-kv][delete-failed]",
+      ok: false,
+    });
+
+    await expect(
+      runGeneratorStackTunnel({
+        env: {
+          OP_FINALIZE_DISPATCH_URL: "https://generator.example",
+          OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
+        },
+        logger,
+        preflight,
+        processImpl,
+        spawnImpl,
+        startLocalGenerator,
+        waitForHealth,
+      }),
+    ).resolves.toEqual({
+      exitCode: 1,
+      marker: "[generator-stack][remote-kv][delete-failed]",
+      ok: false,
+    });
+
+    expect(startLocalGenerator).not.toHaveBeenCalled();
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(waitForHealth).not.toHaveBeenCalled();
+  });
+
+  it("stops both children when quick tunnel remote kv sync fails", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const generatorChild = createChildProcess("generator");
+    const tunnelChild = createChildProcess("tunnel");
+    const localHealth = createDeferred();
+
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      tunnelMode: "quick",
+    });
+    const startLocalGenerator = vi.fn().mockResolvedValue({
+      child: generatorChild,
+    });
+    const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return localHealth.promise;
+      }
+
+      throw new Error(`unexpected health probe for ${label}`);
+    });
+
+    writeRemoteGeneratorRuntimeMock.mockResolvedValueOnce({
+      marker: "[generator-runtime][remote-kv][write-failed]",
+      ok: false,
+    });
+
+    const runPromise = runGeneratorStackTunnel({
+      env: {},
+      logger,
+      preflight,
+      processImpl,
+      spawnImpl,
+      startLocalGenerator,
+      waitForHealth,
+    });
+
+    await settle();
+    localHealth.resolve({
+      exitCode: 0,
+      marker: "[generator-stack][health][local][ready]",
+      ok: true,
+    });
+    await settle();
+    tunnelChild.stdout.emit(
+      "data",
+      "Quick Tunnel ready: https://failed-sync.trycloudflare.com\n",
+    );
+
+    await expect(runPromise).resolves.toEqual({
+      exitCode: 1,
+      marker: "[generator-stack][remote-kv][write-failed]",
+      ok: false,
+    });
+    expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(tunnelChild.kill).toHaveBeenCalledWith("SIGTERM");
   });
 });
 

--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -3,11 +3,27 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { writeRemoteGeneratorRuntimeMock } = vi.hoisted(() => ({
+  writeRemoteGeneratorRuntimeMock: vi.fn(),
+}));
+
+vi.mock("./generator-runtime-remote.mjs", () => ({
+  writeRemoteGeneratorRuntime: writeRemoteGeneratorRuntimeMock,
+}));
 
 import { runGeneratorStackTunnel } from "./run-generator-stack-tunnel.mjs";
 
 describe("runGeneratorStackTunnel", () => {
+  beforeEach(() => {
+    writeRemoteGeneratorRuntimeMock.mockReset();
+    writeRemoteGeneratorRuntimeMock.mockResolvedValue({
+      marker: "[generator-runtime][remote-kv][written]",
+      ok: true,
+    });
+  });
+
   it("starts the generator before the tunnel, reports ready, and stops on tunnel exit", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
@@ -580,6 +596,14 @@ describe("runGeneratorStackTunnel", () => {
         expect.objectContaining({
           label: "external",
           url: "https://fresh-runtime.trycloudflare.com/health",
+        }),
+      );
+      expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: {},
+          logger,
+          mode: "quick",
+          url: "https://fresh-runtime.trycloudflare.com",
         }),
       );
       expect(fs.existsSync(runtimeStatePath)).toBe(true);

--- a/apps/web/scripts/run-generator-stack-dispatch-smoke.mjs
+++ b/apps/web/scripts/run-generator-stack-dispatch-smoke.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveScriptGeneratorRuntime } from "./generator-runtime.mjs";
+import { readRemoteGeneratorRuntime } from "./generator-runtime-remote.mjs";
 import { loadWebScriptEnv } from "./run-local-generator.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -14,12 +15,18 @@ export async function runGeneratorStackDispatchSmoke({
   env = process.env,
   fetchImpl = globalThis.fetch,
   logger = console,
+  readRemoteRuntime = readRemoteGeneratorRuntime,
 } = {}) {
   const unitId = parseUnitId(argv);
   const dispatchSecret = normalizeRequiredValue(
     env.OP_FINALIZE_DISPATCH_SECRET,
   );
-  const runtime = resolveScriptGeneratorRuntime({ appRootPath, env });
+  const runtime = await resolveSmokeGeneratorRuntime({
+    appRootPath,
+    env,
+    logger,
+    readRemoteRuntime,
+  });
   const dispatchUrl = runtime.status === "ok" ? runtime.url : null;
 
   if (!unitId || !dispatchUrl || !dispatchSecret || runtime.status !== "ok") {
@@ -112,9 +119,55 @@ function parseUnitId(argv) {
   return candidate.length > 0 ? candidate : null;
 }
 
+async function resolveSmokeGeneratorRuntime({
+  appRootPath,
+  env,
+  logger,
+  readRemoteRuntime,
+}) {
+  const overrideUrl = normalizeOptionalUrl(env.OP_GENERATOR_RUNTIME_URL_OVERRIDE);
+  if (overrideUrl !== null) {
+    return {
+      source: "override",
+      status: "ok",
+      url: overrideUrl,
+    };
+  }
+
+  const remoteRuntime = await readRemoteRuntime({
+    env,
+    logger,
+  });
+  if (remoteRuntime !== null) {
+    return {
+      source: "worker_kv",
+      status: "ok",
+      url: remoteRuntime.url,
+    };
+  }
+
+  return resolveScriptGeneratorRuntime({
+    appRootPath,
+    env,
+  });
+}
+
 function normalizeRequiredValue(value) {
   const candidate = typeof value === "string" ? value.trim() : "";
   return candidate.length > 0 ? candidate : null;
+}
+
+function normalizeOptionalUrl(value) {
+  const candidate = normalizeRequiredValue(value);
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    return new URL(candidate).toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
 }
 
 function getResultStatus(result) {

--- a/apps/web/scripts/run-generator-stack-dispatch-smoke.mjs
+++ b/apps/web/scripts/run-generator-stack-dispatch-smoke.mjs
@@ -125,7 +125,9 @@ async function resolveSmokeGeneratorRuntime({
   logger,
   readRemoteRuntime,
 }) {
-  const overrideUrl = normalizeOptionalUrl(env.OP_GENERATOR_RUNTIME_URL_OVERRIDE);
+  const overrideUrl = normalizeOptionalUrl(
+    env.OP_GENERATOR_RUNTIME_URL_OVERRIDE,
+  );
   if (overrideUrl !== null) {
     return {
       source: "override",

--- a/apps/web/scripts/run-generator-stack-dispatch-smoke.test.ts
+++ b/apps/web/scripts/run-generator-stack-dispatch-smoke.test.ts
@@ -97,26 +97,34 @@ describe("runGeneratorStackDispatchSmoke", () => {
       }),
       status: 200,
     });
-
-    const result = await runGeneratorStackDispatchSmoke({
-      argv: ["node", "script.mjs", VALID_UNIT_ID],
-      env: {
-        OP_FINALIZE_DISPATCH_SECRET: VALID_ENV.OP_FINALIZE_DISPATCH_SECRET,
-      },
-      fetchImpl,
-      logger,
-    });
-
-    expect(result).toEqual({
-      exitCode: 0,
-      marker: "[generator-stack][smoke][ok]",
-      ok: true,
-      resultStatus: "ignored_finalized",
-    });
-    expect(fetchImpl).toHaveBeenCalledWith(
-      new URL("/dispatch", "http://127.0.0.1:8080/"),
-      expect.any(Object),
+    const appRootPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "one-portrait-smoke-fallback-"),
     );
+
+    try {
+      const result = await runGeneratorStackDispatchSmoke({
+        appRootPath,
+        argv: ["node", "script.mjs", VALID_UNIT_ID],
+        env: {
+          OP_FINALIZE_DISPATCH_SECRET: VALID_ENV.OP_FINALIZE_DISPATCH_SECRET,
+        },
+        fetchImpl,
+        logger,
+      });
+
+      expect(result).toEqual({
+        exitCode: 0,
+        marker: "[generator-stack][smoke][ok]",
+        ok: true,
+        resultStatus: "ignored_finalized",
+      });
+      expect(fetchImpl).toHaveBeenCalledWith(
+        new URL("/dispatch", "http://127.0.0.1:8080/"),
+        expect.any(Object),
+      );
+    } finally {
+      fs.rmSync(appRootPath, { force: true, recursive: true });
+    }
   });
 
   it("reads the runtime state file before legacy env", async () => {

--- a/apps/web/scripts/run-generator-stack-dispatch-smoke.test.ts
+++ b/apps/web/scripts/run-generator-stack-dispatch-smoke.test.ts
@@ -1,9 +1,17 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { runGeneratorStackDispatchSmoke } from "./run-generator-stack-dispatch-smoke.mjs";
+
+const { readRemoteGeneratorRuntimeMock } = vi.hoisted(() => ({
+  readRemoteGeneratorRuntimeMock: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("./generator-runtime-remote.mjs", () => ({
+  readRemoteGeneratorRuntime: readRemoteGeneratorRuntimeMock,
+}));
 
 const VALID_ENV = {
   OP_FINALIZE_DISPATCH_SECRET: "shared-secret",
@@ -14,6 +22,11 @@ const VALID_UNIT_ID =
   "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
 
 describe("runGeneratorStackDispatchSmoke", () => {
+  afterEach(() => {
+    readRemoteGeneratorRuntimeMock.mockReset();
+    readRemoteGeneratorRuntimeMock.mockResolvedValue(null);
+  });
+
   it("fails fast when the unit id argument is missing", async () => {
     const logger = createLogger();
     const fetchImpl = vi.fn();
@@ -151,6 +164,64 @@ describe("runGeneratorStackDispatchSmoke", () => {
       });
       expect(fetchImpl).toHaveBeenCalledWith(
         new URL("/dispatch", "https://runtime-state.example.com/"),
+        expect.any(Object),
+      );
+    } finally {
+      fs.rmSync(appRootPath, { force: true, recursive: true });
+    }
+  });
+
+  it("prefers the remote kv runtime before the local runtime state", async () => {
+    const logger = createLogger();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        status: "ignored_finalized",
+        unitId: VALID_UNIT_ID,
+      }),
+      status: 200,
+    });
+    const appRootPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "one-portrait-smoke-remote-"),
+    );
+    const cacheDir = path.join(appRootPath, ".cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, "generator-runtime.json"),
+      JSON.stringify({
+        mode: "quick",
+        pid: process.pid,
+        updatedAt: new Date().toISOString(),
+        url: "https://runtime-state.example.com",
+        version: 1,
+      }),
+    );
+    readRemoteGeneratorRuntimeMock.mockResolvedValue({
+      mode: "quick",
+      updatedAt: new Date().toISOString(),
+      url: "https://remote-kv.example.com",
+      version: 1,
+    });
+
+    try {
+      const result = await runGeneratorStackDispatchSmoke({
+        appRootPath,
+        argv: ["node", "script.mjs", VALID_UNIT_ID],
+        env: {
+          OP_FINALIZE_DISPATCH_SECRET: VALID_ENV.OP_FINALIZE_DISPATCH_SECRET,
+          OP_FINALIZE_DISPATCH_URL: "https://legacy-env.example.com",
+        },
+        fetchImpl,
+        logger,
+      });
+
+      expect(result).toEqual({
+        exitCode: 0,
+        marker: "[generator-stack][smoke][ok]",
+        ok: true,
+        resultStatus: "ignored_finalized",
+      });
+      expect(fetchImpl).toHaveBeenCalledWith(
+        new URL("/dispatch", "https://remote-kv.example.com/"),
         expect.any(Object),
       );
     } finally {

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -6,6 +6,7 @@ import {
   removeGeneratorRuntimeState,
   writeGeneratorRuntimeState,
 } from "./generator-runtime.mjs";
+import { writeRemoteGeneratorRuntime } from "./generator-runtime-remote.mjs";
 import { waitForGeneratorStackHealth } from "./generator-stack-health.mjs";
 import {
   resolveCloudflaredConfigPath,
@@ -30,6 +31,7 @@ export async function runGeneratorStackTunnel({
   spawnImpl = spawn,
   startLocalGenerator = startLocalGeneratorLauncher,
   waitForHealth = waitForGeneratorStackHealth,
+  writeRemoteRuntime = writeRemoteGeneratorRuntime,
 } = {}) {
   const signalState = createSignalState(processImpl);
   let generator = null;
@@ -160,6 +162,14 @@ export async function runGeneratorStackTunnel({
           : processImpl.pid,
       url: publicBaseUrl,
     });
+    if (preflightResult.tunnelMode === "quick") {
+      await writeRemoteRuntime({
+        env: mergedEnv,
+        logger,
+        mode: "quick",
+        url: publicBaseUrl,
+      });
+    }
 
     const externalHealth = await waitForHealthPhase({
       healthPromise: waitForHealth({

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -6,7 +6,10 @@ import {
   removeGeneratorRuntimeState,
   writeGeneratorRuntimeState,
 } from "./generator-runtime.mjs";
-import { writeRemoteGeneratorRuntime } from "./generator-runtime-remote.mjs";
+import {
+  deleteRemoteGeneratorRuntime,
+  writeRemoteGeneratorRuntime,
+} from "./generator-runtime-remote.mjs";
 import { waitForGeneratorStackHealth } from "./generator-stack-health.mjs";
 import {
   resolveCloudflaredConfigPath,
@@ -31,12 +34,14 @@ export async function runGeneratorStackTunnel({
   spawnImpl = spawn,
   startLocalGenerator = startLocalGeneratorLauncher,
   waitForHealth = waitForGeneratorStackHealth,
+  deleteRemoteRuntime = deleteRemoteGeneratorRuntime,
   writeRemoteRuntime = writeRemoteGeneratorRuntime,
 } = {}) {
   const signalState = createSignalState(processImpl);
   let generator = null;
   let tunnel = null;
   let tunnelChild = null;
+  let remoteRuntimeInitialized = false;
   const mergedEnv = loadWebScriptEnv({ env });
   const cloudflaredConfigPath = resolveCloudflaredConfigPath(mergedEnv);
 
@@ -47,6 +52,18 @@ export async function runGeneratorStackTunnel({
     if (!preflightResult.ok) {
       return preflightResult;
     }
+    const deleteBeforeStartResult = await deleteRemoteRuntime({
+      env: mergedEnv,
+      logger,
+    });
+    if (!deleteBeforeStartResult.ok) {
+      return {
+        exitCode: 1,
+        marker: "[generator-stack][remote-kv][delete-failed]",
+        ok: false,
+      };
+    }
+    remoteRuntimeInitialized = true;
 
     if (signalState.value !== null) {
       return stopForSignal({
@@ -163,12 +180,21 @@ export async function runGeneratorStackTunnel({
       url: publicBaseUrl,
     });
     if (preflightResult.tunnelMode === "quick") {
-      await writeRemoteRuntime({
+      const writeRemoteRuntimeResult = await writeRemoteRuntime({
         env: mergedEnv,
         logger,
         mode: "quick",
         url: publicBaseUrl,
       });
+      if (!writeRemoteRuntimeResult.ok) {
+        await stopTrackedChild(generator);
+        await stopTrackedChild(tunnel);
+        return {
+          exitCode: 1,
+          marker: "[generator-stack][remote-kv][write-failed]",
+          ok: false,
+        };
+      }
     }
 
     const externalHealth = await waitForHealthPhase({
@@ -236,6 +262,12 @@ export async function runGeneratorStackTunnel({
       tunnel,
     });
   } finally {
+    if (remoteRuntimeInitialized) {
+      await deleteRemoteRuntime({
+        env: mergedEnv,
+        logger,
+      });
+    }
     signalState.cleanup();
     removeGeneratorRuntimeState({ appRootPath, env: mergedEnv });
   }

--- a/apps/web/scripts/run-local-generator.mjs
+++ b/apps/web/scripts/run-local-generator.mjs
@@ -43,20 +43,24 @@ export function startLocalGenerator({
     imageTag,
   });
 
-  const child = spawnImpl("docker", buildDockerRunArgs({
-    containerName: `one-portrait-generator-${localPort}`,
-    imageTag,
-    runtimeEnv: buildGeneratorContainerEnv(mergedEnv),
-    localPort,
-  }), {
-    cwd,
-    env: {
-      ...process.env,
-      ...env,
-      ...mergedEnv,
+  const child = spawnImpl(
+    "docker",
+    buildDockerRunArgs({
+      containerName: `one-portrait-generator-${localPort}`,
+      imageTag,
+      runtimeEnv: buildGeneratorContainerEnv(mergedEnv),
+      localPort,
+    }),
+    {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+        ...mergedEnv,
+      },
+      stdio: "inherit",
     },
-    stdio: "inherit",
-  });
+  );
 
   return { child };
 }
@@ -142,7 +146,12 @@ function normalizePortEnvValue(value) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function buildDockerRunArgs({ containerName, imageTag, localPort, runtimeEnv }) {
+function buildDockerRunArgs({
+  containerName,
+  imageTag,
+  localPort,
+  runtimeEnv,
+}) {
   return [
     "run",
     "--rm",
@@ -157,7 +166,9 @@ function buildDockerRunArgs({ containerName, imageTag, localPort, runtimeEnv }) 
 
 function buildDockerEnvArgs(runtimeEnv) {
   return Object.entries(runtimeEnv).flatMap(([key, value]) =>
-    typeof value === "string" && value.length > 0 ? ["--env", `${key}=${value}`] : [],
+    typeof value === "string" && value.length > 0
+      ? ["--env", `${key}=${value}`]
+      : [],
   );
 }
 
@@ -187,9 +198,7 @@ function defaultRunDockerBuild({ contextPath, dockerfilePath, imageTag }) {
   );
 
   if (result.status !== 0) {
-    throw new Error(
-      `docker build failed with exit code ${result.status ?? 1}`,
-    );
+    throw new Error(`docker build failed with exit code ${result.status ?? 1}`);
   }
 }
 

--- a/apps/web/scripts/run-local-generator.mjs
+++ b/apps/web/scripts/run-local-generator.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,8 @@ const __dirname = path.dirname(__filename);
 const webRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(webRoot, "..", "..");
 const generatorRoot = path.join(repoRoot, "generator");
-const generatorTsxBin = path.join(generatorRoot, "node_modules", ".bin", "tsx");
+const generatorDockerfilePath = path.join(generatorRoot, "Dockerfile");
+const generatorImageTag = "one-portrait-generator:local";
 
 export function loadWebScriptEnv({ env = process.env } = {}) {
   return {
@@ -29,23 +30,30 @@ function resolveLocalGeneratorPort(env) {
 export function startLocalGenerator({
   env = process.env,
   spawnImpl = spawn,
-  generatorBin = generatorTsxBin,
-  cwd = generatorRoot,
+  cwd = repoRoot,
+  imageTag = generatorImageTag,
+  runDockerBuild = defaultRunDockerBuild,
 } = {}) {
   const mergedEnv = loadWebScriptEnv({ env });
+  const localPort = resolveLocalGeneratorPort(mergedEnv);
 
-  const child = spawnImpl(generatorBin, ["./src/server.ts"], {
+  runDockerBuild({
+    contextPath: cwd,
+    dockerfilePath: generatorDockerfilePath,
+    imageTag,
+  });
+
+  const child = spawnImpl("docker", buildDockerRunArgs({
+    containerName: `one-portrait-generator-${localPort}`,
+    imageTag,
+    runtimeEnv: buildGeneratorContainerEnv(mergedEnv),
+    localPort,
+  }), {
     cwd,
     env: {
+      ...process.env,
       ...env,
       ...mergedEnv,
-      PORT: resolveLocalGeneratorPort(mergedEnv),
-      SUI_NETWORK: mergedEnv.SUI_NETWORK ?? mergedEnv.NEXT_PUBLIC_SUI_NETWORK,
-      PACKAGE_ID: mergedEnv.PACKAGE_ID ?? mergedEnv.NEXT_PUBLIC_PACKAGE_ID,
-      WALRUS_PUBLISHER:
-        mergedEnv.WALRUS_PUBLISHER ?? mergedEnv.NEXT_PUBLIC_WALRUS_PUBLISHER,
-      WALRUS_AGGREGATOR:
-        mergedEnv.WALRUS_AGGREGATOR ?? mergedEnv.NEXT_PUBLIC_WALRUS_AGGREGATOR,
     },
     stdio: "inherit",
   });
@@ -132,6 +140,57 @@ function normalizePortEnvValue(value) {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildDockerRunArgs({ containerName, imageTag, localPort, runtimeEnv }) {
+  return [
+    "run",
+    "--rm",
+    "--name",
+    containerName,
+    "--publish",
+    `127.0.0.1:${localPort}:8080`,
+    ...buildDockerEnvArgs(runtimeEnv),
+    imageTag,
+  ];
+}
+
+function buildDockerEnvArgs(runtimeEnv) {
+  return Object.entries(runtimeEnv).flatMap(([key, value]) =>
+    typeof value === "string" && value.length > 0 ? ["--env", `${key}=${value}`] : [],
+  );
+}
+
+function buildGeneratorContainerEnv(mergedEnv) {
+  return {
+    ADMIN_CAP_ID: mergedEnv.ADMIN_CAP_ID,
+    ADMIN_SUI_PRIVATE_KEY: mergedEnv.ADMIN_SUI_PRIVATE_KEY,
+    OP_FINALIZE_DISPATCH_SECRET: mergedEnv.OP_FINALIZE_DISPATCH_SECRET,
+    PACKAGE_ID: mergedEnv.PACKAGE_ID ?? mergedEnv.NEXT_PUBLIC_PACKAGE_ID,
+    PORT: "8080",
+    SUI_NETWORK: mergedEnv.SUI_NETWORK ?? mergedEnv.NEXT_PUBLIC_SUI_NETWORK,
+    WALRUS_AGGREGATOR:
+      mergedEnv.WALRUS_AGGREGATOR ?? mergedEnv.NEXT_PUBLIC_WALRUS_AGGREGATOR,
+    WALRUS_PUBLISHER:
+      mergedEnv.WALRUS_PUBLISHER ?? mergedEnv.NEXT_PUBLIC_WALRUS_PUBLISHER,
+  };
+}
+
+function defaultRunDockerBuild({ contextPath, dockerfilePath, imageTag }) {
+  const result = spawnSync(
+    "docker",
+    ["build", "--file", dockerfilePath, "--tag", imageTag, contextPath],
+    {
+      cwd: contextPath,
+      stdio: "inherit",
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `docker build failed with exit code ${result.status ?? 1}`,
+    );
+  }
 }
 
 function isExecutedDirectly() {

--- a/apps/web/scripts/run-local-generator.test.ts
+++ b/apps/web/scripts/run-local-generator.test.ts
@@ -3,7 +3,68 @@ import { describe, expect, it, vi } from "vitest";
 import { startLocalGenerator } from "./run-local-generator.mjs";
 
 describe("startLocalGenerator", () => {
+  it("builds the generator image and runs the container with forwarded env", () => {
+    const runDockerBuild = vi.fn();
+    const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
+
+    startLocalGenerator({
+      env: {
+        ADMIN_CAP_ID: "0xadmincap",
+        ADMIN_SUI_PRIVATE_KEY: "suiprivkey",
+        NEXT_PUBLIC_PACKAGE_ID: "0xpkg",
+        NEXT_PUBLIC_SUI_NETWORK: "testnet",
+        NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+        NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+        OP_FINALIZE_DISPATCH_SECRET: "shared-secret",
+        OP_LOCAL_GENERATOR_PORT: "7070",
+      },
+      runDockerBuild,
+      spawnImpl,
+    });
+
+    expect(runDockerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextPath: expect.stringContaining("one_portrait"),
+        dockerfilePath: expect.stringContaining("generator/Dockerfile"),
+        imageTag: "one-portrait-generator:local",
+      }),
+    );
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining([
+        "run",
+        "--rm",
+        "--name",
+        "one-portrait-generator-7070",
+        "--publish",
+        "127.0.0.1:7070:8080",
+        "--env",
+        "PORT=8080",
+        "--env",
+        "SUI_NETWORK=testnet",
+        "--env",
+        "PACKAGE_ID=0xpkg",
+        "--env",
+        "WALRUS_PUBLISHER=https://publisher.example.com",
+        "--env",
+        "WALRUS_AGGREGATOR=https://aggregator.example.com",
+        "--env",
+        "ADMIN_CAP_ID=0xadmincap",
+        "--env",
+        "ADMIN_SUI_PRIVATE_KEY=suiprivkey",
+        "--env",
+        "OP_FINALIZE_DISPATCH_SECRET=shared-secret",
+        "one-portrait-generator:local",
+      ]),
+      expect.objectContaining({
+        cwd: expect.stringContaining("one_portrait"),
+        stdio: "inherit",
+      }),
+    );
+  });
+
   it("defaults to 8080 when OP_LOCAL_GENERATOR_PORT is blank", () => {
+    const runDockerBuild = vi.fn();
     const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
 
     startLocalGenerator({
@@ -11,42 +72,46 @@ describe("startLocalGenerator", () => {
         OP_LOCAL_GENERATOR_PORT: "",
         PORT: "",
       },
+      runDockerBuild,
       spawnImpl,
     });
 
     expect(spawnImpl).toHaveBeenCalledWith(
-      expect.any(String),
-      ["./src/server.ts"],
-      expect.objectContaining({
-        env: expect.objectContaining({
-          PORT: "8080",
-        }),
-      }),
+      "docker",
+      expect.arrayContaining([
+        "--name",
+        "one-portrait-generator-8080",
+        "--publish",
+        "127.0.0.1:8080:8080",
+      ]),
+      expect.any(Object),
     );
   });
 
   it("uses PORT when OP_LOCAL_GENERATOR_PORT is unset", () => {
+    const runDockerBuild = vi.fn();
     const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
 
     startLocalGenerator({
       env: {
         PORT: "9090",
       },
+      runDockerBuild,
       spawnImpl,
     });
 
     expect(spawnImpl).toHaveBeenCalledWith(
-      expect.any(String),
-      ["./src/server.ts"],
-      expect.objectContaining({
-        env: expect.objectContaining({
-          PORT: "9090",
-        }),
-      }),
+      "docker",
+      expect.arrayContaining([
+        "--publish",
+        "127.0.0.1:9090:8080",
+      ]),
+      expect.any(Object),
     );
   });
 
   it("prefers OP_LOCAL_GENERATOR_PORT over PORT", () => {
+    const runDockerBuild = vi.fn();
     const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
 
     startLocalGenerator({
@@ -54,17 +119,17 @@ describe("startLocalGenerator", () => {
         OP_LOCAL_GENERATOR_PORT: "7070",
         PORT: "9090",
       },
+      runDockerBuild,
       spawnImpl,
     });
 
     expect(spawnImpl).toHaveBeenCalledWith(
-      expect.any(String),
-      ["./src/server.ts"],
-      expect.objectContaining({
-        env: expect.objectContaining({
-          PORT: "7070",
-        }),
-      }),
+      "docker",
+      expect.arrayContaining([
+        "--publish",
+        "127.0.0.1:7070:8080",
+      ]),
+      expect.any(Object),
     );
   });
 });

--- a/apps/web/scripts/run-local-generator.test.ts
+++ b/apps/web/scripts/run-local-generator.test.ts
@@ -102,10 +102,7 @@ describe("startLocalGenerator", () => {
 
     expect(spawnImpl).toHaveBeenCalledWith(
       "docker",
-      expect.arrayContaining([
-        "--publish",
-        "127.0.0.1:9090:8080",
-      ]),
+      expect.arrayContaining(["--publish", "127.0.0.1:9090:8080"]),
       expect.any(Object),
     );
   });
@@ -125,10 +122,7 @@ describe("startLocalGenerator", () => {
 
     expect(spawnImpl).toHaveBeenCalledWith(
       "docker",
-      expect.arrayContaining([
-        "--publish",
-        "127.0.0.1:7070:8080",
-      ]),
+      expect.arrayContaining(["--publish", "127.0.0.1:7070:8080"]),
       expect.any(Object),
     );
   });

--- a/apps/web/src/app/api/admin/create-unit/route.test.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.test.ts
@@ -5,12 +5,20 @@ const { loadAdminRelayEnvMock, loadPublicEnvMock } = vi.hoisted(() => ({
   loadPublicEnvMock: vi.fn(),
 }));
 
+const { getRequestCloudflareEnvMock } = vi.hoisted(() => ({
+  getRequestCloudflareEnvMock: vi.fn(),
+}));
+
 vi.mock("../../../../lib/admin/env", () => ({
   loadAdminRelayEnv: loadAdminRelayEnvMock,
 }));
 
 vi.mock("../../../../lib/env", () => ({
   loadPublicEnv: loadPublicEnvMock,
+}));
+
+vi.mock("../../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 import { POST } from "./route";
@@ -26,6 +34,7 @@ describe("POST /api/admin/create-unit", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    getRequestCloudflareEnvMock.mockReset();
     loadAdminRelayEnvMock.mockReset();
     loadPublicEnvMock.mockReset();
   });
@@ -66,6 +75,7 @@ describe("POST /api/admin/create-unit", () => {
   });
 
   it("relays the validated create-unit request to the generator", async () => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
     loadPublicEnvMock.mockReturnValue({
       packageId: "0xpkg",
       registryObjectId: VALID_REGISTRY_ID,

--- a/apps/web/src/app/api/admin/create-unit/route.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.ts
@@ -1,4 +1,3 @@
-import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   adminUnavailable,
@@ -7,6 +6,7 @@ import {
   parseCreateUnitInput,
 } from "../../../../lib/admin/api";
 import { relayAdminPost } from "../../../../lib/admin/dispatch";
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { loadPublicEnv } from "../../../../lib/env";
 
 export async function POST(request: Request): Promise<Response> {

--- a/apps/web/src/app/api/admin/create-unit/route.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.ts
@@ -1,3 +1,4 @@
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   adminUnavailable,
@@ -11,15 +12,22 @@ import { loadPublicEnv } from "../../../../lib/env";
 export async function POST(request: Request): Promise<Response> {
   try {
     assertAdminMutationRequest(request);
+    const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
     const input = parseCreateUnitInput(await request.json());
     const { registryObjectId } = loadPublicEnv(process.env);
 
-    return await relayAdminPost("/admin/create-unit", {
-      athleteId: input.athleteId,
-      blobId: input.blobId,
-      maxSlots: input.maxSlots,
-      registryObjectId,
-    });
+    return await relayAdminPost(
+      "/admin/create-unit",
+      {
+        athleteId: input.athleteId,
+        blobId: input.blobId,
+        maxSlots: input.maxSlots,
+        registryObjectId,
+      },
+      {
+        env: cloudflareEnv,
+      },
+    );
   } catch (error) {
     return toResponse(error);
   }

--- a/apps/web/src/app/api/admin/finalize/route.test.ts
+++ b/apps/web/src/app/api/admin/finalize/route.test.ts
@@ -8,10 +8,10 @@ const {
   getFinalizeUnitSnapshotMock,
   getRequestCloudflareEnvMock,
 } = vi.hoisted(() => ({
-    dispatchFinalizeMock: vi.fn(),
-    getFinalizeUnitSnapshotMock: vi.fn(),
-    getRequestCloudflareEnvMock: vi.fn(),
-  }));
+  dispatchFinalizeMock: vi.fn(),
+  getFinalizeUnitSnapshotMock: vi.fn(),
+  getRequestCloudflareEnvMock: vi.fn(),
+}));
 
 vi.mock("../../../../lib/finalize/dispatch", () => ({
   dispatchFinalize: dispatchFinalizeMock,

--- a/apps/web/src/app/api/admin/finalize/route.test.ts
+++ b/apps/web/src/app/api/admin/finalize/route.test.ts
@@ -1,17 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const VALID_UNIT_ID =
   "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
 
-const { dispatchFinalizeMock, getFinalizeUnitSnapshotMock } = vi.hoisted(
-  () => ({
+const {
+  dispatchFinalizeMock,
+  getFinalizeUnitSnapshotMock,
+  getRequestCloudflareEnvMock,
+} = vi.hoisted(() => ({
     dispatchFinalizeMock: vi.fn(),
     getFinalizeUnitSnapshotMock: vi.fn(),
-  }),
-);
+    getRequestCloudflareEnvMock: vi.fn(),
+  }));
 
 vi.mock("../../../../lib/finalize/dispatch", () => ({
   dispatchFinalize: dispatchFinalizeMock,
+}));
+
+vi.mock("../../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 vi.mock("../../../../lib/sui", async () => {
@@ -28,6 +35,10 @@ vi.mock("../../../../lib/sui", async () => {
 import { POST } from "./route";
 
 describe("POST /api/admin/finalize", () => {
+  beforeEach(() => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
+  });
+
   it("returns 400 for an invalid payload", async () => {
     const response = await POST(
       new Request("http://localhost/api/admin/finalize", {
@@ -88,6 +99,12 @@ describe("POST /api/admin/finalize", () => {
     const response = await POST(validRequest());
 
     expect(response.status).toBe(200);
+    expect(dispatchFinalizeMock).toHaveBeenCalledWith(
+      { unitId: VALID_UNIT_ID },
+      {
+        env: undefined,
+      },
+    );
     await expect(response.json()).resolves.toEqual({
       status: "finalized",
       unitId: VALID_UNIT_ID,

--- a/apps/web/src/app/api/admin/finalize/route.ts
+++ b/apps/web/src/app/api/admin/finalize/route.ts
@@ -1,9 +1,9 @@
-import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   assertAdminMutationRequest,
   jsonAdminError,
 } from "../../../../lib/admin/api";
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   FinalizeApiError,
   jsonError,

--- a/apps/web/src/app/api/admin/finalize/route.ts
+++ b/apps/web/src/app/api/admin/finalize/route.ts
@@ -1,3 +1,4 @@
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   assertAdminMutationRequest,
@@ -14,6 +15,7 @@ import { getFinalizeUnitSnapshot } from "../../../../lib/sui";
 export async function POST(request: Request): Promise<Response> {
   try {
     assertAdminMutationRequest(request);
+    const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
     const input = parseFinalizeInput(await request.json());
     const snapshot = await getFinalizeUnitSnapshot(input.unitId);
 
@@ -32,7 +34,14 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     try {
-      return Response.json(await dispatchFinalize({ unitId: input.unitId }));
+      return Response.json(
+        await dispatchFinalize(
+          { unitId: input.unitId },
+          {
+            env: cloudflareEnv,
+          },
+        ),
+      );
     } catch (error) {
       console.error("Admin finalize dispatch failed", error);
 

--- a/apps/web/src/app/api/admin/health/route.test.ts
+++ b/apps/web/src/app/api/admin/health/route.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { getAdminHealthMock } = vi.hoisted(() => ({
+const { getAdminHealthMock, getRequestCloudflareEnvMock } = vi.hoisted(() => ({
   getAdminHealthMock: vi.fn(),
+  getRequestCloudflareEnvMock: vi.fn(),
 }));
 
 vi.mock("../../../../lib/admin/health", () => ({
   getAdminHealth: getAdminHealthMock,
+}));
+
+vi.mock("../../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 import { GET } from "./route";
@@ -13,9 +18,15 @@ import { GET } from "./route";
 describe("GET /api/admin/health", () => {
   afterEach(() => {
     getAdminHealthMock.mockReset();
+    getRequestCloudflareEnvMock.mockReset();
   });
 
   it("returns readiness, dispatch probe, and runtime source data", async () => {
+    getRequestCloudflareEnvMock.mockReturnValue({
+      OP_GENERATOR_RUNTIME_KV: {
+        get: vi.fn(),
+      },
+    });
     getAdminHealthMock.mockResolvedValue({
       currentUrl: "https://generator.example.com",
       dispatchAuthorization: {
@@ -32,6 +43,13 @@ describe("GET /api/admin/health", () => {
 
     const response = await GET();
 
+    expect(getAdminHealthMock).toHaveBeenCalledWith({
+      env: {
+        OP_GENERATOR_RUNTIME_KV: {
+          get: expect.any(Function),
+        },
+      },
+    });
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       currentUrl: "https://generator.example.com",
@@ -49,6 +67,7 @@ describe("GET /api/admin/health", () => {
   });
 
   it("surfaces a misconfigured runtime payload", async () => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
     getAdminHealthMock.mockResolvedValue({
       currentUrl: null,
       dispatchAuthorization: {
@@ -65,6 +84,9 @@ describe("GET /api/admin/health", () => {
 
     const response = await GET();
 
+    expect(getAdminHealthMock).toHaveBeenCalledWith({
+      env: undefined,
+    });
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       dispatchAuthorization: {

--- a/apps/web/src/app/api/admin/health/route.ts
+++ b/apps/web/src/app/api/admin/health/route.ts
@@ -1,5 +1,10 @@
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { getAdminHealth } from "../../../../lib/admin/health";
 
 export async function GET(): Promise<Response> {
-  return Response.json(await getAdminHealth());
+  return Response.json(
+    await getAdminHealth({
+      env: getRequestCloudflareEnv() ?? undefined,
+    }),
+  );
 }

--- a/apps/web/src/app/api/admin/health/route.ts
+++ b/apps/web/src/app/api/admin/health/route.ts
@@ -1,5 +1,5 @@
-import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { getAdminHealth } from "../../../../lib/admin/health";
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 
 export async function GET(): Promise<Response> {
   return Response.json(

--- a/apps/web/src/app/api/admin/rotate-unit/route.test.ts
+++ b/apps/web/src/app/api/admin/rotate-unit/route.test.ts
@@ -5,12 +5,20 @@ const { loadAdminRelayEnvMock, loadPublicEnvMock } = vi.hoisted(() => ({
   loadPublicEnvMock: vi.fn(),
 }));
 
+const { getRequestCloudflareEnvMock } = vi.hoisted(() => ({
+  getRequestCloudflareEnvMock: vi.fn(),
+}));
+
 vi.mock("../../../../lib/admin/env", () => ({
   loadAdminRelayEnv: loadAdminRelayEnvMock,
 }));
 
 vi.mock("../../../../lib/env", () => ({
   loadPublicEnv: loadPublicEnvMock,
+}));
+
+vi.mock("../../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 import { POST } from "./route";
@@ -26,6 +34,7 @@ describe("POST /api/admin/rotate-unit", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    getRequestCloudflareEnvMock.mockReset();
     loadAdminRelayEnvMock.mockReset();
     loadPublicEnvMock.mockReset();
   });
@@ -65,6 +74,7 @@ describe("POST /api/admin/rotate-unit", () => {
   });
 
   it("relays the validated rotate-unit request to the generator", async () => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
     loadPublicEnvMock.mockReturnValue({
       packageId: "0xpkg",
       registryObjectId: VALID_REGISTRY_ID,

--- a/apps/web/src/app/api/admin/rotate-unit/route.ts
+++ b/apps/web/src/app/api/admin/rotate-unit/route.ts
@@ -1,4 +1,3 @@
-import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   adminUnavailable,
@@ -7,6 +6,7 @@ import {
   parseRotateUnitInput,
 } from "../../../../lib/admin/api";
 import { relayAdminPost } from "../../../../lib/admin/dispatch";
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { loadPublicEnv } from "../../../../lib/env";
 
 export async function POST(request: Request): Promise<Response> {

--- a/apps/web/src/app/api/admin/rotate-unit/route.ts
+++ b/apps/web/src/app/api/admin/rotate-unit/route.ts
@@ -1,3 +1,4 @@
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import {
   AdminApiError,
   adminUnavailable,
@@ -11,14 +12,21 @@ import { loadPublicEnv } from "../../../../lib/env";
 export async function POST(request: Request): Promise<Response> {
   try {
     assertAdminMutationRequest(request);
+    const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
     const input = parseRotateUnitInput(await request.json());
     const { registryObjectId } = loadPublicEnv(process.env);
 
-    return await relayAdminPost("/admin/rotate-unit", {
-      athleteId: input.athleteId,
-      registryObjectId,
-      unitId: input.unitId,
-    });
+    return await relayAdminPost(
+      "/admin/rotate-unit",
+      {
+        athleteId: input.athleteId,
+        registryObjectId,
+        unitId: input.unitId,
+      },
+      {
+        env: cloudflareEnv,
+      },
+    );
   } catch (error) {
     return toResponse(error);
   }

--- a/apps/web/src/app/api/admin/upsert-athlete-metadata/route.test.ts
+++ b/apps/web/src/app/api/admin/upsert-athlete-metadata/route.test.ts
@@ -5,12 +5,20 @@ const { loadAdminRelayEnvMock, loadPublicEnvMock } = vi.hoisted(() => ({
   loadPublicEnvMock: vi.fn(),
 }));
 
+const { getRequestCloudflareEnvMock } = vi.hoisted(() => ({
+  getRequestCloudflareEnvMock: vi.fn(),
+}));
+
 vi.mock("../../../../lib/admin/env", () => ({
   loadAdminRelayEnv: loadAdminRelayEnvMock,
 }));
 
 vi.mock("../../../../lib/env", () => ({
   loadPublicEnv: loadPublicEnvMock,
+}));
+
+vi.mock("../../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 import { POST } from "./route";
@@ -24,6 +32,7 @@ describe("POST /api/admin/upsert-athlete-metadata", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    getRequestCloudflareEnvMock.mockReset();
     loadAdminRelayEnvMock.mockReset();
     loadPublicEnvMock.mockReset();
   });
@@ -65,6 +74,7 @@ describe("POST /api/admin/upsert-athlete-metadata", () => {
   });
 
   it("relays the validated metadata request to the generator", async () => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
     loadPublicEnvMock.mockReturnValue({
       packageId: "0xpkg",
       registryObjectId: VALID_REGISTRY_ID,

--- a/apps/web/src/app/api/admin/upsert-athlete-metadata/route.ts
+++ b/apps/web/src/app/api/admin/upsert-athlete-metadata/route.ts
@@ -6,21 +6,29 @@ import {
   parseUpsertAthleteMetadataInput,
 } from "../../../../lib/admin/api";
 import { relayAdminPost } from "../../../../lib/admin/dispatch";
+import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { loadPublicEnv } from "../../../../lib/env";
 
 export async function POST(request: Request): Promise<Response> {
   try {
     assertAdminMutationRequest(request);
+    const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
     const input = parseUpsertAthleteMetadataInput(await request.json());
     const { registryObjectId } = loadPublicEnv(process.env);
 
-    return await relayAdminPost("/admin/upsert-athlete-metadata", {
-      athleteId: input.athleteId,
-      displayName: input.displayName,
-      registryObjectId,
-      slug: input.slug,
-      thumbnailUrl: input.thumbnailUrl,
-    });
+    return await relayAdminPost(
+      "/admin/upsert-athlete-metadata",
+      {
+        athleteId: input.athleteId,
+        displayName: input.displayName,
+        registryObjectId,
+        slug: input.slug,
+        thumbnailUrl: input.thumbnailUrl,
+      },
+      {
+        env: cloudflareEnv,
+      },
+    );
   } catch (error) {
     return toResponse(error);
   }

--- a/apps/web/src/app/api/finalize/route.test.ts
+++ b/apps/web/src/app/api/finalize/route.test.ts
@@ -8,10 +8,10 @@ const {
   getFinalizeUnitSnapshotMock,
   getRequestCloudflareEnvMock,
 } = vi.hoisted(() => ({
-    dispatchFinalizeMock: vi.fn(),
-    getFinalizeUnitSnapshotMock: vi.fn(),
-    getRequestCloudflareEnvMock: vi.fn(),
-  }));
+  dispatchFinalizeMock: vi.fn(),
+  getFinalizeUnitSnapshotMock: vi.fn(),
+  getRequestCloudflareEnvMock: vi.fn(),
+}));
 
 vi.mock("../../../lib/finalize/dispatch", () => ({
   dispatchFinalize: dispatchFinalizeMock,

--- a/apps/web/src/app/api/finalize/route.test.ts
+++ b/apps/web/src/app/api/finalize/route.test.ts
@@ -1,17 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const VALID_UNIT_ID =
   "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
 
-const { dispatchFinalizeMock, getFinalizeUnitSnapshotMock } = vi.hoisted(
-  () => ({
+const {
+  dispatchFinalizeMock,
+  getFinalizeUnitSnapshotMock,
+  getRequestCloudflareEnvMock,
+} = vi.hoisted(() => ({
     dispatchFinalizeMock: vi.fn(),
     getFinalizeUnitSnapshotMock: vi.fn(),
-  }),
-);
+    getRequestCloudflareEnvMock: vi.fn(),
+  }));
 
 vi.mock("../../../lib/finalize/dispatch", () => ({
   dispatchFinalize: dispatchFinalizeMock,
+}));
+
+vi.mock("../../../lib/cloudflare-context", () => ({
+  getRequestCloudflareEnv: getRequestCloudflareEnvMock,
 }));
 
 vi.mock("../../../lib/sui", async () => {
@@ -29,6 +36,10 @@ vi.mock("../../../lib/sui", async () => {
 import { POST } from "./route";
 
 describe("POST /api/finalize", () => {
+  beforeEach(() => {
+    getRequestCloudflareEnvMock.mockReturnValue(null);
+  });
+
   it("returns 400 for an invalid payload", async () => {
     const response = await POST(
       new Request("http://localhost/api/finalize", {
@@ -97,9 +108,14 @@ describe("POST /api/finalize", () => {
 
     expect(response.status).toBe(200);
     expect(getFinalizeUnitSnapshotMock).toHaveBeenCalledWith(VALID_UNIT_ID);
-    expect(dispatchFinalizeMock).toHaveBeenCalledWith({
-      unitId: VALID_UNIT_ID,
-    });
+    expect(dispatchFinalizeMock).toHaveBeenCalledWith(
+      {
+        unitId: VALID_UNIT_ID,
+      },
+      {
+        env: undefined,
+      },
+    );
     await expect(response.json()).resolves.toEqual({
       status: "queued",
       unitId: VALID_UNIT_ID,

--- a/apps/web/src/app/api/finalize/route.ts
+++ b/apps/web/src/app/api/finalize/route.ts
@@ -1,3 +1,4 @@
+import { getRequestCloudflareEnv } from "../../../lib/cloudflare-context";
 import {
   FinalizeApiError,
   jsonError,
@@ -7,14 +8,17 @@ import { dispatchFinalize } from "../../../lib/finalize/dispatch";
 import { createFinalizeRouteService } from "../../../lib/finalize/service";
 import { getFinalizeUnitSnapshot } from "../../../lib/sui";
 
-const finalizeRoute = createFinalizeRouteService({
-  dispatch: dispatchFinalize,
-  readUnitSnapshot: getFinalizeUnitSnapshot,
-});
-
 export async function POST(request: Request): Promise<Response> {
   try {
     const input = parseFinalizeInput(await request.json());
+    const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
+    const finalizeRoute = createFinalizeRouteService({
+      dispatch: (dispatchRequest) =>
+        dispatchFinalize(dispatchRequest, {
+          env: cloudflareEnv,
+        }),
+      readUnitSnapshot: getFinalizeUnitSnapshot,
+    });
     const result = await finalizeRoute.execute(input.unitId);
     return Response.json(result);
   } catch (error) {

--- a/apps/web/src/cloudflare-env.d.ts
+++ b/apps/web/src/cloudflare-env.d.ts
@@ -1,5 +1,7 @@
 declare global {
-  interface CloudflareEnv {}
+  interface CloudflareEnv {
+    OP_GENERATOR_RUNTIME_KV: KVNamespace;
+  }
 }
 
 export {};

--- a/apps/web/src/lib/admin/dispatch.ts
+++ b/apps/web/src/lib/admin/dispatch.ts
@@ -1,13 +1,21 @@
 import { DISPATCH_SECRET_HEADER } from "../finalize/dispatch";
+import type { GeneratorRuntimeCloudflareEnv } from "../generator-runtime";
 
 import { ADMIN_MUTATION_HEADER, ADMIN_MUTATION_HEADER_VALUE } from "./api";
-import { loadAdminRelayEnv } from "./env";
+import { loadAdminRelayEnv, loadCloudflareAdminRelayEnv } from "./env";
+
+type RelayAdminPostDeps = {
+  readonly env?: GeneratorRuntimeCloudflareEnv;
+};
 
 export async function relayAdminPost(
   path: string,
   payload: unknown,
+  deps: RelayAdminPostDeps = {},
 ): Promise<Response> {
-  const relay = loadAdminRelayEnv(process.env);
+  const relay = deps.env
+    ? await loadCloudflareAdminRelayEnv(deps.env)
+    : loadAdminRelayEnv(process.env);
   const response = await fetch(
     new Request(new URL(path, `${relay.generatorBaseUrl}/`).toString(), {
       method: "POST",

--- a/apps/web/src/lib/admin/env.test.ts
+++ b/apps/web/src/lib/admin/env.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { AdminEnvError, loadAdminRelayEnv } from "./env";
+import {
+  AdminEnvError,
+  loadAdminRelayEnv,
+  loadCloudflareAdminRelayEnv,
+} from "./env";
 
 describe("loadAdminRelayEnv", () => {
   it("returns the generator relay config", () => {
@@ -75,5 +79,26 @@ describe("loadAdminRelayEnv", () => {
         OP_GENERATOR_BASE_URL: "https://generator.example.com",
       }),
     ).toThrow(AdminEnvError);
+  });
+});
+
+describe("loadCloudflareAdminRelayEnv", () => {
+  it("reads the generator relay config from worker kv", async () => {
+    await expect(
+      loadCloudflareAdminRelayEnv({
+        OP_FINALIZE_DISPATCH_SECRET: "request-secret",
+        OP_GENERATOR_RUNTIME_KV: {
+          get: async () => ({
+            mode: "quick",
+            updatedAt: new Date().toISOString(),
+            url: "https://worker-kv.example.com/",
+            version: 1,
+          }),
+        },
+      }),
+    ).resolves.toEqual({
+      generatorBaseUrl: "https://worker-kv.example.com",
+      sharedSecret: "request-secret",
+    });
   });
 });

--- a/apps/web/src/lib/admin/env.ts
+++ b/apps/web/src/lib/admin/env.ts
@@ -13,7 +13,9 @@ export type AdminRelayEnv = {
 };
 
 import {
+  type GeneratorRuntimeCloudflareEnv,
   type GeneratorRuntimeResolution,
+  resolveCloudflareGeneratorRuntime,
   resolveGeneratorRuntime,
 } from "../generator-runtime";
 
@@ -41,6 +43,28 @@ export function loadAdminRelayEnv(
     generatorBaseUrl: runtime.url,
     sharedSecret: readRequiredValue(
       source.OP_FINALIZE_DISPATCH_SECRET,
+      "OP_FINALIZE_DISPATCH_SECRET",
+    ),
+  };
+}
+
+export async function loadCloudflareAdminRelayEnv(
+  source: GeneratorRuntimeCloudflareEnv,
+): Promise<AdminRelayEnv> {
+  const runtime = await resolveCloudflareGeneratorRuntime({
+    env: source,
+  });
+
+  if (runtime.status !== "ok") {
+    throw new AdminEnvError(runtime.message);
+  }
+
+  return {
+    generatorBaseUrl: runtime.url,
+    sharedSecret: readRequiredValue(
+      typeof source.OP_FINALIZE_DISPATCH_SECRET === "string"
+        ? source.OP_FINALIZE_DISPATCH_SECRET
+        : undefined,
       "OP_FINALIZE_DISPATCH_SECRET",
     ),
   };

--- a/apps/web/src/lib/admin/health.test.ts
+++ b/apps/web/src/lib/admin/health.test.ts
@@ -65,4 +65,46 @@ describe("getAdminHealth", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("reads the current url from worker kv when request env is provided", async () => {
+    fetchMock.mockImplementation(async (request: Request) => {
+      if (request.url === "https://worker-kv.example.com/health") {
+        return new Response("ok", { status: 200 });
+      }
+
+      return new Response(JSON.stringify({ status: "ok" }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getAdminHealth({
+        env: {
+          OP_FINALIZE_DISPATCH_SECRET: "shared-secret",
+          OP_GENERATOR_RUNTIME_KV: {
+            get: async () => ({
+              mode: "quick",
+              updatedAt: new Date().toISOString(),
+              url: "https://worker-kv.example.com/",
+              version: 1,
+            }),
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      currentUrl: "https://worker-kv.example.com",
+      dispatchAuthorization: {
+        httpStatus: 200,
+        status: "ok",
+      },
+      generatorReadiness: {
+        httpStatus: 200,
+        status: "ok",
+      },
+      resolutionStatus: "ok",
+      source: "worker_kv",
+    });
+  });
 });

--- a/apps/web/src/lib/admin/health.ts
+++ b/apps/web/src/lib/admin/health.ts
@@ -1,5 +1,9 @@
 import { DISPATCH_SECRET_HEADER } from "../finalize/dispatch";
-import { resolveGeneratorRuntime } from "../generator-runtime";
+import {
+  type GeneratorRuntimeCloudflareEnv,
+  resolveCloudflareGeneratorRuntime,
+  resolveGeneratorRuntime,
+} from "../generator-runtime";
 
 export type AdminHealthStatus = {
   readonly httpStatus: number | null;
@@ -16,11 +20,22 @@ export type AdminHealthSummary = {
     | "legacy_env"
     | "none"
     | "override"
-    | "runtime_state";
+    | "runtime_state"
+    | "worker_kv";
 };
 
-export async function getAdminHealth(): Promise<AdminHealthSummary> {
-  const runtime = resolveGeneratorRuntime({ env: process.env });
+type GetAdminHealthDeps = {
+  readonly env?: GeneratorRuntimeCloudflareEnv;
+};
+
+export async function getAdminHealth(
+  deps: GetAdminHealthDeps = {},
+): Promise<AdminHealthSummary> {
+  const env = deps.env ?? process.env;
+  const runtime =
+    deps.env === undefined
+      ? resolveGeneratorRuntime({ env: process.env })
+      : await resolveCloudflareGeneratorRuntime({ env });
   if (runtime.status !== "ok") {
     return {
       currentUrl: null,
@@ -38,7 +53,9 @@ export async function getAdminHealth(): Promise<AdminHealthSummary> {
   }
 
   const sharedSecret = normalizeSharedSecret(
-    process.env.OP_FINALIZE_DISPATCH_SECRET,
+    typeof env.OP_FINALIZE_DISPATCH_SECRET === "string"
+      ? env.OP_FINALIZE_DISPATCH_SECRET
+      : undefined,
   );
   const [generatorReadiness, dispatchAuthorization] = await Promise.all([
     fetchGeneratorReadiness(runtime.url),

--- a/apps/web/src/lib/cloudflare-context.ts
+++ b/apps/web/src/lib/cloudflare-context.ts
@@ -1,0 +1,11 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+import type { GeneratorRuntimeCloudflareEnv } from "./generator-runtime";
+
+export function getRequestCloudflareEnv(): GeneratorRuntimeCloudflareEnv | null {
+  try {
+    return getCloudflareContext().env as GeneratorRuntimeCloudflareEnv;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/finalize/dispatch.test.ts
+++ b/apps/web/src/lib/finalize/dispatch.test.ts
@@ -126,4 +126,47 @@ describe("createFinalizeDispatcher", () => {
       message: expect.stringContaining("OP_FINALIZE_DISPATCH_SECRET"),
     });
   });
+
+  it("uses request-scoped worker kv and secret when provided", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({
+        status: "ignored_pending",
+        unitId: VALID_UNIT_ID,
+      }),
+    );
+    const dispatchFinalize = createFinalizeDispatcher({
+      fetchImpl,
+      dispatchSecret: "shared-secret-from-process-env",
+    });
+
+    await expect(
+      dispatchFinalize(
+        {
+          unitId: VALID_UNIT_ID,
+        },
+        {
+          env: {
+            OP_FINALIZE_DISPATCH_SECRET: "request-scoped-secret",
+            OP_GENERATOR_RUNTIME_KV: {
+              get: async () => ({
+                mode: "quick",
+                updatedAt: new Date().toISOString(),
+                url: "https://worker-kv.example.com",
+                version: 1,
+              }),
+            },
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      status: "ignored_pending",
+      unitId: VALID_UNIT_ID,
+    });
+
+    const request = (fetchImpl.mock.calls[0] as unknown as [Request])[0];
+    expect(request.url).toBe("https://worker-kv.example.com/dispatch");
+    expect(request.headers.get(DISPATCH_SECRET_HEADER)).toBe(
+      "request-scoped-secret",
+    );
+  });
 });

--- a/apps/web/src/lib/finalize/dispatch.ts
+++ b/apps/web/src/lib/finalize/dispatch.ts
@@ -1,5 +1,7 @@
 import {
+  type GeneratorRuntimeCloudflareEnv,
   type GeneratorRuntimeResolution,
+  resolveCloudflareGeneratorRuntime,
   resolveGeneratorRuntime,
 } from "../generator-runtime";
 import { FinalizeApiError } from "./api";
@@ -26,7 +28,13 @@ export const DISPATCH_SECRET_HEADER = "x-op-finalize-dispatch-secret";
 type FinalizeDispatcherDeps = {
   readonly fetchImpl?: typeof fetch;
   readonly dispatchSecret?: string | undefined;
-  readonly resolveRuntime?: () => GeneratorRuntimeResolution;
+  readonly resolveRuntime?:
+    | (() => GeneratorRuntimeResolution | Promise<GeneratorRuntimeResolution>)
+    | undefined;
+};
+
+type FinalizeDispatchRuntimeDeps = {
+  readonly env?: GeneratorRuntimeCloudflareEnv;
 };
 
 export function createFinalizeDispatcher(
@@ -38,13 +46,24 @@ export function createFinalizeDispatcher(
 ) {
   return async function dispatchFinalize(
     request: FinalizeDispatchRequest,
+    runtimeDeps: FinalizeDispatchRuntimeDeps = {},
   ): Promise<FinalizeDispatchResult> {
-    const runtime = deps.resolveRuntime?.() ?? resolveGeneratorRuntime();
+    const runtime = runtimeDeps.env
+      ? await resolveCloudflareGeneratorRuntime({
+          env: runtimeDeps.env,
+        })
+      : await Promise.resolve(
+          deps.resolveRuntime?.() ?? resolveGeneratorRuntime(),
+        );
     if (runtime.status !== "ok") {
       throw new FinalizeApiError(503, "finalize_unavailable", runtime.message);
     }
 
-    const dispatchSecret = normalizeDispatchSecret(deps.dispatchSecret);
+    const dispatchSecret = normalizeDispatchSecret(
+      typeof runtimeDeps.env?.OP_FINALIZE_DISPATCH_SECRET === "string"
+        ? runtimeDeps.env.OP_FINALIZE_DISPATCH_SECRET
+        : deps.dispatchSecret,
+    );
     if (dispatchSecret === null) {
       throw new FinalizeApiError(
         503,

--- a/apps/web/src/lib/generator-runtime.test.ts
+++ b/apps/web/src/lib/generator-runtime.test.ts
@@ -230,6 +230,28 @@ describe("resolveCloudflareGeneratorRuntime", () => {
       url: "http://127.0.0.1:8080",
     });
   });
+
+  it("ignores stale worker kv payloads and falls back to legacy env", async () => {
+    await expect(
+      resolveCloudflareGeneratorRuntime({
+        env: {
+          OP_GENERATOR_BASE_URL: "https://legacy.example.com",
+          OP_GENERATOR_RUNTIME_KV: {
+            get: async () => ({
+              mode: "quick",
+              updatedAt: new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+              url: "https://stale-worker-kv.example.com",
+              version: 1,
+            }),
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      source: "legacy_env",
+      status: "ok",
+      url: "https://legacy.example.com",
+    });
+  });
 });
 
 function createAppRootWithRuntimeState(input: {

--- a/apps/web/src/lib/generator-runtime.test.ts
+++ b/apps/web/src/lib/generator-runtime.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { resolveGeneratorRuntime } from "./generator-runtime";
+import {
+  resolveCloudflareGeneratorRuntime,
+  resolveGeneratorRuntime,
+} from "./generator-runtime";
 
 const createdDirs: string[] = [];
 
@@ -138,6 +141,93 @@ describe("resolveGeneratorRuntime", () => {
       source: "runtime_state",
       status: "ok",
       url: "https://env-path.example.com",
+    });
+  });
+});
+
+describe("resolveCloudflareGeneratorRuntime", () => {
+  it("prefers the shell override over worker kv and legacy env", async () => {
+    const kvGet = () =>
+      Promise.resolve({
+        mode: "quick",
+        updatedAt: new Date().toISOString(),
+        url: "https://worker-kv.example.com",
+        version: 1,
+      });
+
+    await expect(
+      resolveCloudflareGeneratorRuntime({
+        env: {
+          OP_FINALIZE_DISPATCH_URL: "https://legacy.example.com",
+          OP_GENERATOR_RUNTIME_KV: {
+            get: kvGet,
+          },
+          OP_GENERATOR_RUNTIME_URL_OVERRIDE: "https://override.example.com",
+        },
+      }),
+    ).resolves.toEqual({
+      source: "override",
+      status: "ok",
+      url: "https://override.example.com",
+    });
+  });
+
+  it("prefers worker kv over legacy env", async () => {
+    await expect(
+      resolveCloudflareGeneratorRuntime({
+        env: {
+          OP_FINALIZE_DISPATCH_URL: "https://legacy.example.com",
+          OP_GENERATOR_RUNTIME_KV: {
+            get: async () => ({
+              mode: "quick",
+              updatedAt: new Date().toISOString(),
+              url: "https://worker-kv.example.com/",
+              version: 1,
+            }),
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      source: "worker_kv",
+      status: "ok",
+      url: "https://worker-kv.example.com",
+    });
+  });
+
+  it("ignores an invalid worker kv payload and falls back to legacy env", async () => {
+    await expect(
+      resolveCloudflareGeneratorRuntime({
+        env: {
+          OP_GENERATOR_BASE_URL: "https://legacy.example.com",
+          OP_GENERATOR_RUNTIME_KV: {
+            get: async () => ({
+              nope: true,
+            }),
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      source: "legacy_env",
+      status: "ok",
+      url: "https://legacy.example.com",
+    });
+  });
+
+  it("ignores worker kv read failures and falls back to localhost", async () => {
+    await expect(
+      resolveCloudflareGeneratorRuntime({
+        env: {
+          OP_GENERATOR_RUNTIME_KV: {
+            get: async () => {
+              throw new Error("kv offline");
+            },
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      source: "fallback",
+      status: "ok",
+      url: "http://127.0.0.1:8080",
     });
   });
 });

--- a/apps/web/src/lib/generator-runtime.ts
+++ b/apps/web/src/lib/generator-runtime.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const DEFAULT_FALLBACK_URL = "http://127.0.0.1:8080";
 const DEFAULT_STATE_MAX_AGE_MS = 15 * 60 * 1000;
+const DEFAULT_REMOTE_STATE_MAX_AGE_MS = 15 * 60 * 1000;
 const RUNTIME_STATE_VERSION = 1;
 
 type EnvSource = Readonly<Record<string, string | undefined>>;
@@ -294,7 +295,9 @@ async function readGeneratorRuntimeKvState(
 
   try {
     const parsed = await kv.get(GENERATOR_RUNTIME_KV_KEY, "json");
-    return normalizeRuntimeKvState(parsed);
+    return normalizeRuntimeKvState(parsed, {
+      now: Date.now(),
+    });
   } catch {
     return null;
   }
@@ -337,6 +340,7 @@ function normalizeRuntimeState(input: unknown): GeneratorRuntimeState | null {
 
 function normalizeRuntimeKvState(
   input: unknown,
+  { now }: { now: number },
 ): GeneratorRuntimeKvState | null {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return null;
@@ -355,6 +359,14 @@ function normalizeRuntimeKvState(
     (mode !== "named" && mode !== "quick") ||
     typeof updatedAt !== "string" ||
     url === null
+  ) {
+    return null;
+  }
+
+  const updatedAtMs = Date.parse(updatedAt);
+  if (
+    !Number.isFinite(updatedAtMs) ||
+    now - updatedAtMs > DEFAULT_REMOTE_STATE_MAX_AGE_MS
   ) {
     return null;
   }

--- a/apps/web/src/lib/generator-runtime.ts
+++ b/apps/web/src/lib/generator-runtime.ts
@@ -37,10 +37,7 @@ export type GeneratorRuntimeKvState = {
 };
 
 export type GeneratorRuntimeKvNamespace = {
-  get(
-    key: string,
-    type: "json",
-  ): Promise<Record<string, unknown> | null>;
+  get(key: string, type: "json"): Promise<Record<string, unknown> | null>;
 };
 
 export type GeneratorRuntimeCloudflareEnv = RuntimeEnvSource & {
@@ -257,8 +254,12 @@ export async function resolveCloudflareGeneratorRuntime({
   };
 }
 
-function resolveLegacyRuntimeUrl(env: RuntimeEnvSource): LegacyRuntimeResolution {
-  const generatorBaseUrl = normalizeUrl(readEnvString(env.OP_GENERATOR_BASE_URL));
+function resolveLegacyRuntimeUrl(
+  env: RuntimeEnvSource,
+): LegacyRuntimeResolution {
+  const generatorBaseUrl = normalizeUrl(
+    readEnvString(env.OP_GENERATOR_BASE_URL),
+  );
   const finalizeDispatchUrl = normalizeUrl(
     readEnvString(env.OP_FINALIZE_DISPATCH_URL),
   );
@@ -334,7 +335,9 @@ function normalizeRuntimeState(input: unknown): GeneratorRuntimeState | null {
   };
 }
 
-function normalizeRuntimeKvState(input: unknown): GeneratorRuntimeKvState | null {
+function normalizeRuntimeKvState(
+  input: unknown,
+): GeneratorRuntimeKvState | null {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return null;
   }

--- a/apps/web/src/lib/generator-runtime.ts
+++ b/apps/web/src/lib/generator-runtime.ts
@@ -6,12 +6,18 @@ const DEFAULT_STATE_MAX_AGE_MS = 15 * 60 * 1000;
 const RUNTIME_STATE_VERSION = 1;
 
 type EnvSource = Readonly<Record<string, string | undefined>>;
+type RuntimeEnvValue = string | GeneratorRuntimeKvNamespace | undefined;
+type RuntimeEnvSource = Readonly<Record<string, RuntimeEnvValue>>;
+
+export const GENERATOR_RUNTIME_KV_BINDING = "OP_GENERATOR_RUNTIME_KV";
+export const GENERATOR_RUNTIME_KV_KEY = "generator-runtime/current";
 
 export type GeneratorRuntimeSource =
   | "fallback"
   | "legacy_env"
   | "override"
-  | "runtime_state";
+  | "runtime_state"
+  | "worker_kv";
 
 export type GeneratorRuntimeMode = "named" | "quick";
 
@@ -21,6 +27,26 @@ export type GeneratorRuntimeState = {
   readonly updatedAt: string;
   readonly url: string;
   readonly version: number;
+};
+
+export type GeneratorRuntimeKvState = {
+  readonly mode: GeneratorRuntimeMode;
+  readonly updatedAt: string;
+  readonly url: string;
+  readonly version: number;
+};
+
+export type GeneratorRuntimeKvNamespace = {
+  get(
+    key: string,
+    type: "json",
+  ): Promise<Record<string, unknown> | null>;
+};
+
+export type GeneratorRuntimeCloudflareEnv = RuntimeEnvSource & {
+  readonly [GENERATOR_RUNTIME_KV_BINDING]?:
+    | GeneratorRuntimeKvNamespace
+    | undefined;
 };
 
 export type GeneratorRuntimeResolution =
@@ -142,6 +168,10 @@ type ReadGeneratorRuntimeStateDeps = {
   readonly stateMaxAgeMs?: number;
 };
 
+type ResolveCloudflareGeneratorRuntimeDeps = {
+  readonly env: GeneratorRuntimeCloudflareEnv;
+};
+
 export function readGeneratorRuntimeState(
   deps: ReadGeneratorRuntimeStateDeps = {},
 ): GeneratorRuntimeState | null {
@@ -185,9 +215,53 @@ export function readGeneratorRuntimeState(
   }
 }
 
-function resolveLegacyRuntimeUrl(env: EnvSource): LegacyRuntimeResolution {
-  const generatorBaseUrl = normalizeUrl(env.OP_GENERATOR_BASE_URL);
-  const finalizeDispatchUrl = normalizeUrl(env.OP_FINALIZE_DISPATCH_URL);
+export async function resolveCloudflareGeneratorRuntime({
+  env,
+}: ResolveCloudflareGeneratorRuntimeDeps): Promise<GeneratorRuntimeResolution> {
+  const overrideUrl = normalizeUrl(
+    readEnvString(env.OP_GENERATOR_RUNTIME_URL_OVERRIDE),
+  );
+  if (overrideUrl !== null) {
+    return {
+      source: "override",
+      status: "ok",
+      url: overrideUrl,
+    };
+  }
+
+  const kvRuntime = await readGeneratorRuntimeKvState(env);
+  if (kvRuntime !== null) {
+    return {
+      source: "worker_kv",
+      status: "ok",
+      url: kvRuntime.url,
+    };
+  }
+
+  const legacyUrl = resolveLegacyRuntimeUrl(env);
+  if (legacyUrl.status === "misconfigured") {
+    return legacyUrl;
+  }
+  if (legacyUrl.url !== null) {
+    return {
+      source: "legacy_env",
+      status: "ok",
+      url: legacyUrl.url,
+    };
+  }
+
+  return {
+    source: "fallback",
+    status: "ok",
+    url: DEFAULT_FALLBACK_URL,
+  };
+}
+
+function resolveLegacyRuntimeUrl(env: RuntimeEnvSource): LegacyRuntimeResolution {
+  const generatorBaseUrl = normalizeUrl(readEnvString(env.OP_GENERATOR_BASE_URL));
+  const finalizeDispatchUrl = normalizeUrl(
+    readEnvString(env.OP_FINALIZE_DISPATCH_URL),
+  );
 
   if (
     generatorBaseUrl !== null &&
@@ -207,6 +281,22 @@ function resolveLegacyRuntimeUrl(env: EnvSource): LegacyRuntimeResolution {
     status: "ok",
     url: generatorBaseUrl ?? finalizeDispatchUrl,
   };
+}
+
+async function readGeneratorRuntimeKvState(
+  env: GeneratorRuntimeCloudflareEnv,
+): Promise<GeneratorRuntimeKvState | null> {
+  const kv = env[GENERATOR_RUNTIME_KV_BINDING];
+  if (!kv) {
+    return null;
+  }
+
+  try {
+    const parsed = await kv.get(GENERATOR_RUNTIME_KV_KEY, "json");
+    return normalizeRuntimeKvState(parsed);
+  } catch {
+    return null;
+  }
 }
 
 function normalizeRuntimeState(input: unknown): GeneratorRuntimeState | null {
@@ -244,6 +334,36 @@ function normalizeRuntimeState(input: unknown): GeneratorRuntimeState | null {
   };
 }
 
+function normalizeRuntimeKvState(input: unknown): GeneratorRuntimeKvState | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+
+  const record = input as Record<string, unknown>;
+  const mode = record.mode;
+  const updatedAt = record.updatedAt;
+  const url = normalizeUrl(
+    typeof record.url === "string" ? record.url : undefined,
+  );
+  const version = record.version;
+
+  if (
+    version !== RUNTIME_STATE_VERSION ||
+    (mode !== "named" && mode !== "quick") ||
+    typeof updatedAt !== "string" ||
+    url === null
+  ) {
+    return null;
+  }
+
+  return {
+    mode,
+    updatedAt,
+    url,
+    version,
+  };
+}
+
 function normalizeUrl(value: string | undefined): string | null {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (normalized.length === 0) {
@@ -259,6 +379,10 @@ function normalizeUrl(value: string | undefined): string | null {
   } catch {
     return null;
   }
+}
+
+function readEnvString(value: RuntimeEnvValue): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function normalizeStatePath(

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -7,8 +7,8 @@
   "kv_namespaces": [
     {
       "binding": "OP_GENERATOR_RUNTIME_KV",
-      "id": "00000000000000000000000000000000",
-      "preview_id": "11111111111111111111111111111111"
+      "id": "9265a79b1e984244a9ee6afbf1d7bd59",
+      "preview_id": "3a9c9cde41ea4df588c6e1f0a3fca43f"
     }
   ],
   "vars": {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -4,6 +4,13 @@
   "main": "src/worker.ts",
   "compatibility_date": "2024-12-30",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "kv_namespaces": [
+    {
+      "binding": "OP_GENERATOR_RUNTIME_KV",
+      "id": "00000000000000000000000000000000",
+      "preview_id": "11111111111111111111111111111111"
+    }
+  ],
   "vars": {
     "NEXT_PUBLIC_SUI_NETWORK": "testnet",
     "NEXT_PUBLIC_PACKAGE_ID": "0x3c1a92273f2ad9369f9fa18167b06f6023b2982340c768886c5f85ba4ab8f7a3",

--- a/docs/finalize-generator-runbook.md
+++ b/docs/finalize-generator-runbook.md
@@ -4,7 +4,7 @@
 
 この runbook は、`manji` PC 上で finalize generator スタックを運用するための手順です。
 `generator:tunnel` で local generator と Cloudflare Tunnel を 1 コマンドで起動し、`/health` の local / external 確認まで自動で行います。
-起動した URL は `apps/web/.cache/generator-runtime.json` に保存し、`/admin`、`/api/finalize`、`generator:smoke`、preview Worker が同じ値を見ます。
+起動した URL は `apps/web/.cache/generator-runtime.json` に保存しつつ、Quick Tunnel のときは Cloudflare KV にも登録します。`/api/finalize`、`/api/admin/*`、admin health、`generator:smoke` は共有先として Cloudflare KV を優先し、同一マシン上の補助 fallback として local runtime state を残します。
 Cloudflare Workers 側の `/api/finalize` の proof は別 runbook (`docs/demo-smoke.md`) で扱います。
 
 `/admin` があっても、ここでの役割は health / dispatch の observability に限ります。
@@ -14,8 +14,8 @@ Cloudflare Workers 側の `/api/finalize` の proof は別 runbook (`docs/demo-s
 
 | 場所 | 役割 |
 | :--- | :--- |
-| Cloudflare Worker | `UnitFilledEvent` を受けた `/api/finalize` から runtime resolver 経由で external generator を呼ぶ |
-| `manji` PC 上の `generator:tunnel` | local generator を起動し、Cloudflare Tunnel を張り、local / external health を自動確認する |
+| Cloudflare Worker | `UnitFilledEvent` を受けた `/api/finalize` から Worker KV 優先の runtime resolver 経由で external generator を呼ぶ |
+| `manji` PC 上の `generator:tunnel` | local generator を起動し、Cloudflare Tunnel を張り、Quick Tunnel のときは current URL を Worker KV に登録する |
 | Cloudflare Tunnel | `http://localhost:<port>` を外部公開する |
 
 ## 起動に必要な値
@@ -94,6 +94,7 @@ corepack pnpm --filter web run generator:tunnel
 - 外部 URL の自動検出または named tunnel URL の確定
 - `https://<hostname>/health` または `https://<random>.trycloudflare.com/health` の自動確認
 - `apps/web/.cache/generator-runtime.json` の更新
+- Quick Tunnel URL の Cloudflare KV 登録
 
 local / external の `/health` は、どちらも 200 になるまで自動で再試行します。
 ready になると `[generator-stack][ready]` が出ます。
@@ -153,12 +154,12 @@ finalize 本体は実行しません。
 | `/dispatch` が `401` を返す | Worker と generator の `OP_FINALIZE_DISPATCH_SECRET` |
 | `/dispatch-auth-probe` が `401` を返す | web / Worker と generator の `OP_FINALIZE_DISPATCH_SECRET` |
 | `/dispatch` が `500` を返す | generator 側の `ADMIN_CAP_ID`、`ADMIN_SUI_PRIVATE_KEY`、`PACKAGE_ID`、`SUI_NETWORK` |
-| Worker から finalize が進まない | `apps/web/.cache/generator-runtime.json`、`OP_GENERATOR_RUNTIME_URL_OVERRIDE`、legacy URL 設定、generator ログ |
+| Worker から finalize が進まない | Cloudflare KV の current URL、`OP_GENERATOR_RUNTIME_URL_OVERRIDE`、legacy URL 設定、generator ログ |
 
 ## デモ当日の最低チェック
 
 1. `generator:tunnel` が起動済みで、local / external health が `ok`
-2. `/admin` の current URL と source が想定どおり
+2. `/admin` の current URL と source が想定どおりで、Quick Tunnel 時は `worker_kv` を見ている
 3. Worker と generator の `OP_FINALIZE_DISPATCH_SECRET` が一致
 4. 必要なら `generator:smoke` を already-running stack で 1 回通す
 5. `/api/finalize` の proof は `docs/demo-smoke.md` で別途確認する

--- a/docs/finalize-generator-runbook.md
+++ b/docs/finalize-generator-runbook.md
@@ -3,7 +3,7 @@
 ## 目的
 
 この runbook は、`manji` PC 上で finalize generator スタックを運用するための手順です。
-`generator:tunnel` で local generator と Cloudflare Tunnel を 1 コマンドで起動し、`/health` の local / external 確認まで自動で行います。
+`generator:tunnel` で generator コンテナと Cloudflare Tunnel を 1 コマンドで起動し、`/health` の local / external 確認まで自動で行います。
 起動した URL は `apps/web/.cache/generator-runtime.json` に保存しつつ、Quick Tunnel のときは Cloudflare KV にも登録します。`/api/finalize`、`/api/admin/*`、admin health、`generator:smoke` は共有先として Cloudflare KV を優先し、同一マシン上の補助 fallback として local runtime state を残します。
 Cloudflare Workers 側の `/api/finalize` の proof は別 runbook (`docs/demo-smoke.md`) で扱います。
 
@@ -15,7 +15,7 @@ Cloudflare Workers 側の `/api/finalize` の proof は別 runbook (`docs/demo-s
 | 場所 | 役割 |
 | :--- | :--- |
 | Cloudflare Worker | `UnitFilledEvent` を受けた `/api/finalize` から Worker KV 優先の runtime resolver 経由で external generator を呼ぶ |
-| `manji` PC 上の `generator:tunnel` | local generator を起動し、Cloudflare Tunnel を張り、Quick Tunnel のときは current URL を Worker KV に登録する |
+| `manji` PC 上の `generator:tunnel` | generator コンテナを build/run し、Cloudflare Tunnel を張り、Quick Tunnel のときは current URL を Worker KV に登録する |
 | Cloudflare Tunnel | `http://localhost:<port>` を外部公開する |
 
 ## 起動に必要な値


### PR DESCRIPTION
## 概要
Quick Tunnel の URL を Worker KV で共有し、finalize/admin/smoke と local generator 起動を同じ運用にそろえます。

## 変更内容
- `apps/web/src/lib/generator-runtime.ts` など
  - Worker 側の URL 解決順を `override -> Worker KV -> legacy env -> local fallback` に統一
  - `/api/finalize` と `/api/admin/*` が request-scoped Cloudflare env から resolver と secret を読むように修正
- `apps/web/scripts/generator-runtime-remote.mjs` など
  - `generator:tunnel` と `generator:smoke` から Wrangler remote KV を読み書き
  - stale payload を無視し、delete/write 失敗時は ready 前に停止
  - production namespace を使うため `--preview false` を明示
- `apps/web/scripts/run-local-generator.mjs` と `docs/finalize-generator-runbook.md`
  - generator を Docker コンテナで起動するように変更
  - Quick Tunnel / smoke / runbook を新運用に合わせて更新
- `apps/web/wrangler.jsonc`
  - `OP_GENERATOR_RUNTIME_KV` binding に実 namespace id / preview_id を設定

## 関連する Issue やチケット
Close #67

## 動作確認
- `corepack pnpm run check`
- `NEXT_PUBLIC_SUI_NETWORK=testnet NEXT_PUBLIC_REGISTRY_OBJECT_ID=0x08ba74331f2e7574956c9fdfe3472cdc269513325258452f962e0a36a5d6bcb6 corepack pnpm --filter web run build`
- `NEXT_PUBLIC_SUI_NETWORK=testnet NEXT_PUBLIC_REGISTRY_OBJECT_ID=0x08ba74331f2e7574956c9fdfe3472cdc269513325258452f962e0a36a5d6bcb6 corepack pnpm --filter web run test:bundle-size`
- verification reviewer: No findings
- Cloudflare remote KV smoke
  - `wrangler kv key put generator-runtime/current ... --binding OP_GENERATOR_RUNTIME_KV --preview false --remote`
  - `wrangler kv key get generator-runtime/current --binding OP_GENERATOR_RUNTIME_KV --preview false --remote --text`
  - `wrangler kv key delete generator-runtime/current --binding OP_GENERATOR_RUNTIME_KV --preview false --remote`
