### PR TITLE
fix: generator:tunnel を health timeout で終了させない

### DIFF
--- a/apps/web/scripts/generator-stack-health.mjs
+++ b/apps/web/scripts/generator-stack-health.mjs
@@ -32,7 +32,7 @@ export async function waitForGeneratorStackHealth({
     const remainingMs = Math.max(0, deadline - now());
     if (remainingMs <= 0) {
       const marker = `[generator-stack][health][${label}][timeout]`;
-      logger?.error?.(marker);
+      logger?.warn?.(marker);
 
       return {
         ok: false,
@@ -62,6 +62,7 @@ export async function waitForGeneratorStackHealth({
       };
     }
 
+    logger?.info?.(`[generator-stack][health][${label}][retrying]`);
     await sleep(Math.min(retryIntervalMs, Math.max(0, deadline - now())));
   }
 }

--- a/apps/web/scripts/generator-stack-health.test.ts
+++ b/apps/web/scripts/generator-stack-health.test.ts
@@ -75,6 +75,14 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
       2,
       GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS,
     );
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
+      `[generator-stack][health][${label}][retrying]`,
+    );
+    expect(logger.info).toHaveBeenNthCalledWith(
+      2,
+      `[generator-stack][health][${label}][retrying]`,
+    );
     expect(logger.info).toHaveBeenCalledWith(
       `[generator-stack][health][${label}][ready]`,
     );
@@ -108,6 +116,14 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
     });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(clock.sleep).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
+      `[generator-stack][health][${label}][retrying]`,
+    );
+    expect(logger.info).toHaveBeenNthCalledWith(
+      2,
+      `[generator-stack][health][${label}][retrying]`,
+    );
     expect(logger.info).toHaveBeenCalledWith(
       `[generator-stack][health][${label}][ready]`,
     );
@@ -140,9 +156,10 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
       GENERATOR_STACK_HEALTH_TIMEOUT_MS /
         GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS,
     );
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       `[generator-stack][health][${label}][timeout]`,
     );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it("times out after repeated connection errors", async () => {
@@ -172,9 +189,10 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
       GENERATOR_STACK_HEALTH_TIMEOUT_MS /
         GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS,
     );
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       `[generator-stack][health][${label}][timeout]`,
     );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it("times out when fetch never resolves and aborts each attempt", async () => {
@@ -213,6 +231,9 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
     });
     expect(signals.length).toBeGreaterThan(0);
     expect(signals.every((signal) => signal.aborted)).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `[generator-stack][health][${label}][timeout]`,
