### PR TITLE
fix: finalize 実行時の generator 互換性を修正

### DIFF
--- a/generator/src/mosaic.ts
+++ b/generator/src/mosaic.ts
@@ -323,9 +323,7 @@ function deriveFinalizeGridFromSubmissionCount(count: number): MosaicGrid {
 
     if (
       score < bestScore ||
-      (score === bestScore &&
-        bestGrid !== null &&
-        rows > bestGrid.rows)
+      (score === bestScore && bestGrid !== null && rows > bestGrid.rows)
     ) {
       bestGrid = { cols, rows };
       bestScore = score;

--- a/generator/src/mosaic.ts
+++ b/generator/src/mosaic.ts
@@ -262,7 +262,9 @@ export async function generateFinalizeMosaic(
       id: submission.walrusBlobId,
       image: Buffer.from(submission.imageBytes),
     })),
-    grid: input.grid ?? defaultGrid,
+    grid:
+      input.grid ??
+      deriveFinalizeGridFromSubmissionCount(input.submissions.length),
     tileSize: input.tileSize ?? defaultTileSize,
     colorMix: input.colorMix,
     overlayOpacity: input.overlayOpacity,
@@ -295,6 +297,48 @@ export async function generateFinalizeMosaic(
   };
 }
 
+function deriveFinalizeGridFromSubmissionCount(count: number): MosaicGrid {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(
+      `Submission count must be a positive integer (got ${count}).`,
+    );
+  }
+
+  const defaultCount = defaultGrid.cols * defaultGrid.rows;
+  if (count === defaultCount) {
+    return defaultGrid;
+  }
+
+  const targetAspectRatio = defaultGrid.cols / defaultGrid.rows;
+  let bestGrid: MosaicGrid | null = null;
+  let bestScore = Number.POSITIVE_INFINITY;
+
+  for (let cols = 1; cols <= Math.sqrt(count); cols += 1) {
+    if (count % cols !== 0) {
+      continue;
+    }
+
+    const rows = count / cols;
+    const score = Math.abs(cols / rows - targetAspectRatio);
+
+    if (
+      score < bestScore ||
+      (score === bestScore &&
+        bestGrid !== null &&
+        rows > bestGrid.rows)
+    ) {
+      bestGrid = { cols, rows };
+      bestScore = score;
+    }
+  }
+
+  if (bestGrid !== null) {
+    return bestGrid;
+  }
+
+  throw new Error(`Could not derive a mosaic grid for ${count} submissions.`);
+}
+
 async function buildTargetCells(
   targetImage: Buffer,
   grid: MosaicGrid,
@@ -309,6 +353,7 @@ async function buildTargetCells(
   const raw = await sharp(targetImage)
     .rotate()
     .resize(grid.cols, grid.rows, { fit: "cover" })
+    .ensureAlpha()
     .raw()
     .toBuffer();
 

--- a/generator/src/sui.ts
+++ b/generator/src/sui.ts
@@ -479,29 +479,49 @@ function readSubmissions(value: unknown): readonly GeneratorSubmissionRef[] {
   }
 
   return value.map((entry, index) => {
-    if (typeof entry !== "object" || entry === null) {
+    const record = unwrapSubmissionRecord(entry);
+
+    if (record === null) {
       throw new Error(`submissions[${index}] is not an object`);
     }
 
     return {
       submissionNo: readIntegerField(
-        (entry as Record<string, unknown>).submission_no,
+        record.submission_no,
         `submissions[${index}].submission_no`,
       ),
       submitter: readAddressField(
-        (entry as Record<string, unknown>).submitter,
+        record.submitter,
         `submissions[${index}].submitter`,
       ),
       submittedAtMs: readIntegerField(
-        (entry as Record<string, unknown>).submitted_at_ms,
+        record.submitted_at_ms,
         `submissions[${index}].submitted_at_ms`,
       ),
       walrusBlobId: readVectorU8AsString(
-        (entry as Record<string, unknown>).walrus_blob_id,
+        record.walrus_blob_id,
         `submissions[${index}].walrus_blob_id`,
       ),
     };
   });
+}
+
+function unwrapSubmissionRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  if ("fields" in value) {
+    const fields = (value as { fields?: unknown }).fields;
+
+    if (typeof fields === "object" && fields !== null) {
+      return fields as Record<string, unknown>;
+    }
+  }
+
+  return value as Record<string, unknown>;
 }
 
 async function readUnitSnapshot(

--- a/generator/src/walrus-write.ts
+++ b/generator/src/walrus-write.ts
@@ -1,4 +1,4 @@
-const MOSAIC_WALRUS_EPOCHS = 100;
+const DEFAULT_MOSAIC_WALRUS_EPOCHS = 50;
 
 export class WalrusWriteError extends Error {
   readonly status: number | null;
@@ -26,6 +26,7 @@ export type WalrusWriteClient = {
 export function createWalrusWriteClient(options: {
   readonly publisherBaseUrl: string;
   readonly aggregatorBaseUrl: string;
+  readonly epochs?: number;
   readonly fetchFn?: typeof fetch;
 }): WalrusWriteClient {
   return {
@@ -33,8 +34,9 @@ export function createWalrusWriteClient(options: {
       const fetchFn = options.fetchFn ?? fetch;
       const publisherBaseUrl = trimTrailingSlashes(options.publisherBaseUrl);
       const aggregatorBaseUrl = trimTrailingSlashes(options.aggregatorBaseUrl);
+      const epochs = options.epochs ?? DEFAULT_MOSAIC_WALRUS_EPOCHS;
       const response = await fetchFn(
-        `${publisherBaseUrl}/v1/blobs?epochs=${MOSAIC_WALRUS_EPOCHS}`,
+        `${publisherBaseUrl}/v1/blobs?epochs=${epochs}`,
         {
           method: "PUT",
           body: bytes,

--- a/generator/test/mosaic.test.ts
+++ b/generator/test/mosaic.test.ts
@@ -133,7 +133,9 @@ describe("generateMosaic", () => {
     expect(result.width).toBe(10);
     expect(result.height).toBe(20);
     expect(result.placements).toHaveLength(2);
-    expect(result.placements.map((placement) => [placement.x, placement.y])).toEqual([
+    expect(
+      result.placements.map((placement) => [placement.x, placement.y]),
+    ).toEqual([
       [0, 0],
       [0, 1],
     ]);

--- a/generator/test/mosaic.test.ts
+++ b/generator/test/mosaic.test.ts
@@ -95,6 +95,49 @@ describe("generateMosaic", () => {
       y: 1,
     });
   });
+
+  it("derives an exact fallback grid from submission count when none is provided", async () => {
+    const submissions = [
+      await buildSubmission("tile-a", 1, "0x1", { r: 20, g: 20, b: 20 }),
+      await buildSubmission("tile-b", 2, "0x2", { r: 220, g: 220, b: 220 }),
+    ];
+    const targetImage = await sharp({
+      create: {
+        width: 1,
+        height: 2,
+        channels: 3,
+        background: { r: 0, g: 0, b: 0 },
+      },
+    })
+      .composite([
+        {
+          input: await solidPng(1, 1, { r: 20, g: 20, b: 20 }),
+          left: 0,
+          top: 0,
+        },
+        {
+          input: await solidPng(1, 1, { r: 220, g: 220, b: 220 }),
+          left: 0,
+          top: 1,
+        },
+      ])
+      .png()
+      .toBuffer();
+
+    const result = await generateFinalizeMosaic({
+      targetImage,
+      submissions,
+      tileSize: 10,
+    });
+
+    expect(result.width).toBe(10);
+    expect(result.height).toBe(20);
+    expect(result.placements).toHaveLength(2);
+    expect(result.placements.map((placement) => [placement.x, placement.y])).toEqual([
+      [0, 0],
+      [0, 1],
+    ]);
+  });
 });
 
 async function buildTile(

--- a/generator/test/sui.test.ts
+++ b/generator/test/sui.test.ts
@@ -62,6 +62,40 @@ describe("createSeedingSnapshotLoader", () => {
       submitterAddresses: ["0xsubmitter-a", "0xsubmitter-b"],
     });
   });
+
+  it("accepts submission refs wrapped in nested move-object fields", async () => {
+    const client = {
+      getObject: vi.fn(async () => ({
+        data: unitData({
+          submissions: [
+            {
+              type: "0xpkg::unit::SubmissionRef",
+              fields: submission({
+                submitter: "0xwrapped-submitter",
+                submissionNo: 7,
+                submittedAtMs: 1_700_000_000_123,
+                walrusBlobId: "wrapped-blob",
+              }),
+            },
+          ],
+        }),
+      })),
+    } as unknown as GeneratorSuiReadClient;
+
+    const loader = createSeedingSnapshotLoader(client);
+    const snapshot = await loader(UNIT_ID);
+
+    expect(snapshot.submissions).toEqual([
+      parsedSubmission({
+        submitter: "0xwrapped-submitter",
+        submissionNo: 7,
+        submittedAtMs: 1_700_000_000_123,
+        walrusBlobId: "wrapped-blob",
+      }),
+    ]);
+    expect(snapshot.submittedCount).toBe(1);
+    expect(snapshot.submitterAddresses).toEqual(["0xwrapped-submitter"]);
+  });
 });
 
 describe("createUpsertAthleteMetadataTransactionExecutor", () => {

--- a/generator/test/walrus-write.test.ts
+++ b/generator/test/walrus-write.test.ts
@@ -27,7 +27,7 @@ describe("createWalrusWriteClient", () => {
       aggregatorUrl: "https://aggregator.example/v1/blobs/mosaic-blob-1",
     });
     expect(fetchFn).toHaveBeenCalledWith(
-      "https://publisher.example/v1/blobs?epochs=100",
+      "https://publisher.example/v1/blobs?epochs=50",
       expect.objectContaining({
         method: "PUT",
       }),


### PR DESCRIPTION
## 概要
finalize 実行時に generator が実運用データを正しく扱えるようにし、関連する回帰テストを追加します。

## 変更内容
- `generator/src/mosaic.ts`
  - finalize 用モザイク生成で grid 未指定時に submission 数から厳密なグリッドを導出するよう修正
  - ターゲット画像の raw 化前に `ensureAlpha()` を通して RGBA 前提の処理と整合させた
- `generator/src/sui.ts`
  - Sui の nested move-object fields に包まれた submission 参照も読み取れるようにした
- `generator/src/walrus-write.ts`
  - Walrus 書き込み epochs を上書き可能にし、既定値を runtime 互換の値へ調整した
- `generator/test/mosaic.test.ts`
  - submission 数から fallback grid を導出するケースを追加
- `generator/test/sui.test.ts`
  - nested fields 形式の submission 参照を受け入れるケースを追加
- `generator/test/walrus-write.test.ts`
  - 既定 epochs の期待値を更新

## 関連する Issue やチケット
なし

## 動作確認
- `pnpm --filter generator test`