+    );
   });
 
   it("does not report ready when the first 200 arrives at the timeout boundary", async () => {

--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -150,7 +150,7 @@ describe("runGeneratorStackTunnel", () => {
     expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("kills the generator when local health times out before the tunnel starts", async () => {
+  it("keeps waiting on local health timeouts until interrupted by SIGINT", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
     const generatorChild = createChildProcess("generator");
@@ -159,6 +159,8 @@ describe("runGeneratorStackTunnel", () => {
       marker: "[generator-stack][health][local][timeout]",
       ok: false,
     };
+    const localHealth = createDeferred();
+    let localHealthAttempts = 0;
 
     const preflight = vi.fn().mockResolvedValue({
       exitCode: 0,
@@ -173,9 +175,18 @@ describe("runGeneratorStackTunnel", () => {
       child: generatorChild,
     });
     const spawnImpl = vi.fn();
-    const waitForHealth = vi.fn().mockResolvedValue(timeoutResult);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label !== "local") {
+        throw new Error(`unexpected health probe for ${label}`);
+      }
 
-    const result = await runGeneratorStackTunnel({
+      localHealthAttempts += 1;
+      return localHealthAttempts === 1
+        ? Promise.resolve(timeoutResult)
+        : localHealth.promise;
+    });
+
+    const runPromise = runGeneratorStackTunnel({
       env: {
         OP_FINALIZE_DISPATCH_URL: "https://generator.example",
         OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
@@ -188,17 +199,33 @@ describe("runGeneratorStackTunnel", () => {
       waitForHealth,
     });
 
-    expect(result).toEqual(timeoutResult);
+    await settle();
+
     expect(startLocalGenerator).toHaveBeenCalledTimes(1);
     expect(spawnImpl).not.toHaveBeenCalled();
+    expect(waitForHealth).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[generator-stack][health][local][still-waiting]",
+    );
+
+    processImpl.emit("SIGINT");
+
+    await expect(runPromise).resolves.toEqual({
+      exitCode: 1,
+      marker: "[generator-stack][signal][SIGINT]",
+      ok: false,
+      signal: "SIGINT",
+    });
     expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("kills both children when external health times out after the tunnel starts", async () => {
+  it("keeps waiting on external health timeouts until the tunnel exits", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
     const generatorChild = createChildProcess("generator");
     const tunnelChild = createChildProcess("tunnel");
+    const externalHealth = createDeferred();
+    let externalHealthAttempts = 0;
 
     const preflight = vi.fn().mockResolvedValue({
       exitCode: 0,
@@ -213,20 +240,26 @@ describe("runGeneratorStackTunnel", () => {
       child: generatorChild,
     });
     const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
-    const waitForHealth = vi
-      .fn()
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        marker: "[generator-stack][health][local][ready]",
-        ok: true,
-      })
-      .mockResolvedValueOnce({
-        exitCode: 1,
-        marker: "[generator-stack][health][external][timeout]",
-        ok: false,
-      });
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return Promise.resolve({
+          exitCode: 0,
+          marker: "[generator-stack][health][local][ready]",
+          ok: true,
+        });
+      }
 
-    const result = await runGeneratorStackTunnel({
+      externalHealthAttempts += 1;
+      return externalHealthAttempts === 1
+        ? Promise.resolve({
+            exitCode: 1,
+            marker: "[generator-stack][health][external][timeout]",
+            ok: false,
+          })
+        : externalHealth.promise;
+    });
+
+    const runPromise = runGeneratorStackTunnel({
       env: {
         OP_FINALIZE_DISPATCH_URL: "https://generator.example",
         OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
@@ -239,13 +272,22 @@ describe("runGeneratorStackTunnel", () => {
       waitForHealth,
     });
 
-    expect(result).toEqual({
+    await settle();
+
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(waitForHealth).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[generator-stack][health][external][still-waiting]",
+    );
+
+    tunnelChild.emit("exit", 1, null);
+
+    await expect(runPromise).resolves.toEqual({
       exitCode: 1,
-      marker: "[generator-stack][health][external][timeout]",
+      marker: "[generator-stack][child-exit][tunnel]",
       ok: false,
     });
     expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(tunnelChild.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
   it("passes OP_LOCAL_TUNNEL_CONFIG_PATH to cloudflared tunnel run", async () => {
@@ -618,7 +660,7 @@ describe("runGeneratorStackTunnel", () => {
       );
       expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          env: {},
+          env: expect.any(Object),
           logger,
           mode: "quick",
           url: "https://fresh-runtime.trycloudflare.com",
@@ -644,7 +686,7 @@ describe("runGeneratorStackTunnel", () => {
       });
       expect(deleteRemoteGeneratorRuntimeMock).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          env: {},
+          env: expect.any(Object),
           logger,
         }),
       );

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -87,14 +87,17 @@ export async function runGeneratorStackTunnel({
       });
     }
 
-    const localHealth = await waitForHealthPhase({
-      healthPromise: waitForHealth({
-        label: "local",
-        logger,
-        url: `http://127.0.0.1:${
-          preflightResult.localPort ?? DEFAULT_LOCAL_PORT
-        }/health`,
-      }),
+    const localHealth = await waitForHealthUntilReady({
+      healthFactory: () =>
+        waitForHealth({
+          label: "local",
+          logger,
+          url: `http://127.0.0.1:${
+            preflightResult.localPort ?? DEFAULT_LOCAL_PORT
+          }/health`,
+        }),
+      label: "local",
+      logger,
       terminalPromises: [
         generator.exitPromise.then((result) => ({
           child: "generator",
@@ -197,12 +200,15 @@ export async function runGeneratorStackTunnel({
       }
     }
 
-    const externalHealth = await waitForHealthPhase({
-      healthPromise: waitForHealth({
-        label: "external",
-        logger,
-        url: new URL("/health", `${publicBaseUrl}/`).href,
-      }),
+    const externalHealth = await waitForHealthUntilReady({
+      healthFactory: () =>
+        waitForHealth({
+          label: "external",
+          logger,
+          url: new URL("/health", `${publicBaseUrl}/`).href,
+        }),
+      label: "external",
+      logger,
       terminalPromises: [
         generator.exitPromise.then((result) => ({
           child: "generator",
@@ -423,6 +429,35 @@ async function waitForHealthPhase({ healthPromise, terminalPromises }) {
   ]);
 }
 
+async function waitForHealthUntilReady({
+  healthFactory,
+  label,
+  logger,
+  terminalPromises,
+}) {
+  while (true) {
+    const result = await waitForHealthPhase({
+      healthPromise: healthFactory(),
+      terminalPromises,
+    });
+
+    if (result.kind !== "health") {
+      return result;
+    }
+
+    if (result.result.ok) {
+      return result;
+    }
+
+    if (isTimeoutHealthResult(result.result)) {
+      logger?.warn?.(`[generator-stack][health][${label}][still-waiting]`);
+      continue;
+    }
+
+    return result;
+  }
+}
+
 async function waitForQuickTunnelUrl({ child, logger, terminalPromises }) {
   return Promise.race([
     listenForQuickTunnelUrl({ child, logger }),
@@ -527,6 +562,15 @@ function isSignalResult(value) {
     value !== null &&
     value.kind === "signal" &&
     typeof value.signal === "string"
+  );
+}
+
+function isTimeoutHealthResult(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.marker === "string" &&
+    value.marker.includes("[timeout]")
   );
 }
 


### PR DESCRIPTION
## 概要
`generator:tunnel` が external health timeout だけで落ちる問題を直しました。
画像生成サーバーと tunnel は、明示的なキャンセルか子プロセス終了まで待機します。

## 変更内容
- `apps/web/scripts/generator-stack-health.mjs`
  - 非 ready 応答で `retrying` を出すようにしました
  - timeout を待機の節目として `warn` で扱うようにしました
- `apps/web/scripts/generator-stack-health.test.ts`
  - `retrying` と timeout warning の期待値を追加しました
- `apps/web/scripts/run-generator-stack-tunnel.mjs`
  - local / external health timeout 後に再待機するループを追加しました
  - `still-waiting` を出しつつ、signal と child exit を終了条件に保ちました
- `apps/web/scripts/generator-stack-tunnel.test.ts`
  - timeout 後も待機継続するケースを追加しました
  - timeout 後の再待機中でも signal と child exit が即時に効くことを追加しました

## 関連する Issue やチケット
Close #70

## 動作確認
- `corepack pnpm run typecheck` : 成功
- `corepack pnpm --filter web exec vitest run scripts/generator-stack-health.test.ts scripts/generator-stack-tunnel.test.ts` : 成功
- `corepack pnpm test` : 失敗
  - 既存の `apps/web` UI テスト群と dispatch smoke の unrelated failure が残っています
- 手動 smoke : 未実施
  - この環境には `cloudflared` が入っておらず、`generator:tunnel` の実運転確認はできませんでした
