### PR TITLE
refactor: athlete_id を廃止して unitId ベースにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ apps/web/.cache
 **/e2e/artifacts
 **/test-results
 **/playwright-report
+**/.e2e-xdg
 
 # Devcontainer / agent runtime state
 .claude/

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ flowchart LR
         │  UnitFilled 検知 → POST /api/finalize
         ▼
 [ Sui Testnet  Move package: one_portrait ]
-        ├─ Registry (shared)        athlete_id -> current_unit_id
-        ├─ Unit (shared)            athlete_id / target blob / submitters / submissions / status / master_id?
+        ├─ Registry (shared)        unit_ids
+        ├─ Unit (shared)            display_name / target blob / submitters / submissions / status / master_id?
         ├─ MasterPortrait           placements: Table<blob_id, Placement>
         └─ Kakera (Soulbound)       blob_id / submission_no / unit_id
 

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -175,6 +175,7 @@ describe("AdminClient", () => {
       />,
     );
 
+    expect(screen.queryByLabelText(/athlete ID/)).toBeNull();
     fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
       target: { value: "target-blob-7" },
     });
@@ -183,8 +184,10 @@ describe("AdminClient", () => {
     await waitFor(() => {
       expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
     });
+    expect(screen.getByText(/ユニットID: 0xunit-created/)).toBeTruthy();
+    expect(screen.getByText(/ステータス: created/)).toBeTruthy();
+    expect(screen.queryByText(/athlete ID: 7/)).toBeNull();
     expect(createPayload).toEqual({
-      athleteId: 7,
       blobId: "target-blob-7",
       displayMaxSlots: unitTileCount,
       displayName: "Demo Athlete Seven",
@@ -269,7 +272,6 @@ describe("AdminClient", () => {
       expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
     });
     expect(createPayload).toEqual({
-      athleteId: 12,
       blobId: "target-blob-demo",
       displayMaxSlots: unitTileCount,
       displayName: "Demo Athlete Twelve",

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -42,9 +42,7 @@ describe("AdminClient", () => {
       <AdminClient
         initialAthletes={[
           {
-            athletePublicId: "1",
             currentUnit: {
-              athletePublicId: "1",
               displayMaxSlots: 2000,
               displayName: "Demo Athlete One",
               masterId: null,
@@ -161,7 +159,6 @@ describe("AdminClient", () => {
       <AdminClient
         initialAthletes={[
           {
-            athletePublicId: "7",
             currentUnit: null,
             displayName: "Demo Athlete Seven",
             entryId: "draft-7",
@@ -175,7 +172,7 @@ describe("AdminClient", () => {
       />,
     );
 
-    expect(screen.queryByLabelText(/athlete ID/)).toBeNull();
+    expect(screen.queryByLabelText(/unit ID/)).toBeNull();
     fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
       target: { value: "target-blob-7" },
     });
@@ -186,7 +183,7 @@ describe("AdminClient", () => {
     });
     expect(screen.getByText(/ユニットID: 0xunit-created/)).toBeTruthy();
     expect(screen.getByText(/ステータス: created/)).toBeTruthy();
-    expect(screen.queryByText(/athlete ID: 7/)).toBeNull();
+    expect(screen.queryByText(/unit ID: 7/)).toBeNull();
     expect(createPayload).toEqual({
       blobId: "target-blob-7",
       displayMaxSlots: unitTileCount,
@@ -245,7 +242,6 @@ describe("AdminClient", () => {
       <AdminClient
         initialAthletes={[
           {
-            athletePublicId: "12",
             currentUnit: null,
             displayName: "Demo Athlete Twelve",
             entryId: "draft-12",

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -28,9 +28,6 @@ export function AdminClient({
 }: AdminClientProps): React.ReactElement {
   const [athletes, setAthletes] = useState(initialAthletes);
   const [health, setHealth] = useState(initialHealth);
-  const [createAthleteId, setCreateAthleteId] = useState(
-    initialAthletes[0]?.athletePublicId ?? "",
-  );
   const [createDisplayName, setCreateDisplayName] = useState(
     initialAthletes[0]?.displayName ?? "",
   );
@@ -97,7 +94,6 @@ export function AdminClient({
       return;
     }
 
-    setCreateAthleteId(athlete.athletePublicId);
     setCreateDisplayName(athlete.displayName);
     setCreateThumbnailUrl(athlete.thumbnailUrl);
 
@@ -159,7 +155,6 @@ export function AdminClient({
 
     try {
       const payload = await postJson("/api/admin/create-unit", {
-        athleteId: Number(createAthleteId),
         blobId: targetBlobId,
         displayMaxSlots: effectiveDisplayMaxSlots,
         displayName: createDisplayName,
@@ -291,17 +286,6 @@ export function AdminClient({
         >
           <div className="grid gap-4 md:grid-cols-2">
             <label className="grid gap-2 text-sm text-stone-200">
-              athlete ID
-              <input
-                className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
-                inputMode="numeric"
-                onChange={(event) => setCreateAthleteId(event.target.value)}
-                placeholder="例: 7"
-                value={createAthleteId}
-              />
-            </label>
-
-            <label className="grid gap-2 text-sm text-stone-200">
               displayName
               <input
                 className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
@@ -420,7 +404,6 @@ export function AdminClient({
             disabled={
               isUploading ||
               pendingAction === "create" ||
-              createAthleteId.trim().length === 0 ||
               createDisplayName.trim().length === 0 ||
               createThumbnailUrl.trim().length === 0 ||
               targetBlobId.trim().length === 0 ||
@@ -592,14 +575,11 @@ async function postJson(
 
 function formatActionDetail(payload: Record<string, unknown>): string {
   const parts = [
+    typeof payload.unitId === "string" ? `ユニットID: ${payload.unitId}` : null,
     typeof payload.status === "string" ? `ステータス: ${payload.status}` : null,
     typeof payload.digest === "string"
       ? `ダイジェスト: ${payload.digest}`
       : null,
-    typeof payload.athleteId === "number"
-      ? `athlete ID: ${payload.athleteId}`
-      : null,
-    typeof payload.unitId === "string" ? `ユニットID: ${payload.unitId}` : null,
     typeof payload.mosaicBlobId === "string"
       ? `モザイク Blob ID: ${payload.mosaicBlobId}`
       : null,

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -88,7 +88,7 @@ export function AdminClient({
 
   function loadCreateDraft(entryKey: string): void {
     const athlete = athletes.find(
-      (entry) => (entry.entryId ?? entry.athletePublicId) === entryKey,
+      (entry) => (entry.entryId ?? entry.currentUnit?.unitId) === entryKey,
     );
     if (!athlete) {
       return;
@@ -270,10 +270,10 @@ export function AdminClient({
               <option value="">選択してください</option>
               {athletes.map((athlete) => (
                 <option
-                  key={athlete.entryId ?? athlete.athletePublicId}
-                  value={athlete.entryId ?? athlete.athletePublicId}
+                  key={athlete.entryId ?? athlete.currentUnit?.unitId}
+                  value={athlete.entryId ?? athlete.currentUnit?.unitId}
                 >
-                  #{athlete.athletePublicId} {athlete.displayName}
+                  {athlete.displayName}
                 </option>
               ))}
             </select>
@@ -433,7 +433,7 @@ export function AdminClient({
           {athletes.map((athlete) => (
             <AdminAthleteCard
               athlete={athlete}
-              key={athlete.entryId ?? athlete.athletePublicId}
+              key={athlete.entryId ?? athlete.currentUnit?.unitId}
               onFinalize={handleFinalize}
               pendingAction={pendingAction}
             />
@@ -513,7 +513,6 @@ function AdminAthleteCard({
       {currentUnit ? (
         <>
           <dl className="grid gap-2 text-sm text-stone-200">
-            <InfoRow label="athlete ID" value={athlete.athletePublicId} />
             <InfoRow label="ユニット ID" value={currentUnit.unitId} />
             <InfoRow
               label="表示進行"

--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -30,9 +30,7 @@ describe("AdminPage", () => {
   it("renders the admin console with the initial server data", async () => {
     loadAdminAthletesMock.mockResolvedValue([
       {
-        athletePublicId: "1",
         currentUnit: {
-          athletePublicId: "1",
           displayMaxSlots: 2000,
           displayName: "Demo Athlete One",
           masterId: null,

--- a/apps/web/src/app/api/admin/create-unit/route.test.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.test.ts
@@ -60,7 +60,6 @@ describe("POST /api/admin/create-unit", () => {
     const response = await POST(
       new Request("http://localhost/api/admin/create-unit", {
         body: JSON.stringify({
-          athleteId: 12,
           blobId: "target-blob-12",
           displayMaxSlots: 2000,
           displayName: "Demo Athlete Twelve",
@@ -106,7 +105,6 @@ describe("POST /api/admin/create-unit", () => {
     const response = await POST(
       new Request("http://localhost/api/admin/create-unit", {
         body: JSON.stringify({
-          athleteId: 12,
           blobId: "target-blob-12",
           displayMaxSlots: 2000,
           displayName: "Demo Athlete Twelve",
@@ -128,7 +126,6 @@ describe("POST /api/admin/create-unit", () => {
       "shared-secret",
     );
     await expect(request.json()).resolves.toEqual({
-      athleteId: 12,
       blobId: "target-blob-12",
       displayMaxSlots: 2000,
       displayName: "Demo Athlete Twelve",

--- a/apps/web/src/app/api/admin/create-unit/route.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.ts
@@ -19,7 +19,6 @@ export async function POST(request: Request): Promise<Response> {
     return await relayAdminPost(
       "/admin/create-unit",
       {
-        athleteId: input.athleteId,
         displayMaxSlots: input.displayMaxSlots,
         displayName: input.displayName,
         blobId: input.blobId,

--- a/apps/web/src/app/api/admin/status/route.test.ts
+++ b/apps/web/src/app/api/admin/status/route.test.ts
@@ -14,9 +14,7 @@ describe("GET /api/admin/status", () => {
   it("returns the on-chain admin athlete entries", async () => {
     loadAdminAthletesMock.mockResolvedValue([
       {
-        athletePublicId: "1",
         currentUnit: {
-          athletePublicId: "1",
           masterId: null,
           maxSlots: 2000,
           status: "filled",
@@ -31,7 +29,6 @@ describe("GET /api/admin/status", () => {
         thumbnailUrl: "https://example.com/1.png",
       },
       {
-        athletePublicId: "2",
         currentUnit: null,
         displayName: "Athlete #2",
         lookupState: "missing",
@@ -47,9 +44,7 @@ describe("GET /api/admin/status", () => {
     await expect(response.json()).resolves.toEqual({
       athletes: [
         {
-          athletePublicId: "1",
           currentUnit: {
-            athletePublicId: "1",
             masterId: null,
             maxSlots: 2000,
             status: "filled",
@@ -64,7 +59,6 @@ describe("GET /api/admin/status", () => {
           thumbnailUrl: "https://example.com/1.png",
         },
         {
-          athletePublicId: "2",
           currentUnit: null,
           displayName: "Athlete #2",
           lookupState: "missing",

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -56,7 +56,7 @@ import { GalleryClient } from "./gallery-client";
 
 const CATALOG = [
   {
-    athletePublicId: "1",
+    unitId: "0xunit-1",
     slug: "demo-athlete-one",
     displayName: "Demo Athlete One",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
@@ -66,7 +66,6 @@ const CATALOG = [
 function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
   return {
     objectId: "0xkakera-1",
-    athletePublicId: "1",
     unitId: "0xunit-1",
     walrusBlobId: "walrus-original-1",
     submissionNo: 17,
@@ -82,7 +81,7 @@ function pendingEntry(
 ): Extract<GalleryEntryView, { status: { kind: "pending" } }> {
   return {
     unitId: "0xunit-1",
-    athletePublicId: "1",
+    displayName: "Demo Athlete One",
     walrusBlobId: "walrus-original-1",
     submissionNo: 17,
     mintedAtMs: 1700000000000,
@@ -101,7 +100,7 @@ function completedEntry(
 ): Extract<GalleryEntryView, { status: { kind: "completed" } }> {
   return {
     unitId: "0xunit-1",
-    athletePublicId: "1",
+    displayName: "Demo Athlete One",
     walrusBlobId: "walrus-original-1",
     submissionNo: 17,
     mintedAtMs: 1700000000000,

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -27,7 +27,7 @@ type GalleryRenderableEntry = GalleryEntryView | GalleryUnavailableEntry;
 
 type GalleryUnavailableEntry = {
   readonly unitId: string;
-  readonly athletePublicId: string;
+  readonly displayName: string;
   readonly walrusBlobId: string;
   readonly submissionNo: number;
   readonly mintedAtMs: number;
@@ -341,7 +341,7 @@ function GalleryEntriesSection({
     <section className="grid gap-px bg-[var(--rule)] md:grid-cols-2">
       {entries.map((entry) => (
         <GalleryCard
-          athlete={findAthlete(catalog, entry.athletePublicId)}
+          athlete={findAthlete(catalog, entry.unitId)}
           entry={entry}
           key={`${entry.unitId}:${entry.walrusBlobId}`}
           originalImageFailed={failedOriginalBlobIds.includes(
@@ -434,8 +434,7 @@ function GalleryCard({
   onOriginalImageError,
 }: GalleryCardProps): React.ReactElement {
   const completedEntry = isCompletedEntry(entry) ? entry : null;
-  const displayName =
-    athlete?.displayName ?? `Athlete #${entry.athletePublicId}`;
+  const displayName = athlete?.displayName ?? entry.displayName;
   const originalPhotoUrl = buildWalrusAggregatorUrl(entry.walrusBlobId);
   const completedMosaicUrl = completedEntry
     ? buildWalrusAggregatorUrl(completedEntry.mosaicWalrusBlobId)
@@ -612,11 +611,9 @@ function isCompletedEntry(
 
 function findAthlete(
   catalog: readonly AthleteCatalogEntry[],
-  athletePublicId: string,
+  unitId: string,
 ): AthleteCatalogEntry | null {
-  return (
-    catalog.find((entry) => entry.athletePublicId === athletePublicId) ?? null
-  );
+  return catalog.find((entry) => entry.unitId === unitId) ?? null;
 }
 
 const demoBlobAssetMap: Record<string, string> = {
@@ -665,7 +662,7 @@ function buildUnitPageHref(args: {
 function createUnavailableEntry(kakera: OwnedKakera): GalleryUnavailableEntry {
   return {
     unitId: kakera.unitId,
-    athletePublicId: kakera.athletePublicId,
+    displayName: `Unit ${kakera.unitId.slice(0, 10)}...`,
     walrusBlobId: kakera.walrusBlobId,
     submissionNo: kakera.submissionNo,
     mintedAtMs: kakera.mintedAtMs,

--- a/apps/web/src/app/gallery/page.test.tsx
+++ b/apps/web/src/app/gallery/page.test.tsx
@@ -37,7 +37,7 @@ vi.mock("./gallery-page-client", () => ({
     packageId,
   }: {
     catalog: readonly {
-      athletePublicId: string;
+      unitId: string;
       slug: string;
       displayName: string;
       thumbnailUrl: string;
@@ -62,13 +62,11 @@ import GalleryPage from "./page";
 
 const CATALOG = [
   {
-    athletePublicId: "1",
     slug: "demo-athlete-one",
     displayName: "Demo Athlete One",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
   },
   {
-    athletePublicId: "2",
     slug: "demo-athlete-two",
     displayName: "Demo Athlete Two",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+2",
@@ -119,7 +117,6 @@ describe("GalleryPage", () => {
     getDemoGalleryEntriesMock.mockReturnValue([
       {
         unitId: "0xdemo-unit",
-        athletePublicId: "1",
         walrusBlobId: "demo-original",
         submissionNo: 17,
         mintedAtMs: 1800000000000,
@@ -151,7 +148,6 @@ describe("GalleryPage", () => {
     getDemoGalleryEntriesMock.mockReturnValue([
       {
         unitId: "0xdemo-unit",
-        athletePublicId: "1",
         walrusBlobId: "demo-original",
         submissionNo: 17,
         mintedAtMs: 1800000000000,

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -34,13 +34,14 @@ import HomePage from "./page";
 
 const CATALOG = [
   {
-    athletePublicId: "1",
+    unitId: demoUnitId,
     slug: "demo-athlete-one",
     displayName: "Demo Athlete One",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
   },
   {
-    athletePublicId: "2",
+    unitId:
+      "0x00000000000000000000000000000000000000000000000000000000000000d4",
     slug: "demo-athlete-two",
     displayName: "Demo Athlete Two",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+2",
@@ -199,7 +200,7 @@ describe("HomePage", () => {
 
     const ui = await HomePage({
       searchParams: Promise.resolve({
-        op_e2e_home_card_state: "1:waiting,2:unavailable",
+        op_e2e_home_card_state: `${demoUnitId}:waiting,0x00000000000000000000000000000000000000000000000000000000000000d4:unavailable`,
       }),
     });
     render(ui);
@@ -225,7 +226,7 @@ describe("HomePage", () => {
 
     const ui = await HomePage({
       searchParams: Promise.resolve({
-        op_e2e_home_card_state: "1:waiting",
+        op_e2e_home_card_state: "0xunit-1:waiting",
       }),
     });
     render(ui);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -146,11 +146,7 @@ export default async function HomePage(
         ) : (
           <div className="grid gap-px bg-[var(--rule)] md:grid-cols-2 xl:grid-cols-4">
             {entries.map((athlete, idx) => (
-              <AthleteCard
-                athlete={athlete}
-                idx={idx}
-                key={athlete.unitId}
-              />
+              <AthleteCard athlete={athlete} idx={idx} key={athlete.unitId} />
             ))}
           </div>
         )}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,11 +4,7 @@ import Link from "next/link";
 const mosaicAspectRatio = `${unitTileGrid.cols} / ${unitTileGrid.rows}`;
 
 import { getAthleteCatalog } from "../lib/catalog";
-import {
-  getDemoCurrentUnitIdForAthlete,
-  getDemoUnitProgress,
-  isDemoModeEnabled,
-} from "../lib/demo";
+import { getDemoUnitProgress, isDemoModeEnabled } from "../lib/demo";
 import { getActiveHomeUnits, RegistrySchemaError } from "../lib/sui";
 
 function formatProgressCount(value: number): string {
@@ -22,7 +18,7 @@ type HomePageProps = {
 };
 
 type HomeEntry = {
-  readonly athletePublicId: string;
+  readonly unitId: string;
   readonly displayName: string;
   readonly thumbnailUrl: string;
   readonly progress:
@@ -153,7 +149,7 @@ export default async function HomePage(
               <AthleteCard
                 athlete={athlete}
                 idx={idx}
-                key={athlete.athletePublicId}
+                key={athlete.unitId}
               />
             ))}
           </div>
@@ -355,7 +351,7 @@ async function loadChainEntries(): Promise<readonly HomeEntry[]> {
   try {
     const units = await getActiveHomeUnits();
     return units.map((unit) => ({
-      athletePublicId: unit.athletePublicId,
+      unitId: unit.unitId,
       displayName: unit.displayName,
       thumbnailUrl: unit.thumbnailUrl,
       progress: {
@@ -386,9 +382,9 @@ async function loadDemoEntries(
   const entries: HomeEntry[] = [];
 
   for (const athlete of catalog) {
-    const unitId = getDemoCurrentUnitIdForAthlete(athlete.athletePublicId);
+    const unitId = athlete.unitId;
     const override = resolveE2ECardOverride(
-      athlete.athletePublicId,
+      athlete.unitId,
       rawOverride,
       unitId,
     );
@@ -429,7 +425,7 @@ function buildWaitingRoomHref(unitId: string, athleteName: string): string {
 }
 
 function resolveE2ECardOverride(
-  athletePublicId: string,
+  entryUnitId: string,
   rawOverride: string | undefined,
   unitId: string | null,
 ):
@@ -452,8 +448,8 @@ function resolveE2ECardOverride(
     .filter(Boolean);
 
   for (const token of tokens) {
-    const [targetAthleteId, kind] = token.split(":");
-    if (targetAthleteId !== athletePublicId) {
+    const [targetUnitId, kind] = token.split(":");
+    if (targetUnitId !== entryUnitId) {
       continue;
     }
 

--- a/apps/web/src/app/units/[unitId]/live-progress.test.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.test.tsx
@@ -66,7 +66,6 @@ describe("LiveProgress", () => {
       capturedOnSubmitted?.({
         kind: "submitted",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         submitter: "0xabc",
         walrusBlobId: [],
         submissionNo: 11,
@@ -101,7 +100,6 @@ describe("LiveProgress", () => {
       capturedOnSubmitted?.({
         kind: "submitted",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         submitter: "0xabc",
         walrusBlobId: [],
         submissionNo: 1,
@@ -132,7 +130,6 @@ describe("LiveProgress", () => {
       capturedOnSubmitted?.({
         kind: "submitted",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         submitter: "0xabc",
         walrusBlobId: [],
         submissionNo: 5,
@@ -205,7 +202,6 @@ describe("LiveProgress", () => {
       capturedOnMosaicReady?.({
         kind: "mosaicReady",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         masterId: "0xmaster-1",
         mosaicWalrusBlobId: [109, 111, 115, 97, 105, 99],
       });
@@ -242,7 +238,6 @@ describe("LiveProgress", () => {
       capturedOnFilled?.({
         kind: "filled",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         filledCount: unitTileCount,
         maxSlots: unitTileCount,
       });
@@ -274,7 +269,6 @@ describe("LiveProgress", () => {
       const event: UnitFilledEvent = {
         kind: "filled",
         unitId: "0xunit-1",
-        athletePublicId: "1",
         filledCount: unitTileCount,
         maxSlots: unitTileCount,
       };

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -9,13 +9,11 @@ import { STUB_MASTER_ID, STUB_UNIT_ID } from "../../../lib/e2e/stub-data";
 
 const {
   getUnitProgressMock,
-  getAthleteByPublicIdMock,
   loadPublicEnvMock,
   participationAccessMock,
   unitRevealClientMock,
 } = vi.hoisted(() => ({
   getUnitProgressMock: vi.fn(),
-  getAthleteByPublicIdMock: vi.fn(),
   loadPublicEnvMock: vi.fn(),
   participationAccessMock: vi.fn(),
   unitRevealClientMock: vi.fn(),
@@ -23,10 +21,6 @@ const {
 
 vi.mock("../../../lib/sui", () => ({
   getUnitProgress: getUnitProgressMock,
-}));
-
-vi.mock("../../../lib/catalog", () => ({
-  getAthleteByPublicId: getAthleteByPublicIdMock,
 }));
 
 vi.mock("../../../lib/env", () => ({
@@ -89,19 +83,17 @@ import UnitPage from "./page";
 
 function buildProgress(
   overrides: Partial<{
-    athletePublicId: string;
+    unitId: string;
     displayName: string | null;
     masterId: string | null;
     maxSlots: number;
     status: "pending" | "filled" | "finalized";
     submittedCount: number;
     thumbnailUrl: string | null;
-    unitId: string;
   }> = {},
 ) {
   return {
     unitId: "0xunit-1",
-    athletePublicId: "1",
     displayName: "Demo Athlete One",
     submittedCount: 15,
     maxSlots: unitTileCount,
@@ -129,7 +121,6 @@ afterEach(() => {
   delete process.env.NEXT_PUBLIC_WALRUS_PUBLISHER;
   delete process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR;
   getUnitProgressMock.mockReset();
-  getAthleteByPublicIdMock.mockReset();
   loadPublicEnvMock.mockReset();
   participationAccessMock.mockReset();
   unitRevealClientMock.mockReset();
@@ -163,17 +154,10 @@ describe("UnitPage", () => {
   it("renders demo unit progress with the display_max_slots based counter", async () => {
     getUnitProgressMock.mockResolvedValue({
       unitId: "0xunit-1",
-      athletePublicId: "1",
       submittedCount: 1995,
       maxSlots: 2000,
       status: "pending",
       masterId: null,
-    });
-    getAthleteByPublicIdMock.mockResolvedValue({
-      athletePublicId: "1",
-      slug: "demo-athlete-one",
-      displayName: "Demo Athlete One",
-      thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
     });
     loadPublicEnvMock.mockReturnValue({
       suiNetwork: "testnet",
@@ -400,12 +384,6 @@ describe("UnitPage", () => {
 
   it("uses demo fixture progress without calling Sui when demo mode is enabled", async () => {
     process.env.NEXT_PUBLIC_DEMO_MODE = "1";
-    getAthleteByPublicIdMock.mockResolvedValue({
-      athletePublicId: "1",
-      slug: "demo-athlete-one",
-      displayName: "Demo Athlete One",
-      thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
-    });
     loadPublicEnvMock.mockReturnValue({
       suiNetwork: "testnet",
       packageId: "0xpkg",
@@ -509,7 +487,6 @@ describe("UnitPage", () => {
         maxSlots: unitTileCount,
       }),
     );
-    expect(getAthleteByPublicIdMock).not.toHaveBeenCalled();
   });
 
   it("ignores the finalized unit bootstrap for non-stub units", async () => {

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -14,10 +14,7 @@ import { unitTileCount } from "@one-portrait/shared";
 import Link from "next/link";
 
 import { getDemoUnitProgress, isDemoModeEnabled } from "../../../lib/demo";
-import {
-  STUB_MASTER_ID,
-  STUB_UNIT_ID,
-} from "../../../lib/e2e/stub-data";
+import { STUB_MASTER_ID, STUB_UNIT_ID } from "../../../lib/e2e/stub-data";
 import { getUnitProgress } from "../../../lib/sui";
 import type { WalrusEnv } from "../../../lib/walrus/put";
 

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -13,10 +13,8 @@
 import { unitTileCount } from "@one-portrait/shared";
 import Link from "next/link";
 
-import { getAthleteByPublicId } from "../../../lib/catalog";
 import { getDemoUnitProgress, isDemoModeEnabled } from "../../../lib/demo";
 import {
-  STUB_ATHLETE_ID,
   STUB_MASTER_ID,
   STUB_UNIT_ID,
 } from "../../../lib/e2e/stub-data";
@@ -38,7 +36,6 @@ type ResolvedProgress = {
   readonly displayName: string | null;
   readonly submittedCount: number;
   readonly maxSlots: number;
-  readonly athletePublicId: string | null;
   readonly masterId: string | null;
   readonly thumbnailUrl: string | null;
 };
@@ -71,19 +68,13 @@ export default async function UnitPage(
   const progress = demoMode
     ? safeGetDemoUnitProgress(unitId)
     : (e2eBootstrapProgress ?? (await safeGetUnitProgress(unitId)));
-  const athlete =
-    demoMode && progress.athletePublicId
-      ? await safeGetAthleteByPublicId(progress.athletePublicId)
-      : null;
-
   const displayName = resolveDisplayName(
     searchParams.athleteName,
-    progress.displayName ?? athlete?.displayName ?? null,
+    progress.displayName,
   );
-  const thumbnailUrl = progress.thumbnailUrl ?? athlete?.thumbnailUrl ?? null;
+  const thumbnailUrl = progress.thumbnailUrl;
 
-  const hasProgress =
-    progress.submittedCount >= 0 && progress.athletePublicId !== null;
+  const hasProgress = progress.submittedCount >= 0;
 
   return (
     <main className="grain relative min-h-screen overflow-hidden text-[var(--ink)]">
@@ -269,7 +260,6 @@ function safeGetDemoUnitProgress(unitId: string): ResolvedProgress {
     displayName: view.displayName,
     submittedCount: view.submittedCount,
     maxSlots: view.maxSlots,
-    athletePublicId: view.athletePublicId,
     masterId: view.masterId,
     thumbnailUrl: view.thumbnailUrl,
   };
@@ -282,20 +272,11 @@ async function safeGetUnitProgress(unitId: string): Promise<ResolvedProgress> {
       displayName: view.displayName,
       submittedCount: view.submittedCount,
       maxSlots: view.maxSlots,
-      athletePublicId: view.athletePublicId,
       masterId: view.masterId,
       thumbnailUrl: view.thumbnailUrl,
     };
   } catch {
     return degradedProgress();
-  }
-}
-
-async function safeGetAthleteByPublicId(athletePublicId: string) {
-  try {
-    return (await getAthleteByPublicId(athletePublicId)) ?? null;
-  } catch {
-    return null;
   }
 }
 
@@ -317,7 +298,6 @@ function degradedProgress(): ResolvedProgress {
     displayName: null,
     submittedCount: -1,
     maxSlots: FALLBACK_MAX_SLOTS,
-    athletePublicId: null,
     masterId: null,
     thumbnailUrl: null,
   };
@@ -351,7 +331,6 @@ function activeProgress(): ResolvedProgress {
     displayName: "Demo Athlete One",
     submittedCount: FALLBACK_MAX_SLOTS - 1,
     maxSlots: FALLBACK_MAX_SLOTS,
-    athletePublicId: "1",
     masterId: null,
     thumbnailUrl: null,
   };
@@ -362,7 +341,6 @@ function finalizedProgress(): ResolvedProgress {
     displayName: "Demo Athlete One",
     submittedCount: FALLBACK_MAX_SLOTS,
     maxSlots: FALLBACK_MAX_SLOTS,
-    athletePublicId: STUB_ATHLETE_ID,
     masterId: STUB_MASTER_ID,
     thumbnailUrl: null,
   };

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -1282,7 +1282,6 @@ describe("ParticipationAccess", () => {
         capturedOnSubmitted?.({
           kind: "submitted",
           unitId: "0xunit-1",
-          athletePublicId: "1",
           submitter: "0xabc123",
           walrusBlobId: [],
           submissionNo: 42,

--- a/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
@@ -48,7 +48,6 @@ vi.mock("./live-progress", () => ({
     onMosaicReady?: (event: {
       readonly kind: "mosaicReady";
       readonly unitId: string;
-      readonly athletePublicId: string;
       readonly masterId: string;
       readonly mosaicWalrusBlobId: readonly number[];
     }) => void;
@@ -62,7 +61,6 @@ vi.mock("./live-progress", () => ({
           onMosaicReady?.({
             kind: "mosaicReady",
             unitId: "0xunit-1",
-            athletePublicId: "1",
             masterId: "0xmaster-1",
             mosaicWalrusBlobId: Array.from(
               new TextEncoder().encode("mosaic-event-blob"),
@@ -88,7 +86,7 @@ function completedEntry(
 ): Extract<GalleryEntryView, { status: { kind: "completed" } }> {
   return {
     unitId: "0xunit-1",
-    athletePublicId: "1",
+    displayName: "Demo Athlete One",
     walrusBlobId: "walrus-blob-1",
     submissionNo: 42,
     mintedAtMs: 1700000000000,
@@ -108,7 +106,6 @@ function completedEntry(
 function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
   return {
     objectId: "0xkakera-1",
-    athletePublicId: "1",
     unitId: "0xunit-1",
     walrusBlobId: "walrus-blob-1",
     submissionNo: 42,

--- a/apps/web/src/data/athlete-catalog.ts
+++ b/apps/web/src/data/athlete-catalog.ts
@@ -9,22 +9,25 @@
  */
 
 import type { AthleteCatalogEntry } from "../lib/catalog/types";
+import { demoUnitId } from "../lib/demo";
 
 export const athleteCatalogEntries: readonly AthleteCatalogEntry[] = [
   {
-    athletePublicId: "1",
+    unitId: demoUnitId,
     slug: "demo-athlete-one",
     displayName: "Demo Athlete One",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
   },
   {
-    athletePublicId: "2",
+    unitId:
+      "0x00000000000000000000000000000000000000000000000000000000000000d4",
     slug: "demo-athlete-two",
     displayName: "Demo Athlete Two",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+2",
   },
   {
-    athletePublicId: "3",
+    unitId:
+      "0x00000000000000000000000000000000000000000000000000000000000000d5",
     slug: "demo-athlete-three",
     displayName: "Demo Athlete Three",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+3",

--- a/apps/web/src/lib/admin/api.test.ts
+++ b/apps/web/src/lib/admin/api.test.ts
@@ -5,7 +5,41 @@ import {
   ADMIN_MUTATION_HEADER_VALUE,
   AdminApiError,
   assertAdminMutationRequest,
+  parseCreateUnitInput,
 } from "./api";
+
+describe("parseCreateUnitInput", () => {
+  it("accepts create-unit input without athleteId", () => {
+    expect(
+      parseCreateUnitInput({
+        blobId: "target-blob-12",
+        displayMaxSlots: 2000,
+        displayName: "Demo Athlete Twelve",
+        maxSlots: 2000,
+        thumbnailUrl: "https://example.com/12.png",
+      }),
+    ).toEqual({
+      blobId: "target-blob-12",
+      displayMaxSlots: 2000,
+      displayName: "Demo Athlete Twelve",
+      maxSlots: 2000,
+      thumbnailUrl: "https://example.com/12.png",
+    });
+  });
+
+  it("rejects create-unit input that still includes athleteId", () => {
+    expect(() =>
+      parseCreateUnitInput({
+        athleteId: 12,
+        blobId: "target-blob-12",
+        displayMaxSlots: 2000,
+        displayName: "Demo Athlete Twelve",
+        maxSlots: 2000,
+        thumbnailUrl: "https://example.com/12.png",
+      }),
+    ).toThrowError(AdminApiError);
+  });
+});
 
 describe("assertAdminMutationRequest", () => {
   it("accepts same-origin browser requests marked by the admin client", () => {

--- a/apps/web/src/lib/admin/api.ts
+++ b/apps/web/src/lib/admin/api.ts
@@ -19,7 +19,6 @@ export class AdminApiError extends Error {
 }
 
 export type CreateUnitRouteInput = {
-  readonly athleteId: number;
   readonly displayMaxSlots: number;
   readonly displayName: string;
   readonly blobId: string;
@@ -30,7 +29,6 @@ export type CreateUnitRouteInput = {
 export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
   const record = asRecord(input);
   assertExactKeys(record, [
-    "athleteId",
     "blobId",
     "displayMaxSlots",
     "displayName",
@@ -52,7 +50,6 @@ export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
   }
 
   return {
-    athleteId: parseAthleteId(record.athleteId),
     displayMaxSlots,
     displayName: parseNonEmptyTrimmedString(record.displayName, "displayName"),
     blobId: parseBlobId(record.blobId),
@@ -126,25 +123,6 @@ function assertExactKeys(
       `\`${expected.join("`, `")}\` だけを送ってください。`,
     );
   }
-}
-
-function parseAthleteId(value: unknown): number {
-  const athleteId =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && /^[0-9]+$/.test(value)
-        ? Number(value)
-        : NaN;
-
-  if (!Number.isInteger(athleteId) || athleteId < 0 || athleteId > 65_535) {
-    throw new AdminApiError(
-      400,
-      "invalid_args",
-      "`athleteId` は u16 の整数で送ってください。",
-    );
-  }
-
-  return athleteId;
 }
 
 function parseBlobId(value: unknown): string {

--- a/apps/web/src/lib/admin/athletes.ts
+++ b/apps/web/src/lib/admin/athletes.ts
@@ -5,7 +5,6 @@ import {
 } from "../sui";
 
 export type AdminAthleteEntry = {
-  readonly athletePublicId: string;
   readonly currentUnit: AdminUnitSnapshot | null;
   readonly displayName: string;
   readonly entryId?: string;
@@ -40,7 +39,6 @@ function buildEntry(
   lookupState: AdminAthleteEntry["lookupState"],
 ): AdminAthleteEntry {
   return {
-    athletePublicId: currentUnit.athletePublicId,
     currentUnit,
     displayName: currentUnit.displayName,
     entryId: currentUnit.unitId,
@@ -53,7 +51,6 @@ function buildEntry(
 
 function buildUnavailableEntry(unitId: string): AdminAthleteEntry {
   return {
-    athletePublicId: "unavailable",
     currentUnit: null,
     displayName: `Unit ${unitId.slice(0, 10)}…`,
     entryId: unitId,

--- a/apps/web/src/lib/catalog/athlete-catalog.test.ts
+++ b/apps/web/src/lib/catalog/athlete-catalog.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { AthleteCatalogEntry, AthleteChainRef } from "./index";
 import {
-  getAthleteByPublicId,
   getAthleteBySlug,
+  getAthleteByUnitId,
   getAthleteCatalog,
 } from "./index";
 
@@ -14,36 +14,20 @@ describe("getAthleteCatalog", () => {
     expect(catalog.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("gives every entry the required display fields", async () => {
+  it("gives every entry the required unit display fields", async () => {
     const catalog = await getAthleteCatalog();
 
     for (const entry of catalog) {
-      expect(typeof entry.athletePublicId).toBe("string");
-      expect(entry.athletePublicId.length).toBeGreaterThan(0);
-      expect(typeof entry.displayName).toBe("string");
+      expect(entry.unitId).toMatch(/^0x[0-9a-f]+$/i);
       expect(entry.displayName.length).toBeGreaterThan(0);
-      expect(typeof entry.slug).toBe("string");
       expect(entry.slug.length).toBeGreaterThan(0);
-      expect(typeof entry.thumbnailUrl).toBe("string");
       expect(entry.thumbnailUrl.length).toBeGreaterThan(0);
     }
   });
 
-  it("keeps athletePublicId as a decimal string that matches on-chain u16", async () => {
+  it("has unique unitId and slug across entries", async () => {
     const catalog = await getAthleteCatalog();
-
-    for (const entry of catalog) {
-      expect(entry.athletePublicId).toMatch(/^[0-9]+$/);
-      const numeric = Number(entry.athletePublicId);
-      expect(Number.isInteger(numeric)).toBe(true);
-      expect(numeric).toBeGreaterThanOrEqual(0);
-      expect(numeric).toBeLessThanOrEqual(65_535);
-    }
-  });
-
-  it("has unique athletePublicId and slug across entries", async () => {
-    const catalog = await getAthleteCatalog();
-    const ids = new Set(catalog.map((entry) => entry.athletePublicId));
+    const ids = new Set(catalog.map((entry) => entry.unitId));
     const slugs = new Set(catalog.map((entry) => entry.slug));
 
     expect(ids.size).toBe(catalog.length);
@@ -60,20 +44,16 @@ describe("getAthleteBySlug", () => {
       return;
     }
 
-    const found = await getAthleteBySlug(first.slug);
-
-    expect(found).toEqual(first);
+    await expect(getAthleteBySlug(first.slug)).resolves.toEqual(first);
   });
 
   it("returns undefined for an unknown slug", async () => {
-    const found = await getAthleteBySlug("does-not-exist-xyz");
-
-    expect(found).toBeUndefined();
+    await expect(getAthleteBySlug("does-not-exist-xyz")).resolves.toBeUndefined();
   });
 });
 
-describe("getAthleteByPublicId", () => {
-  it("returns the matching entry when the id exists", async () => {
+describe("getAthleteByUnitId", () => {
+  it("returns the matching entry when the unit exists", async () => {
     const catalog = await getAthleteCatalog();
     const first = catalog[0];
     if (!first) {
@@ -81,46 +61,34 @@ describe("getAthleteByPublicId", () => {
       return;
     }
 
-    const found = await getAthleteByPublicId(first.athletePublicId);
-
-    expect(found).toEqual(first);
+    await expect(getAthleteByUnitId(first.unitId)).resolves.toEqual(first);
   });
 
-  it("returns undefined for an unknown public id", async () => {
-    const found = await getAthleteByPublicId("999999");
-
-    expect(found).toBeUndefined();
+  it("returns undefined for an unknown unit", async () => {
+    await expect(getAthleteByUnitId("0x999999")).resolves.toBeUndefined();
   });
 });
 
-describe("AthleteChainRef (on-chain place-holder)", () => {
-  it("accepts only athletePublicId and currentUnitId", () => {
+describe("AthleteChainRef", () => {
+  it("accepts only unitId", () => {
     const ref: AthleteChainRef = {
-      athletePublicId: "1",
-      currentUnitId: "0xabc",
+      unitId: "0xabc",
     };
 
-    expect(ref.athletePublicId).toBe("1");
-    expect(ref.currentUnitId).toBe("0xabc");
+    expect(ref.unitId).toBe("0xabc");
   });
 
-  it("allows currentUnitId to be null before a Unit is created", () => {
+  it("allows unitId to be null before a Unit is created", () => {
     const ref: AthleteChainRef = {
-      athletePublicId: "2",
-      currentUnitId: null,
+      unitId: null,
     };
 
-    expect(ref.currentUnitId).toBeNull();
+    expect(ref.unitId).toBeNull();
   });
 
   it("keeps display metadata out of chain ref (type-level assertion)", () => {
-    // This test encodes the boundary contract: AthleteChainRef must not
-    // carry any display meta. If someone adds displayName / slug / thumbnailUrl
-    // to AthleteChainRef, the `@ts-expect-error` lines below will become
-    // unused and fail the build, catching the regression at compile time.
     const chainOnly: AthleteChainRef = {
-      athletePublicId: "3",
-      currentUnitId: null,
+      unitId: null,
     };
 
     // @ts-expect-error displayName must live only on AthleteCatalogEntry
@@ -133,26 +101,22 @@ describe("AthleteChainRef (on-chain place-holder)", () => {
     void _displayName;
     void _slug;
     void _thumbnail;
-    expect(chainOnly.athletePublicId).toBe("3");
+    expect(chainOnly.unitId).toBeNull();
   });
 });
 
 describe("AthleteCatalogEntry", () => {
   it("is structurally independent from AthleteChainRef", () => {
-    // The two types share only `athletePublicId`. This test documents that
-    // contract by constructing both from the same id and asserting only the
-    // shared field overlaps.
     const entry: AthleteCatalogEntry = {
-      athletePublicId: "42",
+      unitId: "0x42",
       slug: "example",
       displayName: "Example Athlete",
       thumbnailUrl: "https://example.invalid/thumb.jpg",
     };
     const ref: AthleteChainRef = {
-      athletePublicId: "42",
-      currentUnitId: null,
+      unitId: "0x42",
     };
 
-    expect(entry.athletePublicId).toBe(ref.athletePublicId);
+    expect(entry.unitId).toBe(ref.unitId);
   });
 });

--- a/apps/web/src/lib/catalog/athlete-catalog.test.ts
+++ b/apps/web/src/lib/catalog/athlete-catalog.test.ts
@@ -48,7 +48,9 @@ describe("getAthleteBySlug", () => {
   });
 
   it("returns undefined for an unknown slug", async () => {
-    await expect(getAthleteBySlug("does-not-exist-xyz")).resolves.toBeUndefined();
+    await expect(
+      getAthleteBySlug("does-not-exist-xyz"),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/catalog/athlete-catalog.ts
+++ b/apps/web/src/lib/catalog/athlete-catalog.ts
@@ -10,7 +10,7 @@
  */
 
 import { athleteCatalogEntries } from "../../data/athlete-catalog";
-import type { AthleteCatalogEntry, AthletePublicId } from "./types";
+import type { AthleteCatalogEntry } from "./types";
 
 export async function getAthleteCatalog(): Promise<
   readonly AthleteCatalogEntry[]
@@ -25,9 +25,9 @@ export async function getAthleteBySlug(
   return catalog.find((entry) => entry.slug === slug);
 }
 
-export async function getAthleteByPublicId(
-  athletePublicId: AthletePublicId,
+export async function getAthleteByUnitId(
+  unitId: string,
 ): Promise<AthleteCatalogEntry | undefined> {
   const catalog = await getAthleteCatalog();
-  return catalog.find((entry) => entry.athletePublicId === athletePublicId);
+  return catalog.find((entry) => entry.unitId === unitId);
 }

--- a/apps/web/src/lib/catalog/index.ts
+++ b/apps/web/src/lib/catalog/index.ts
@@ -8,8 +8,8 @@
  */
 
 export {
-  getAthleteByUnitId,
   getAthleteBySlug,
+  getAthleteByUnitId,
   getAthleteCatalog,
 } from "./athlete-catalog";
 export type {

--- a/apps/web/src/lib/catalog/index.ts
+++ b/apps/web/src/lib/catalog/index.ts
@@ -8,12 +8,11 @@
  */
 
 export {
-  getAthleteByPublicId,
+  getAthleteByUnitId,
   getAthleteBySlug,
   getAthleteCatalog,
 } from "./athlete-catalog";
 export type {
   AthleteCatalogEntry,
   AthleteChainRef,
-  AthletePublicId,
 } from "./types";

--- a/apps/web/src/lib/catalog/types.ts
+++ b/apps/web/src/lib/catalog/types.ts
@@ -1,29 +1,10 @@
 /**
  * Catalog type boundary for ONE Portrait.
  *
- * The catalog layer owns **display metadata** (name, slug, thumbnail, etc.).
- * The on-chain layer owns the **Registry -> Unit** pointer and nothing else
- * about how the athlete should be rendered.
- *
- * These two concerns intentionally share **only** `athletePublicId` so that:
- *   - Display tweaks (copy changes, new images) never require a chain migration.
- *   - The chain stays cheap and stable (just `athlete_id: u16`).
- *   - A future CMS can replace the catalog without touching chain code.
+ * The catalog layer owns demo/display metadata for known Units.
+ * Live chain data now carries its own display name and thumbnail on Unit,
+ * so `unitId` is the only catalog key.
  */
-
-/**
- * String-normalized form of the on-chain `athlete_id: u16`.
- *
- * The Move package uses `u16` so numeric values are bound to `[0, 65535]`, but
- * we keep the catalog-side representation as a decimal string for three
- * reasons:
- *   1. Some on-chain identifier types elsewhere in the Sui ecosystem are
- *      addresses or `vector<u8>`; standardising on strings here lets us swap
- *      representations later without breaking callers.
- *   2. JSON payloads from a future CMS will almost certainly arrive as strings.
- *   3. `Map<AthletePublicId, ...>` keys behave identically across sources.
- */
-export type AthletePublicId = string;
 
 /**
  * Display-side record for a single athlete.
@@ -33,8 +14,8 @@ export type AthletePublicId = string;
  * {@link AthleteChainRef}.
  */
 export type AthleteCatalogEntry = {
-  /** Decimal-string form of the on-chain `athlete_id: u16`. */
-  readonly athletePublicId: AthletePublicId;
+  /** Object ID of the current demo/display Unit. */
+  readonly unitId: string;
   /** URL-safe identifier used in routes like `/athletes/[slug]`. */
   readonly slug: string;
   /** Human-readable name shown in UI. */
@@ -52,8 +33,6 @@ export type AthleteCatalogEntry = {
  * `@ts-expect-error` lines flip and the build fails.
  */
 export type AthleteChainRef = {
-  /** Must match an {@link AthleteCatalogEntry.athletePublicId} to be useful. */
-  readonly athletePublicId: AthletePublicId;
   /** Object ID of the current `Unit`, or `null` if no unit has been opened. */
-  readonly currentUnitId: string | null;
+  readonly unitId: string | null;
 };

--- a/apps/web/src/lib/demo/index.ts
+++ b/apps/web/src/lib/demo/index.ts
@@ -16,7 +16,6 @@ const demoProgressByUnitId = new Map<string, AthleteProgressView>([
     demoUnitId,
     {
       unitId: demoUnitId,
-      athletePublicId: "1",
       displayName: "Demo Athlete One",
       submittedCount: 347,
       maxSlots: unitTileCount,
@@ -29,16 +28,10 @@ const demoProgressByUnitId = new Map<string, AthleteProgressView>([
   ],
 ]);
 
-const demoCurrentUnitIdsByAthlete = new Map<string, string | null>([
-  ["1", demoUnitId],
-  ["2", null],
-  ["3", null],
-]);
-
 const demoGalleryEntries = [
   {
     unitId: demoUnitId,
-    athletePublicId: "1",
+    displayName: "Demo Athlete One",
     walrusBlobId: "demo-original-one",
     submissionNo: 347,
     mintedAtMs: 1_800_000_000_000,
@@ -55,7 +48,7 @@ const demoGalleryEntries = [
   {
     unitId:
       "0x00000000000000000000000000000000000000000000000000000000000000d4",
-    athletePublicId: "2",
+    displayName: "Demo Athlete Two",
     walrusBlobId: "demo-original-two",
     submissionNo: 88,
     mintedAtMs: 1_790_000_000_000,
@@ -78,12 +71,6 @@ export function getDemoModeSource(): Readonly<
   return {
     NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
   };
-}
-
-export function getDemoCurrentUnitIdForAthlete(
-  athletePublicId: string,
-): string | null {
-  return demoCurrentUnitIdsByAthlete.get(athletePublicId) ?? null;
 }
 
 export function getDemoUnitProgress(

--- a/apps/web/src/lib/sui/admin-unit.test.ts
+++ b/apps/web/src/lib/sui/admin-unit.test.ts
@@ -33,7 +33,6 @@ function unitData(fields: Record<string, unknown>) {
       type: "0xpkg::unit::Unit",
       fields: {
         id: { id: UNIT_ID },
-        athlete_id: 7,
         display_name: bytes("Demo Athlete Seven"),
         thumbnail_url: bytes("https://example.com/7.png"),
         target_walrus_blob: bytes("target-blob-007"),
@@ -64,7 +63,6 @@ describe("getAdminUnitSnapshot", () => {
     const client = clientReturning(unitData({}));
 
     await expect(getAdminUnitSnapshot(UNIT_ID, { client })).resolves.toEqual({
-      athletePublicId: "7",
       displayMaxSlots: 2000,
       displayName: "Demo Athlete Seven",
       masterId: null,

--- a/apps/web/src/lib/sui/admin-unit.ts
+++ b/apps/web/src/lib/sui/admin-unit.ts
@@ -6,7 +6,6 @@ import { UnitNotFoundError } from "./unit";
 export { UnitNotFoundError } from "./unit";
 
 export type AdminUnitSnapshot = {
-  readonly athletePublicId: string;
   readonly displayName: string;
   readonly displayMaxSlots: number;
   readonly masterId: string | null;
@@ -44,7 +43,6 @@ export async function getAdminUnitSnapshot(
   const realSubmittedCount = countSubmissions(fields.submissions);
 
   return {
-    athletePublicId: String(parseIntegerField(fields.athlete_id, "athlete_id")),
     displayName: readVectorU8AsString(fields.display_name, "display_name"),
     displayMaxSlots,
     masterId: extractOptionalId(fields.master_id),

--- a/apps/web/src/lib/sui/event-types.test.ts
+++ b/apps/web/src/lib/sui/event-types.test.ts
@@ -17,7 +17,6 @@ function submittedRaw(overrides: Record<string, unknown> = {}) {
     type: "0xpkg::events::SubmittedEvent",
     parsedJson: {
       unit_id: UNIT_ID,
-      athlete_id: ATHLETE_ID,
       submitter: SUBMITTER,
       walrus_blob_id: [1, 2, 3],
       submission_no: "1",
@@ -33,7 +32,6 @@ function unitFilledRaw(overrides: Record<string, unknown> = {}) {
     type: "0xpkg::events::UnitFilledEvent",
     parsedJson: {
       unit_id: UNIT_ID,
-      athlete_id: ATHLETE_ID,
       filled_count: String(unitTileCount),
       max_slots: String(unitTileCount),
       ...overrides,
@@ -46,7 +44,6 @@ function mosaicReadyRaw(overrides: Record<string, unknown> = {}) {
     type: "0xpkg::events::MosaicReadyEvent",
     parsedJson: {
       unit_id: UNIT_ID,
-      athlete_id: ATHLETE_ID,
       master_id: MASTER_ID,
       mosaic_walrus_blob_id: [9, 8, 7],
       ...overrides,
@@ -61,7 +58,6 @@ describe("parseSubmittedEvent", () => {
     expect(event).toEqual({
       kind: "submitted",
       unitId: UNIT_ID,
-      athletePublicId: "7",
       submitter: SUBMITTER,
       walrusBlobId: [1, 2, 3],
       submissionNo: 1,
@@ -98,7 +94,6 @@ describe("parseUnitFilledEvent", () => {
     expect(event).toEqual({
       kind: "filled",
       unitId: UNIT_ID,
-      athletePublicId: "7",
       filledCount: unitTileCount,
       maxSlots: unitTileCount,
     });
@@ -118,7 +113,6 @@ describe("parseMosaicReadyEvent", () => {
     expect(event).toEqual({
       kind: "mosaicReady",
       unitId: UNIT_ID,
-      athletePublicId: "7",
       masterId: MASTER_ID,
       mosaicWalrusBlobId: [9, 8, 7],
     });

--- a/apps/web/src/lib/sui/event-types.test.ts
+++ b/apps/web/src/lib/sui/event-types.test.ts
@@ -8,7 +8,6 @@ import {
 } from "./event-types";
 
 const UNIT_ID = "0xunit-1";
-const ATHLETE_ID = 7;
 const SUBMITTER = "0xsubmitter";
 const MASTER_ID = "0xmaster";
 

--- a/apps/web/src/lib/sui/event-types.ts
+++ b/apps/web/src/lib/sui/event-types.ts
@@ -9,7 +9,6 @@
  *
  * Field naming mirrors `contracts/sources/events.move`:
  *   - `unit_id`        → `unitId`           (object id, always `0x`-prefixed)
- *   - `athlete_id`     → `athletePublicId`  (decimal string; matches `@/lib/catalog`)
  *   - `walrus_blob_id` → `walrusBlobId`     (raw `vector<u8>`)
  *   - u64 counts       → `number`           (within JS safe-int range for our scale)
  */
@@ -23,7 +22,6 @@ export type RawSuiEventLike = {
 export type SubmittedEvent = {
   readonly kind: "submitted";
   readonly unitId: string;
-  readonly athletePublicId: string;
   readonly submitter: string;
   readonly walrusBlobId: readonly number[];
   readonly submissionNo: number;
@@ -34,7 +32,6 @@ export type SubmittedEvent = {
 export type UnitFilledEvent = {
   readonly kind: "filled";
   readonly unitId: string;
-  readonly athletePublicId: string;
   readonly filledCount: number;
   readonly maxSlots: number;
 };
@@ -42,7 +39,6 @@ export type UnitFilledEvent = {
 export type MosaicReadyEvent = {
   readonly kind: "mosaicReady";
   readonly unitId: string;
-  readonly athletePublicId: string;
   readonly masterId: string;
   readonly mosaicWalrusBlobId: readonly number[];
 };
@@ -54,10 +50,6 @@ export function parseSubmittedEvent(raw: RawSuiEventLike): SubmittedEvent {
   return {
     kind: "submitted",
     unitId: asString(json.unit_id, "SubmittedEvent.unit_id"),
-    athletePublicId: asAthletePublicId(
-      json.athlete_id,
-      "SubmittedEvent.athlete_id",
-    ),
     submitter: asString(json.submitter, "SubmittedEvent.submitter"),
     walrusBlobId: asByteArray(
       json.walrus_blob_id,
@@ -77,10 +69,6 @@ export function parseUnitFilledEvent(raw: RawSuiEventLike): UnitFilledEvent {
   return {
     kind: "filled",
     unitId: asString(json.unit_id, "UnitFilledEvent.unit_id"),
-    athletePublicId: asAthletePublicId(
-      json.athlete_id,
-      "UnitFilledEvent.athlete_id",
-    ),
     filledCount: asInteger(json.filled_count, "UnitFilledEvent.filled_count"),
     maxSlots: asInteger(json.max_slots, "UnitFilledEvent.max_slots"),
   };
@@ -91,10 +79,6 @@ export function parseMosaicReadyEvent(raw: RawSuiEventLike): MosaicReadyEvent {
   return {
     kind: "mosaicReady",
     unitId: asString(json.unit_id, "MosaicReadyEvent.unit_id"),
-    athletePublicId: asAthletePublicId(
-      json.athlete_id,
-      "MosaicReadyEvent.athlete_id",
-    ),
     masterId: asString(json.master_id, "MosaicReadyEvent.master_id"),
     mosaicWalrusBlobId: asByteArray(
       json.mosaic_walrus_blob_id,
@@ -125,12 +109,6 @@ function asInteger(value: unknown, label: string): number {
     return Number(value);
   }
   throw new Error(`${label} is not an integer-like value: ${String(value)}`);
-}
-
-function asAthletePublicId(value: unknown, label: string): string {
-  // `athlete_id` is u16 on-chain; surface it as the decimal string the rest
-  // of the app keys on (see `lib/catalog/types.ts`).
-  return String(asInteger(value, label));
 }
 
 function asByteArray(value: unknown, label: string): readonly number[] {

--- a/apps/web/src/lib/sui/events.test.ts
+++ b/apps/web/src/lib/sui/events.test.ts
@@ -34,7 +34,6 @@ function submittedSuiEvent(unitId: string, submissionNo = "1") {
     type: `${PACKAGE_ID}::events::SubmittedEvent`,
     parsedJson: {
       unit_id: unitId,
-      athlete_id: 1,
       submitter: "0xsender",
       walrus_blob_id: [1, 2, 3],
       submission_no: submissionNo,
@@ -50,7 +49,6 @@ function unitFilledSuiEvent(unitId: string) {
     type: `${PACKAGE_ID}::events::UnitFilledEvent`,
     parsedJson: {
       unit_id: unitId,
-      athlete_id: 1,
       filled_count: String(unitTileCount),
       max_slots: String(unitTileCount),
     },
@@ -62,7 +60,6 @@ function mosaicReadySuiEvent(unitId: string) {
     type: `${PACKAGE_ID}::events::MosaicReadyEvent`,
     parsedJson: {
       unit_id: unitId,
-      athlete_id: 1,
       master_id: "0xmaster",
       mosaic_walrus_blob_id: [9, 8, 7],
     },

--- a/apps/web/src/lib/sui/gallery.test.ts
+++ b/apps/web/src/lib/sui/gallery.test.ts
@@ -20,7 +20,6 @@ function encodeBytes(value: string): number[] {
 function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
   return {
     objectId: "0xkakera-1",
-    athletePublicId: "7",
     unitId: UNIT_ID,
     walrusBlobId: WALRUS_BLOB_ID,
     submissionNo: SUBMISSION_NO,
@@ -41,7 +40,6 @@ function unitObject(overrides: Partial<Record<string, unknown>> = {}) {
       type: "0xpkg::unit::Unit",
       fields: {
         id: { id: UNIT_ID },
-        athlete_id: 7,
         display_name: encodeBytes("Demo Athlete Seven"),
         thumbnail_url: encodeBytes("https://example.com/7.png"),
         target_walrus_blob: [],
@@ -73,7 +71,6 @@ function masterObject(overrides: Partial<Record<string, unknown>> = {}) {
       fields: {
         id: { id: MASTER_ID },
         unit_id: UNIT_ID,
-        athlete_id: 7,
         mosaic_walrus_blob_id: encodeBytes(MOSAIC_BLOB_ID),
         placements: {
           type: "0x2::table::Table<vector<u8>, 0xpkg::master_portrait::Placement>",
@@ -171,7 +168,7 @@ describe("getGalleryEntry", () => {
       }),
     ).resolves.toEqual({
       unitId: UNIT_ID,
-      athletePublicId: "7",
+      displayName: "Demo Athlete Seven",
       walrusBlobId: WALRUS_BLOB_ID,
       submissionNo: SUBMISSION_NO,
       mintedAtMs: 1700000000000,
@@ -192,7 +189,7 @@ describe("getGalleryEntry", () => {
       }),
     ).resolves.toEqual({
       unitId: UNIT_ID,
-      athletePublicId: "7",
+      displayName: "Demo Athlete Seven",
       walrusBlobId: WALRUS_BLOB_ID,
       submissionNo: SUBMISSION_NO,
       mintedAtMs: 1700000000000,
@@ -222,7 +219,7 @@ describe("getGalleryEntry", () => {
       }),
     ).resolves.toEqual({
       unitId: UNIT_ID,
-      athletePublicId: "7",
+      displayName: "Demo Athlete Seven",
       walrusBlobId: WALRUS_BLOB_ID,
       submissionNo: SUBMISSION_NO,
       mintedAtMs: 1700000000000,

--- a/apps/web/src/lib/sui/gallery.ts
+++ b/apps/web/src/lib/sui/gallery.ts
@@ -3,7 +3,7 @@
  *
  * `/gallery` needs to merge three on-chain sources:
  *   - owned Kakera metadata (`walrusBlobId`, `submissionNo`, `unitId`)
- *   - the current Unit state (`athletePublicId`, `masterId`)
+ *   - the current Unit state (`displayName`, `masterId`)
  *   - the finalized MasterPortrait placement (`blob_id -> Placement`)
  *
  * The important failure boundary is the placement reverse lookup:
@@ -76,7 +76,7 @@ export async function getGalleryEntry(args: {
   if (progress.masterId == null) {
     return {
       unitId: args.kakera.unitId,
-      athletePublicId: progress.athletePublicId,
+      displayName: progress.displayName,
       walrusBlobId: args.kakera.walrusBlobId,
       submissionNo: args.kakera.submissionNo,
       mintedAtMs: args.kakera.mintedAtMs,
@@ -95,7 +95,7 @@ export async function getGalleryEntry(args: {
 
   return {
     unitId: args.kakera.unitId,
-    athletePublicId: progress.athletePublicId,
+    displayName: progress.displayName,
     walrusBlobId: args.kakera.walrusBlobId,
     submissionNo: args.kakera.submissionNo,
     mintedAtMs: args.kakera.mintedAtMs,

--- a/apps/web/src/lib/sui/kakera.test.ts
+++ b/apps/web/src/lib/sui/kakera.test.ts
@@ -45,7 +45,6 @@ function kakeraObject(overrides: {
         fields: {
           id: { id: overrides.objectId ?? "0xkakera-1" },
           unit_id: UNIT_ID,
-          athlete_id: 1,
           submitter: OWNER,
           walrus_blob_id: encodeBytes(WALRUS_BLOB_ID),
           submission_no: "42",
@@ -137,7 +136,6 @@ describe("listOwnedKakera", () => {
     ).resolves.toEqual([
       {
         objectId: "0xkakera-1",
-        athletePublicId: "1",
         unitId: UNIT_ID,
         walrusBlobId: WALRUS_BLOB_ID,
         submissionNo: 42,
@@ -145,7 +143,6 @@ describe("listOwnedKakera", () => {
       },
       {
         objectId: "0xkakera-2",
-        athletePublicId: "1",
         unitId: "0xunit-2",
         walrusBlobId: WALRUS_BLOB_ID,
         submissionNo: 42,
@@ -172,7 +169,6 @@ describe("listOwnedKakera", () => {
     ).resolves.toEqual([
       {
         objectId: "0xkakera-real",
-        athletePublicId: "1",
         unitId: UNIT_ID,
         walrusBlobId: WALRUS_BLOB_ID,
         submissionNo: 42,
@@ -217,7 +213,6 @@ describe("listOwnedKakera", () => {
     ).resolves.toEqual([
       {
         objectId: "0xkakera-real",
-        athletePublicId: "1",
         unitId: UNIT_ID,
         walrusBlobId: WALRUS_BLOB_ID,
         submissionNo: 42,
@@ -255,7 +250,6 @@ describe("findOwnedKakeraForUnit", () => {
       }),
     ).resolves.toEqual({
       objectId: "0xunit-2-kakera",
-      athletePublicId: "1",
       unitId: "0xunit-2",
       walrusBlobId: WALRUS_BLOB_ID,
       submissionNo: 42,
@@ -296,7 +290,6 @@ describe("findKakeraForSubmission", () => {
 
     expect(result).not.toBeNull();
     expect(result?.objectId).toBe("0xkakera-1");
-    expect(result?.athletePublicId).toBe("1");
     expect(result?.unitId).toBe(UNIT_ID);
     expect(result?.walrusBlobId).toBe(WALRUS_BLOB_ID);
     expect(result?.submissionNo).toBe(42);

--- a/apps/web/src/lib/sui/kakera.ts
+++ b/apps/web/src/lib/sui/kakera.ts
@@ -24,7 +24,6 @@ export type KakeraOwnedClient = {
 
 export type OwnedKakera = {
   readonly objectId: string;
-  readonly athletePublicId: string;
   readonly unitId: string;
   readonly walrusBlobId: string;
   readonly submissionNo: number;
@@ -244,11 +243,6 @@ function parseOwnedKakera(
     return null;
   }
 
-  const athletePublicId = readAthletePublicId(fields.athlete_id);
-  if (athletePublicId == null) {
-    return null;
-  }
-
   const walrusBlobId = readVectorU8AsString(fields.walrus_blob_id);
   if (walrusBlobId == null) {
     return null;
@@ -256,20 +250,9 @@ function parseOwnedKakera(
 
   return {
     objectId,
-    athletePublicId,
     unitId,
     walrusBlobId,
     submissionNo: readIntegerField(fields.submission_no),
     mintedAtMs: readIntegerField(fields.minted_at_ms),
   };
-}
-
-function readAthletePublicId(value: unknown): string | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-  if (typeof value === "string" && /^[0-9]+$/.test(value)) {
-    return value;
-  }
-  return null;
 }

--- a/apps/web/src/lib/sui/registry.test.ts
+++ b/apps/web/src/lib/sui/registry.test.ts
@@ -94,20 +94,16 @@ describe("listRegistryAthletes", () => {
       listRegistryAthletes({ client, registryObjectId: REGISTRY_ID }),
     ).resolves.toEqual([
       {
-        athletePublicId: "1",
         currentUnitId: UNIT_ONE,
         metadata: {
-          athletePublicId: "1",
           displayName: "Demo Athlete One",
           slug: "unit-unit-1",
           thumbnailUrl: "https://example.com/1.png",
         },
       },
       {
-        athletePublicId: "2",
         currentUnitId: UNIT_TWO,
         metadata: {
-          athletePublicId: "2",
           displayName: "Demo Athlete Two",
           slug: "unit-unit-2",
           thumbnailUrl: "https://example.com/2.png",
@@ -148,7 +144,6 @@ describe("getActiveHomeUnits", () => {
       getActiveHomeUnits({ client, registryObjectId: REGISTRY_ID }),
     ).resolves.toEqual([
       {
-        athletePublicId: "1",
         displayName: "Demo Athlete One",
         maxSlots: 2000,
         submittedCount: 1997,
@@ -179,7 +174,7 @@ function registryObject(fields: Record<string, unknown>) {
 
 function unitObject(
   unitId: string,
-  athleteId: number,
+  thumbnailIndex: number,
   displayName: string,
   overrides: Record<string, unknown> = {},
 ) {
@@ -194,9 +189,8 @@ function unitObject(
       type: "0xpkg::unit::Unit",
       fields: {
         id: { id: unitId },
-        athlete_id: athleteId,
         display_name: bytes(displayName),
-        thumbnail_url: bytes(`https://example.com/${athleteId}.png`),
+        thumbnail_url: bytes(`https://example.com/${thumbnailIndex}.png`),
         target_walrus_blob: bytes("target-blob"),
         max_slots: "2000",
         display_max_slots: "2000",

--- a/apps/web/src/lib/sui/registry.ts
+++ b/apps/web/src/lib/sui/registry.ts
@@ -2,7 +2,6 @@ import { getPublicEnvSource, loadPublicEnv } from "../env";
 import { getSuiClient, type SuiReadClient } from "./client";
 import type {
   ActiveHomeUnitView,
-  AthleteMetadataView,
   RegistryAthleteView,
   RegistryView,
 } from "./types";
@@ -66,14 +65,12 @@ export async function listRegistryAthletes(
       try {
         const unit = await getUnitProgress(unitId, { client });
         return {
-          athletePublicId: unit.athletePublicId,
           currentUnitId: unit.unitId,
           metadata: {
-            athletePublicId: unit.athletePublicId,
             displayName: unit.displayName,
             slug: buildSyntheticSlug(unit.unitId),
             thumbnailUrl: unit.thumbnailUrl,
-          } satisfies AthleteMetadataView,
+          },
         } satisfies RegistryAthleteView;
       } catch (error) {
         console.error(`Failed to load registry unit ${unitId}`, error);
@@ -104,7 +101,6 @@ export async function getActiveHomeUnits(
         }
 
         return {
-          athletePublicId: unit.athletePublicId,
           displayName: unit.displayName,
           maxSlots: unit.maxSlots,
           submittedCount: unit.submittedCount,

--- a/apps/web/src/lib/sui/submission-execution.test.ts
+++ b/apps/web/src/lib/sui/submission-execution.test.ts
@@ -29,7 +29,6 @@ function kakeraObject() {
         fields: {
           id: { id: "0xkakera-1" },
           unit_id: UNIT_ID,
-          athlete_id: 1,
           submitter: OWNER,
           walrus_blob_id: encodeBytes(WALRUS_BLOB_ID),
           submission_no: "42",
@@ -123,7 +122,6 @@ describe("checkSubmissionExecution", () => {
       status: "success",
       kakera: {
         objectId: "0xkakera-1",
-        athletePublicId: "1",
         unitId: UNIT_ID,
         walrusBlobId: WALRUS_BLOB_ID,
         submissionNo: 42,

--- a/apps/web/src/lib/sui/types.ts
+++ b/apps/web/src/lib/sui/types.ts
@@ -1,25 +1,20 @@
-import type { AthletePublicId } from "../catalog/types";
-
 export type RegistryView = {
   readonly objectId: string;
   readonly unitIds: readonly string[];
 };
 
 export type AthleteMetadataView = {
-  readonly athletePublicId: AthletePublicId;
   readonly displayName: string;
   readonly slug: string;
   readonly thumbnailUrl: string;
 };
 
 export type RegistryAthleteView = {
-  readonly athletePublicId: AthletePublicId;
   readonly currentUnitId: string;
   readonly metadata: AthleteMetadataView;
 };
 
 export type ActiveHomeUnitView = {
-  readonly athletePublicId: AthletePublicId;
   readonly displayName: string;
   readonly maxSlots: number;
   readonly submittedCount: number;
@@ -42,7 +37,6 @@ export type UnitStatus = "pending" | "filled" | "finalized";
  *   - `masterId`: `null` until the unit reaches `finalized`.
  */
 export type AthleteProgressView = {
-  readonly athletePublicId: AthletePublicId;
   readonly displayName: string;
   readonly masterId: string | null;
   readonly maxSlots: number;
@@ -70,7 +64,7 @@ export type MasterPlacementLookupView = {
 export type GalleryEntryView =
   | {
       readonly unitId: string;
-      readonly athletePublicId: AthletePublicId;
+      readonly displayName: string;
       readonly walrusBlobId: string;
       readonly submissionNo: number;
       readonly mintedAtMs: number;
@@ -81,7 +75,7 @@ export type GalleryEntryView =
     }
   | {
       readonly unitId: string;
-      readonly athletePublicId: AthletePublicId;
+      readonly displayName: string;
       readonly walrusBlobId: string;
       readonly submissionNo: number;
       readonly mintedAtMs: number;

--- a/apps/web/src/lib/sui/unit.test.ts
+++ b/apps/web/src/lib/sui/unit.test.ts
@@ -33,7 +33,6 @@ function unitData(fields: Record<string, unknown>) {
       type: "0xpkg::unit::Unit",
       fields: {
         id: { id: UNIT_ID },
-        athlete_id: 1,
         display_name: bytes("Demo Athlete One"),
         thumbnail_url: bytes("https://example.com/1.png"),
         target_walrus_blob: [],
@@ -62,7 +61,6 @@ describe("getUnitProgress", () => {
 
     await expect(getUnitProgress(UNIT_ID, { client })).resolves.toEqual({
       unitId: UNIT_ID,
-      athletePublicId: "1",
       displayName: "Demo Athlete One",
       masterId: null,
       maxSlots: 2000,

--- a/apps/web/src/lib/sui/unit.ts
+++ b/apps/web/src/lib/sui/unit.ts
@@ -37,14 +37,10 @@ export async function getUnitProgress(
     parseOptionalIntegerField(fields.display_max_slots) ?? realMaxSlots;
   const submittedCount =
     Math.max(0, displayMaxSlots - realMaxSlots) + realSubmittedCount;
-  const athletePublicId = String(
-    parseIntegerField(fields.athlete_id, "athlete_id"),
-  );
   const masterId = extractOptionalId(fields.master_id);
 
   return {
     unitId: data.objectId,
-    athletePublicId,
     displayName: readVectorU8AsString(fields.display_name, "display_name"),
     submittedCount,
     masterId,

--- a/apps/web/src/lib/sui/use-owned-kakera.test.ts
+++ b/apps/web/src/lib/sui/use-owned-kakera.test.ts
@@ -26,7 +26,6 @@ const WALRUS_BLOB_ID = "walrus-blob-xyz";
 function makeKakera(): OwnedKakera {
   return {
     objectId: "0xkakera-1",
-    athletePublicId: "1",
     unitId: UNIT_ID,
     walrusBlobId: WALRUS_BLOB_ID,
     submissionNo: 42,

--- a/apps/web/tests/e2e/fixtures/mock-network.ts
+++ b/apps/web/tests/e2e/fixtures/mock-network.ts
@@ -462,7 +462,6 @@ function handleGetObject(
           hasPublicTransfer: false,
           fields: {
             id: { id: STUB_UNIT_ID },
-            athlete_id: Number(STUB_ATHLETE_ID),
             display_name: Array.from(
               new TextEncoder().encode("Demo Athlete One"),
             ),
@@ -507,7 +506,6 @@ function handleGetObject(
           fields: {
             id: { id: STUB_MASTER_ID },
             unit_id: STUB_UNIT_ID,
-            athlete_id: Number(STUB_ATHLETE_ID),
             mosaic_walrus_blob_id: Array.from(
               new TextEncoder().encode(STUB_MOSAIC_BLOB_ID),
             ),
@@ -645,7 +643,6 @@ function handleOwnedObjects(
             hasPublicTransfer: false,
             fields: {
               id: { id: STUB_KAKERA_OBJECT_ID },
-              athlete_id: STUB_ATHLETE_ID,
               unit_id: STUB_UNIT_ID,
               walrus_blob_id: blobBytes,
               submission_no: STUB_SUBMISSION_NO,
@@ -725,7 +722,6 @@ function makeSubmittedEvent(opts: {
     eventSeq: opts.eventSeq,
     parsedJson: {
       unit_id: STUB_UNIT_ID,
-      athlete_id: STUB_ATHLETE_ID,
       submitter: E2E_STUB_ACCOUNT_ADDRESS,
       walrus_blob_id: Array.from(new TextEncoder().encode(STUB_BLOB_ID)),
       submission_no: STUB_SUBMISSION_NO,
@@ -743,7 +739,6 @@ function makeUnitFilledEvent(opts: {
     eventSeq: opts.eventSeq,
     parsedJson: {
       unit_id: STUB_UNIT_ID,
-      athlete_id: STUB_ATHLETE_ID,
       filled_count: unitTileCount,
       max_slots: unitTileCount,
     },
@@ -758,7 +753,6 @@ function makeMosaicReadyEvent(opts: {
     eventSeq: opts.eventSeq,
     parsedJson: {
       unit_id: STUB_UNIT_ID,
-      athlete_id: STUB_ATHLETE_ID,
       master_id: STUB_MASTER_ID,
       mosaic_walrus_blob_id: Array.from(
         new TextEncoder().encode(STUB_MOSAIC_BLOB_ID),

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -7,6 +7,11 @@ import {
   TINY_JPEG_NAME,
 } from "./fixtures/tiny-jpeg";
 
+const DEMO_UNIT_ID =
+  "0x00000000000000000000000000000000000000000000000000000000000000d2";
+const DEMO_SECOND_UNIT_ID =
+  "0x00000000000000000000000000000000000000000000000000000000000000d4";
+
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
@@ -141,7 +146,9 @@ test.describe("readiness regression", () => {
     await installDefaultMocks(page);
     await page.setViewportSize({ width: 390, height: 844 });
 
-    await page.goto("/?op_e2e_home_card_state=1:waiting,2:unavailable");
+    await page.goto(
+      `/?op_e2e_home_card_state=${DEMO_UNIT_ID}:waiting,${DEMO_SECOND_UNIT_ID}:unavailable`,
+    );
 
     await expect(page.getByText(/待機中|No active unit/i)).toBeVisible();
     await expect(

--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,7 @@
       "biome.json",
       "!apps/web/.next",
       "!apps/web/.open-next",
+      "!apps/web/.e2e-xdg",
       "!apps/web/.wrangler",
       "!apps/web/playwright-report",
       "!apps/web/test-results",

--- a/contracts/sources/admin_api.move
+++ b/contracts/sources/admin_api.move
@@ -7,7 +7,6 @@ use one_portrait::unit::{Self as unit, Unit};
 public fun create_unit(
     admin_cap: &AdminCap,
     registry: &mut Registry,
-    athlete_id: u16,
     display_name: vector<u8>,
     thumbnail_url: vector<u8>,
     target_walrus_blob: vector<u8>,
@@ -18,7 +17,6 @@ public fun create_unit(
     unit::create_unit(
         admin_cap,
         registry,
-        athlete_id,
         display_name,
         thumbnail_url,
         target_walrus_blob,

--- a/contracts/sources/events.move
+++ b/contracts/sources/events.move
@@ -5,7 +5,6 @@ use sui::event;
 
 public struct SubmittedEvent has copy, drop {
     unit_id: ID,
-    athlete_id: u16,
     submitter: address,
     walrus_blob_id: vector<u8>,
     submission_no: u64,
@@ -15,21 +14,18 @@ public struct SubmittedEvent has copy, drop {
 
 public struct UnitFilledEvent has copy, drop {
     unit_id: ID,
-    athlete_id: u16,
     filled_count: u64,
     max_slots: u64,
 }
 
 public struct MosaicReadyEvent has copy, drop {
     unit_id: ID,
-    athlete_id: u16,
     master_id: ID,
     mosaic_walrus_blob_id: vector<u8>,
 }
 
 public(package) fun emit_submitted(
     unit_id: ID,
-    athlete_id: u16,
     submitter: address,
     walrus_blob_id: vector<u8>,
     submission_no: u64,
@@ -38,7 +34,6 @@ public(package) fun emit_submitted(
 ) {
     event::emit(SubmittedEvent {
         unit_id,
-        athlete_id,
         submitter,
         walrus_blob_id,
         submission_no,
@@ -49,13 +44,11 @@ public(package) fun emit_submitted(
 
 public(package) fun emit_unit_filled(
     unit_id: ID,
-    athlete_id: u16,
     filled_count: u64,
     max_slots: u64,
 ) {
     event::emit(UnitFilledEvent {
         unit_id,
-        athlete_id,
         filled_count,
         max_slots,
     });
@@ -63,13 +56,11 @@ public(package) fun emit_unit_filled(
 
 public(package) fun emit_mosaic_ready(
     unit_id: ID,
-    athlete_id: u16,
     master_id: ID,
     mosaic_walrus_blob_id: vector<u8>,
 ) {
     event::emit(MosaicReadyEvent {
         unit_id,
-        athlete_id,
         master_id,
         mosaic_walrus_blob_id,
     });
@@ -78,11 +69,6 @@ public(package) fun emit_mosaic_ready(
 #[test_only]
 public fun submitted_event_unit_id_for_testing(event: &SubmittedEvent): ID {
     event.unit_id
-}
-
-#[test_only]
-public fun submitted_event_athlete_id_for_testing(event: &SubmittedEvent): u16 {
-    event.athlete_id
 }
 
 #[test_only]
@@ -116,11 +102,6 @@ public fun unit_filled_event_unit_id_for_testing(event: &UnitFilledEvent): ID {
 }
 
 #[test_only]
-public fun unit_filled_event_athlete_id_for_testing(event: &UnitFilledEvent): u16 {
-    event.athlete_id
-}
-
-#[test_only]
 public fun unit_filled_event_filled_count_for_testing(event: &UnitFilledEvent): u64 {
     event.filled_count
 }
@@ -133,11 +114,6 @@ public fun unit_filled_event_max_slots_for_testing(event: &UnitFilledEvent): u64
 #[test_only]
 public fun mosaic_ready_event_unit_id_for_testing(event: &MosaicReadyEvent): ID {
     event.unit_id
-}
-
-#[test_only]
-public fun mosaic_ready_event_athlete_id_for_testing(event: &MosaicReadyEvent): u16 {
-    event.athlete_id
 }
 
 #[test_only]

--- a/contracts/sources/kakera.move
+++ b/contracts/sources/kakera.move
@@ -4,7 +4,6 @@ module one_portrait::kakera;
 public struct Kakera has key {
     id: UID,
     unit_id: ID,
-    athlete_id: u16,
     submitter: address,
     walrus_blob_id: vector<u8>,
     submission_no: u64,
@@ -13,7 +12,6 @@ public struct Kakera has key {
 
 public(package) fun mint_and_transfer(
     unit_id: ID,
-    athlete_id: u16,
     submitter: address,
     walrus_blob_id: vector<u8>,
     submission_no: u64,
@@ -24,7 +22,6 @@ public(package) fun mint_and_transfer(
         Kakera {
             id: object::new(ctx),
             unit_id,
-            athlete_id,
             submitter,
             walrus_blob_id,
             submission_no,
@@ -37,11 +34,6 @@ public(package) fun mint_and_transfer(
 #[test_only]
 public fun unit_id_for_testing(kakera: &Kakera): ID {
     kakera.unit_id
-}
-
-#[test_only]
-public fun athlete_id_for_testing(kakera: &Kakera): u16 {
-    kakera.athlete_id
 }
 
 #[test_only]

--- a/contracts/sources/master_portrait.move
+++ b/contracts/sources/master_portrait.move
@@ -6,7 +6,6 @@ use sui::table::{Self as table, Table};
 public struct MasterPortrait has key, store {
     id: UID,
     unit_id: ID,
-    athlete_id: u16,
     mosaic_walrus_blob_id: vector<u8>,
     placements: Table<vector<u8>, Placement>,
 }
@@ -56,7 +55,6 @@ public(package) fun placement_input_submission_no(input: &PlacementInput): u64 {
 
 public(package) fun create(
     unit_id: ID,
-    athlete_id: u16,
     mosaic_walrus_blob_id: vector<u8>,
     mut placement_inputs: vector<PlacementInput>,
     ctx: &mut TxContext,
@@ -85,7 +83,6 @@ public(package) fun create(
     MasterPortrait {
         id: object::new(ctx),
         unit_id,
-        athlete_id,
         mosaic_walrus_blob_id,
         placements,
     }
@@ -93,7 +90,6 @@ public(package) fun create(
 
 public(package) fun create_and_transfer(
     unit_id: ID,
-    athlete_id: u16,
     mosaic_walrus_blob_id: vector<u8>,
     placement_inputs: vector<PlacementInput>,
     recipient: address,
@@ -101,7 +97,6 @@ public(package) fun create_and_transfer(
 ): ID {
     let master = create(
         unit_id,
-        athlete_id,
         mosaic_walrus_blob_id,
         placement_inputs,
         ctx,
@@ -114,11 +109,6 @@ public(package) fun create_and_transfer(
 #[test_only]
 public fun unit_id_for_testing(master: &MasterPortrait): ID {
     master.unit_id
-}
-
-#[test_only]
-public fun athlete_id_for_testing(master: &MasterPortrait): u16 {
-    master.athlete_id
 }
 
 #[test_only]

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -22,7 +22,6 @@ const EINVALID_PLACEMENTS: u64 = 8;
 
 public struct Unit has key {
     id: UID,
-    athlete_id: u16,
     display_name: vector<u8>,
     thumbnail_url: vector<u8>,
     target_walrus_blob: vector<u8>,
@@ -44,7 +43,6 @@ public struct SubmissionRef has copy, drop, store {
 public(package) fun create_unit(
     admin_cap: &AdminCap,
     registry: &mut Registry,
-    athlete_id: u16,
     display_name: vector<u8>,
     thumbnail_url: vector<u8>,
     target_walrus_blob: vector<u8>,
@@ -60,7 +58,6 @@ public(package) fun create_unit(
 
     let unit = Unit {
         id: object::new(ctx),
-        athlete_id,
         display_name,
         thumbnail_url,
         target_walrus_blob,
@@ -112,7 +109,6 @@ public(package) fun submit_photo(
 
     kakera::mint_and_transfer(
         object::id(unit),
-        unit.athlete_id,
         submitter,
         copy walrus_blob_id,
         submission_no,
@@ -121,7 +117,6 @@ public(package) fun submit_photo(
     );
     events::emit_submitted(
         object::id(unit),
-        unit.athlete_id,
         submitter,
         walrus_blob_id,
         submission_no,
@@ -131,16 +126,10 @@ public(package) fun submit_photo(
     if (filled_now) {
         events::emit_unit_filled(
             object::id(unit),
-            unit.athlete_id,
             unit.display_max_slots,
             unit.display_max_slots,
         );
     };
-}
-
-#[test_only]
-public fun athlete_id_for_testing(unit: &Unit): u16 {
-    unit.athlete_id
 }
 
 #[test_only]
@@ -280,7 +269,6 @@ public(package) fun finalize(
 
     let master_id = master_portrait::create_and_transfer(
         object::id(unit),
-        unit.athlete_id,
         copy mosaic_blob_id,
         placements,
         tx_context::sender(ctx),
@@ -292,7 +280,6 @@ public(package) fun finalize(
 
     events::emit_mosaic_ready(
         object::id(unit),
-        unit.athlete_id,
         master_id,
         mosaic_blob_id,
     );

--- a/contracts/tests/finalize_tests.move
+++ b/contracts/tests/finalize_tests.move
@@ -18,7 +18,6 @@ fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
     let publisher = @0xA11CE;
     let first_submitter = @0xF21;
     let second_submitter = @0xF22;
-    let athlete_id = 15;
     let mosaic_blob_id = b"mosaic-blob";
 
     let mut scenario = test_scenario::begin(publisher);
@@ -32,7 +31,6 @@ fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         b"Demo Athlete Fifteen",
         b"https://example.com/15.png",
         b"target-blob",
@@ -93,10 +91,6 @@ fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
         unit_id
     );
     assert_eq!(
-        portrait_events::mosaic_ready_event_athlete_id_for_testing(&mosaic_ready_event),
-        athlete_id
-    );
-    assert_eq!(
         portrait_events::mosaic_ready_event_master_id_for_testing(&mosaic_ready_event),
         master_id
     );
@@ -116,7 +110,6 @@ fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
     let master = scenario.take_from_sender<MasterPortrait>();
     assert_eq!(object::id(&master), master_id);
     assert_eq!(master_portrait::unit_id_for_testing(&master), unit_id);
-    assert_eq!(master_portrait::athlete_id_for_testing(&master), athlete_id);
     assert_eq!(
         master_portrait::mosaic_walrus_blob_id_for_testing(&master),
         mosaic_blob_id
@@ -171,7 +164,6 @@ fun finalize_rejects_pending_unit() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        16,
         b"Demo Athlete Sixteen",
         b"https://example.com/16.png",
         b"target-blob",
@@ -217,7 +209,6 @@ fun finalize_rejects_double_finalize() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        17,
         b"Demo Athlete Seventeen",
         b"https://example.com/17.png",
         b"target-blob",
@@ -310,7 +301,6 @@ fun finalize_rejects_mismatched_placements() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        19,
         b"Demo Athlete Nineteen",
         b"https://example.com/19.png",
         b"target-blob",

--- a/contracts/tests/registry_admin_tests.move
+++ b/contracts/tests/registry_admin_tests.move
@@ -29,7 +29,6 @@ fun init_creates_admin_cap_and_shared_registry() {
 #[test]
 fun create_unit_sets_initial_state_and_appends_registry_index() {
     let publisher = @0xA11CE;
-    let athlete_id = 7;
     let max_slots = 500;
     let display_max_slots = 2_000;
     let target_blob = b"target-blob";
@@ -46,7 +45,6 @@ fun create_unit_sets_initial_state_and_appends_registry_index() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         display_name,
         thumbnail_url,
         target_blob,
@@ -64,7 +62,6 @@ fun create_unit_sets_initial_state_and_appends_registry_index() {
     let unit = scenario.take_shared_by_id<Unit>(unit_id);
 
     assert_eq!(object::id(&unit), unit_id);
-    assert_eq!(unit::athlete_id_for_testing(&unit), athlete_id);
     assert_eq!(unit::display_name_for_testing(&unit), display_name);
     assert_eq!(unit::thumbnail_url_for_testing(&unit), thumbnail_url);
     assert_eq!(unit::max_slots_for_testing(&unit), max_slots);
@@ -95,7 +92,6 @@ fun create_unit_keeps_existing_units_in_registry_order() {
     let first_unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        9,
         b"Demo Athlete Nine",
         b"https://example.com/9.png",
         b"target-1",
@@ -114,7 +110,6 @@ fun create_unit_keeps_existing_units_in_registry_order() {
     let second_unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        9,
         b"Demo Athlete Nine Encore",
         b"https://example.com/9b.png",
         b"target-2",

--- a/contracts/tests/submit_photo_tests.move
+++ b/contracts/tests/submit_photo_tests.move
@@ -16,7 +16,6 @@ use sui::test_scenario;
 fun submit_photo_mints_kakera_records_submission_and_emits_event() {
     let publisher = @0xA11CE;
     let submitter = @0xF0A;
-    let athlete_id = 11;
     let max_slots = 500;
     let target_blob = b"target-blob";
     let walrus_blob_id = b"photo-blob";
@@ -33,7 +32,6 @@ fun submit_photo_mints_kakera_records_submission_and_emits_event() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         b"Demo Athlete Eleven",
         b"https://example.com/11.png",
         target_blob,
@@ -77,10 +75,6 @@ fun submit_photo_mints_kakera_records_submission_and_emits_event() {
     let submitted_event = submitted_events[0];
     assert_eq!(portrait_events::submitted_event_unit_id_for_testing(&submitted_event), unit_id);
     assert_eq!(
-        portrait_events::submitted_event_athlete_id_for_testing(&submitted_event),
-        athlete_id
-    );
-    assert_eq!(
         portrait_events::submitted_event_submitter_for_testing(&submitted_event),
         submitter
     );
@@ -109,7 +103,6 @@ fun submit_photo_mints_kakera_records_submission_and_emits_event() {
 
     let kakera = scenario.take_from_sender<Kakera>();
     assert_eq!(kakera::unit_id_for_testing(&kakera), unit_id);
-    assert_eq!(kakera::athlete_id_for_testing(&kakera), athlete_id);
     assert_eq!(kakera::submitter_for_testing(&kakera), submitter);
     assert_eq!(kakera::walrus_blob_id_for_testing(&kakera), walrus_blob_id);
     assert_eq!(kakera::submission_no_for_testing(&kakera), 1);
@@ -131,7 +124,6 @@ fun submit_photo_mints_kakera_records_submission_and_emits_event() {
 fun submit_photo_rejects_duplicate_submission_from_same_sender() {
     let publisher = @0xA11CE;
     let submitter = @0xF0A;
-    let athlete_id = 12;
 
     let mut scenario = test_scenario::begin(publisher);
     test_scenario::create_system_objects(&mut scenario);
@@ -144,7 +136,6 @@ fun submit_photo_rejects_duplicate_submission_from_same_sender() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         b"Demo Athlete Twelve",
         b"https://example.com/12.png",
         b"target-blob",
@@ -186,7 +177,6 @@ fun submit_photo_marks_unit_filled_and_emits_unit_filled_event_on_last_slot() {
     let publisher = @0xA11CE;
     let first_submitter = @0xF01;
     let second_submitter = @0xF02;
-    let athlete_id = 13;
     let max_slots = 2;
     let display_max_slots = 5;
 
@@ -201,7 +191,6 @@ fun submit_photo_marks_unit_filled_and_emits_unit_filled_event_on_last_slot() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         b"Demo Athlete Thirteen",
         b"https://example.com/13.png",
         b"target-blob",
@@ -256,10 +245,6 @@ fun submit_photo_marks_unit_filled_and_emits_unit_filled_event_on_last_slot() {
     let filled_event = filled_events[0];
     assert_eq!(portrait_events::unit_filled_event_unit_id_for_testing(&filled_event), unit_id);
     assert_eq!(
-        portrait_events::unit_filled_event_athlete_id_for_testing(&filled_event),
-        athlete_id
-    );
-    assert_eq!(
         portrait_events::unit_filled_event_filled_count_for_testing(&filled_event),
         display_max_slots
     );
@@ -292,7 +277,6 @@ fun submit_photo_rejects_submission_after_unit_is_filled() {
     let first_submitter = @0xF11;
     let second_submitter = @0xF12;
     let third_submitter = @0xF13;
-    let athlete_id = 14;
 
     let mut scenario = test_scenario::begin(publisher);
     test_scenario::create_system_objects(&mut scenario);
@@ -305,7 +289,6 @@ fun submit_photo_rejects_submission_after_unit_is_filled() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        athlete_id,
         b"Demo Athlete Fourteen",
         b"https://example.com/14.png",
         b"target-blob",
@@ -361,7 +344,6 @@ fun submit_photo_rejects_duplicate_blob_id_from_different_submitter() {
     let unit_id = admin_api::create_unit(
         &admin_cap,
         &mut registry,
-        18,
         b"Demo Athlete Eighteen",
         b"https://example.com/18.png",
         b"target-blob",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -41,7 +41,7 @@
 
 ### 3.5 欠片NFT（参加者への配布）
 完成した作品をファン自身の誇りとして残すため、2,000人の参加者それぞれに **欠片NFT**（モザイクの1片） を自動発行する。
-* **内容:** 自分の投稿写真の `walrus_blob_id`、`unit_id`、`athlete_id`、投稿順を表す `submission_no` (1〜2,000)、投稿時刻、紐づく Master Portrait 参照を保持する。座標 `(x, y)` は直接持たず、完成後に `MasterPortrait.placements` を `blob_id` で逆引きして解決する。
+* **内容:** 自分の投稿写真の `walrus_blob_id`、`unit_id`、投稿順を表す `submission_no` (1〜2,000)、投稿時刻、紐づく Master Portrait 参照を保持する。座標 `(x, y)` は直接持たず、完成後に `MasterPortrait.placements` を `blob_id` で逆引きして解決する。表示名は Unit の `display_name` を正本にする。
 * **Soulbound（譲渡不可）:** 転売・移転を禁止する実装として、Move の型レベルで `store` 能力を付与しない設計を採用する。非営利ミッションと整合し、「ファンの証」としての意味を保全する。
 * **発行タイミング:** `submit_photo` と同一トランザクションで即時発行する。投稿が成功した時点で、参加者は自分のKakeraを受け取る。
 * **表示:** 欠片NFTを開くと、完成後は自分のマスがハイライトされた状態で Master Portrait 全体を閲覧できる。未完成ユニットでは「完成待ち」として表示する。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -24,8 +24,8 @@
    │  UnitFilled 検知 → POST /api/finalize
    ▼
 [Sui Testnet: Move package one_portrait]
-   ├─ Registry (shared): athlete_id -> current_unit_id
-   ├─ Unit (shared): athlete_id / target_walrus_blob / 状態 / submitters / submissions / master_id?
+   ├─ Registry (shared): unit_ids
+   ├─ Unit (shared): display_name / target_walrus_blob / 状態 / submitters / submissions / master_id?
    ├─ MasterPortrait (運営保有, 将来選手移管): placements Table<blob_id, Placement>
    └─ Kakera (Soulbound, ファン保有): blob_id, submission_no, unit_id
 
@@ -125,8 +125,8 @@ one_portrait/
 | モジュール | 主要型 | 責務 |
 | :--- | :--- | :--- |
 | `registry` | `Registry` (shared) | 作成済み `Unit` の ID 一覧を保持し、home / admin が同じ一覧をたどれるようにする。 |
-| `unit` | `Unit` (shared), `SubmissionRef` | `athlete_id`、表示名、サムネイル、`target_walrus_blob`、進捗カウンター、`submitters` Table による重複チェック、順序付き `submissions`、`status` 遷移、`master_id` 保持。公開 API から委譲される内部状態遷移を担う。 |
-| `kakera` | `Kakera` (key only, Soulbound) | ファン投稿時に即時 mint → sender へ transfer。`{ unit_id, athlete_id, submitter, walrus_blob_id, submission_no, minted_at_ms }` を保持。座標は持たない。 |
+| `unit` | `Unit` (shared), `SubmissionRef` | 表示名、サムネイル、`target_walrus_blob`、進捗カウンター、`submitters` Table による重複チェック、順序付き `submissions`、`status` 遷移、`master_id` 保持。公開 API から委譲される内部状態遷移を担う。 |
+| `kakera` | `Kakera` (key only, Soulbound) | ファン投稿時に即時 mint → sender へ transfer。`{ unit_id, submitter, walrus_blob_id, submission_no, minted_at_ms }` を保持。座標は持たない。 |
 | `master_portrait` | `MasterPortrait` (key+store), `Placement` | 完成モザイクNFT。`placements: Table<blob_id, Placement>` で blob_id → `(x, y, submitter, submission_no)` を逆引き可能にする。MVPは運営保有、将来選手移管。 |
 | `events` | `SubmittedEvent` / `UnitFilledEvent` / `MosaicReadyEvent` | クライアント購読用。進捗表示・リビール遷移のトリガー。 |
 | `admin_api` | - | 管理者向け `create_unit` / `finalize` のみを公開し、配置入力の構築は package 内 helper に閉じる。 |
@@ -136,7 +136,6 @@ one_portrait/
 - `Registry`
   - shared object。`unit_ids: vector<ID>` を持ち、作成済み `Unit` の一覧を指す。
 - `Unit`
-  - `athlete_id: u16`
   - `display_name`
   - `thumbnail_url`
   - `target_walrus_blob`
@@ -153,7 +152,6 @@ one_portrait/
   - `submitted_at_ms`
 - `Kakera`
   - `unit_id`
-  - `athlete_id`
   - `submitter`
   - `walrus_blob_id`
   - `submission_no`
@@ -195,7 +193,7 @@ one_portrait/
 
 | ルート | 責務 |
 | :--- | :--- |
-| `/` | `Registry` から各選手の `current_unit_id` を取得し、off-chain catalog で選手メタデータを解決して一覧表示する。 |
+| `/` | `Registry` の `unit_ids` から Unit を取得し、Unit の表示名とサムネイルで一覧表示する。demo catalog がある場合は `unitId` で表示補助情報を解決する。 |
 | `/units/[unitId]` | 待機ページ。`submitted_count / max_slots` のみ表示（モザイクは非公開）。アップロード前に原画像公開性への明示同意を必須にする。投稿完了時に自ウォレットの Kakera を `getOwnedObjects` で取得し「あなたの欠片」として表示（localStorage 非依存）。Sui WebSocket で `SubmittedEvent`→カウンタ更新、`UnitFilledEvent`→`/api/finalize` 発火、`MosaicReadyEvent`→Framer Motion でリビール演出 + Master から自分のマスを逆引きハイライト。 |
 | `/gallery` | 保有 Kakera を `getOwnedObjects` で取得。`master_id` 未設定ユニットは「完成待ち」、設定済みは MasterPortrait を取得して `placements[blob_id]` を逆引き → 座標・`submission_no` を表示。元写真が取得できる間は表示し、取得不能後は完成作品と欠片メタデータを表示する。SWR / sessionStorage でキャッシュ。 |
 | `/api/og/[kakeraId]` | Satori で SNS共有用 OG 画像生成。 |
@@ -302,7 +300,7 @@ one_portrait/
 
 | 優先度 | 項目 |
 | :--- | :--- |
-| P0 | `Registry` による `athlete_id -> current_unit_id` 解決と off-chain catalog による選手表示 |
+| P0 | `Registry.unit_ids` から Unit を取得し、`display_name` と `thumbnail_url` で選手表示 |
 | P0 | zkLogin、写真アップロード、`submit_photo` + Kakera即時mint（同一Tx） |
 | P0 | 原画像公開性への明示同意UI |
 | P0 | 進捗カウンター購読、ブラウザ分散トリガーによる `/api/finalize` 発火 |
@@ -317,7 +315,7 @@ one_portrait/
 ## 14. 実装時の確認観点
 - 投稿成功時に `submission_no` 付き Kakera が即時発行されること
 - 同一アドレスの同一 unit への再投稿が拒否され、別 unit では参加できること
-- `Registry` から各選手の `current_unit_id` を一意に解決できること
+- `Registry` から作成済み Unit の一覧を取得できること
 - finalize 再実行で同一 `placements` が得られること
 - `/gallery` が `master_id` 未設定 unit を「完成待ち」と表示できること
 - 原画像が取得可能な間は表示され、取得不能後も `/gallery` が fallback 表示で破綻しないこと

--- a/generator/src/manifest.ts
+++ b/generator/src/manifest.ts
@@ -1,29 +1,15 @@
 import { appMeta } from "@one-portrait/shared";
 
-type GeneratorAthlete = {
-  readonly id: number;
-  readonly slug: string;
-  readonly heroCopy: string;
-};
-
-const generatorAthletes: readonly GeneratorAthlete[] = [
-  {
-    id: 1,
-    slug: "demo-athlete",
-    heroCopy: "Fan photos become one portrait.",
-  },
-] as const;
-
 export type FinalizeManifestInput = {
   unitId: string;
-  athleteId: number;
+  displayName: string;
   targetWalrusBlobId: string;
   tileCount: number;
 };
 
 export type FinalizeManifest = {
   generatorName: string;
-  athleteSlug: string;
+  displayName: string;
   heroCopy: string;
   unitId: string;
   targetWalrusBlobId: string;
@@ -33,14 +19,10 @@ export type FinalizeManifest = {
 export function buildFinalizeManifest(
   input: FinalizeManifestInput,
 ): FinalizeManifest {
-  const athlete =
-    generatorAthletes.find((item) => item.id === input.athleteId) ??
-    generatorAthletes[0];
-
   return {
     generatorName: appMeta.name,
-    athleteSlug: athlete.slug,
-    heroCopy: athlete.heroCopy,
+    displayName: input.displayName,
+    heroCopy: "Fan photos become one portrait.",
     unitId: input.unitId,
     targetWalrusBlobId: input.targetWalrusBlobId,
     tileCount: input.tileCount,

--- a/generator/src/prepare.ts
+++ b/generator/src/prepare.ts
@@ -54,12 +54,6 @@ export async function prepareFinalizeInput(
     snapshot.targetWalrusBlobId,
   );
   const submissions = sortSubmissions(snapshot.submissions);
-  const displayMaxSlots =
-    typeof snapshot.displayMaxSlots === "number" &&
-    Number.isInteger(snapshot.displayMaxSlots) &&
-    snapshot.displayMaxSlots > 0
-      ? snapshot.displayMaxSlots
-      : submissions.length;
 
   const preparedRealSubmissions = await Promise.all(
     submissions.map(async (submission) => {

--- a/generator/src/prepare.ts
+++ b/generator/src/prepare.ts
@@ -17,7 +17,7 @@ export type PreparedSubmission = GeneratorSubmissionRef & {
 };
 
 export type PreparedFinalizeInput = {
-  readonly athleteId: number;
+  readonly displayName: string;
   readonly submissions: readonly PreparedSubmission[];
   readonly targetImageBytes: Uint8Array;
   readonly targetWalrusBlobId: string;
@@ -81,7 +81,7 @@ export async function prepareFinalizeInput(
   );
 
   return {
-    athleteId: snapshot.athleteId,
+    displayName: snapshot.displayName,
     submissions: [...preparedRealSubmissions, ...preparedDummySubmissions],
     targetImageBytes,
     targetWalrusBlobId: snapshot.targetWalrusBlobId,

--- a/generator/src/server.ts
+++ b/generator/src/server.ts
@@ -207,7 +207,6 @@ function parseDispatchInput(input: unknown): { readonly unitId: string } {
 }
 
 function parseCreateUnitInput(input: unknown): {
-  readonly athleteId: number;
   readonly blobId: string;
   readonly displayMaxSlots: number;
   readonly displayName: string;
@@ -228,7 +227,6 @@ function parseCreateUnitInput(input: unknown): {
   }
 
   return {
-    athleteId: parseAthleteId(record.athleteId),
     blobId: parseNonEmptyString(record.blobId, "blobId"),
     displayMaxSlots,
     displayName: parseNonEmptyString(record.displayName, "displayName"),
@@ -247,23 +245,6 @@ function parseJsonRecord(input: unknown): Record<string, unknown> {
   }
 
   return input as Record<string, unknown>;
-}
-
-function parseAthleteId(value: unknown): number {
-  const athleteId =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && /^[0-9]+$/.test(value)
-        ? Number(value)
-        : NaN;
-
-  if (!Number.isInteger(athleteId) || athleteId < 0 || athleteId > 65_535) {
-    throw new InvalidPayloadError(
-      "Payload requires athleteId as a u16 integer.",
-    );
-  }
-
-  return athleteId;
 }
 
 function parsePositiveInteger(value: unknown, fieldName: string): number {
@@ -314,11 +295,6 @@ function writeJson(
         readonly digest: string;
         readonly status: "created" | "rotated";
         readonly unitId: string;
-      }
-    | {
-        readonly athleteId: number;
-        readonly digest: string;
-        readonly status: "upserted";
       }
     | {
         readonly status: "ok";

--- a/generator/src/sui.ts
+++ b/generator/src/sui.ts
@@ -80,7 +80,7 @@ export function createUnitSnapshotLoader(
 
     return {
       unitId,
-      athleteId: snapshot.athleteId,
+      displayName: snapshot.displayName,
       displayMaxSlots: snapshot.displayMaxSlots,
       targetWalrusBlobId: snapshot.targetWalrusBlobId,
       submissions: snapshot.submissions,
@@ -170,7 +170,6 @@ export function createCreateUnitTransactionExecutor(input: {
   readonly packageId: string;
   readonly privateKey: string;
 }): (args: {
-  readonly athleteId: number;
   readonly blobId: string;
   readonly displayMaxSlots: number;
   readonly displayName: string;
@@ -188,7 +187,6 @@ export function createCreateUnitTransactionExecutor(input: {
       arguments: [
         tx.object(input.adminCapId),
         tx.object(args.registryObjectId),
-        tx.pure(bcs.u16().serialize(args.athleteId)),
         tx.pure.vector(
           "u8",
           Array.from(new TextEncoder().encode(args.displayName)),
@@ -430,7 +428,7 @@ async function readUnitSnapshot(
 
   return {
     unitId,
-    athleteId: readIntegerField(fields.athlete_id, "athlete_id"),
+    displayName: readVectorU8AsString(fields.display_name, "display_name"),
     displayMaxSlots:
       readOptionalIntegerField(fields.display_max_slots, "display_max_slots") ??
       readIntegerField(fields.max_slots, "max_slots"),

--- a/generator/test/manifest.test.ts
+++ b/generator/test/manifest.test.ts
@@ -8,13 +8,13 @@ describe("buildFinalizeManifest", () => {
     expect(
       buildFinalizeManifest({
         unitId: "unit-1",
-        athleteId: 1,
+        displayName: "Demo Athlete",
         targetWalrusBlobId: "blob-demo",
         tileCount: unitTileCount,
       }),
     ).toEqual({
       generatorName: "ONE Portrait",
-      athleteSlug: "demo-athlete",
+      displayName: "Demo Athlete",
       heroCopy: "Fan photos become one portrait.",
       unitId: "unit-1",
       targetWalrusBlobId: "blob-demo",

--- a/generator/test/prepare.test.ts
+++ b/generator/test/prepare.test.ts
@@ -160,7 +160,7 @@ describe("prepareFinalizeInput", () => {
 
 function snapshot(): GeneratorUnitSnapshot {
   return {
-    athleteId: 1,
+    displayName: "Demo Athlete",
     displayMaxSlots: 2,
     targetWalrusBlobId: "target-blob",
     unitId: "0xunit-1",

--- a/generator/test/runtime.test.ts
+++ b/generator/test/runtime.test.ts
@@ -305,7 +305,7 @@ describe("createDefaultFinalizeRunner", () => {
 
 function snapshot() {
   return {
-    athleteId: 1,
+    displayName: "Demo Athlete",
     displayMaxSlots: 1,
     targetWalrusBlobId: "target-blob",
     unitId: "0xunit-1",
@@ -322,7 +322,7 @@ function snapshot() {
 
 function preparedInput(): PreparedFinalizeInput {
   return {
-    athleteId: 1,
+    displayName: "Demo Athlete",
     unitId: "0xunit-1",
     targetWalrusBlobId: "target-blob",
     targetImageBytes: new Uint8Array([1, 2, 3]),

--- a/generator/test/runtime.test.ts
+++ b/generator/test/runtime.test.ts
@@ -136,6 +136,11 @@ describe("createFinalizeRunner", () => {
       },
     ];
     const finalizeTransaction = vi.fn(async () => ({ digest: "0xdigest" }));
+    const prepared = preparedInput();
+    const firstSubmission = prepared.submissions[0];
+    if (firstSubmission == null) {
+      throw new Error("missing prepared submission");
+    }
 
     const runner = createFinalizeRunner({
       readUnitSnapshot: vi.fn(async () => ({
@@ -144,9 +149,9 @@ describe("createFinalizeRunner", () => {
         masterId: null,
       })),
       prepareInput: vi.fn(async () => ({
-        ...preparedInput(),
+        ...prepared,
         submissions: [
-          preparedInput().submissions[0]!,
+          firstSubmission,
           {
             submissionNo: 2,
             submitter: "0xdemo-dummy-0001",

--- a/generator/test/seeding-preflight.test.ts
+++ b/generator/test/seeding-preflight.test.ts
@@ -71,7 +71,7 @@ function snapshot(
   overrides: Partial<GeneratorSeedingSnapshot> = {},
 ): GeneratorSeedingSnapshot {
   return {
-    athleteId: overrides.athleteId ?? 1,
+    displayName: overrides.displayName ?? "Demo Athlete",
     displayMaxSlots: overrides.displayMaxSlots ?? overrides.maxSlots ?? 5,
     targetWalrusBlobId: overrides.targetWalrusBlobId ?? "target-blob",
     unitId: overrides.unitId ?? "0xunit-1",

--- a/generator/test/seeding-reconciliation.test.ts
+++ b/generator/test/seeding-reconciliation.test.ts
@@ -254,7 +254,7 @@ function snapshot(
   overrides: Partial<GeneratorSeedingSnapshot> = {},
 ): GeneratorSeedingSnapshot {
   return {
-    athleteId: overrides.athleteId ?? 1,
+    displayName: overrides.displayName ?? "Demo Athlete",
     displayMaxSlots: overrides.displayMaxSlots ?? overrides.maxSlots ?? 5,
     targetWalrusBlobId: overrides.targetWalrusBlobId ?? "target-blob",
     unitId: overrides.unitId ?? "0xunit-1",

--- a/generator/test/seeding-runner.test.ts
+++ b/generator/test/seeding-runner.test.ts
@@ -499,7 +499,7 @@ function snapshot(
   overrides: Partial<GeneratorSeedingSnapshot> = {},
 ): GeneratorSeedingSnapshot {
   return {
-    athleteId: overrides.athleteId ?? 1,
+    displayName: overrides.displayName ?? "Demo Athlete",
     displayMaxSlots: overrides.displayMaxSlots ?? overrides.maxSlots ?? 5,
     targetWalrusBlobId: overrides.targetWalrusBlobId ?? "target-blob",
     unitId: overrides.unitId ?? "0xunit-1",

--- a/generator/test/seeding-submit.test.ts
+++ b/generator/test/seeding-submit.test.ts
@@ -221,7 +221,7 @@ function snapshot(
   overrides: Partial<GeneratorSeedingSnapshot> = {},
 ): GeneratorSeedingSnapshot {
   return {
-    athleteId: overrides.athleteId ?? 1,
+    displayName: overrides.displayName ?? "Demo Athlete",
     displayMaxSlots: overrides.displayMaxSlots ?? overrides.maxSlots ?? 5,
     targetWalrusBlobId: overrides.targetWalrusBlobId ?? "target-blob",
     unitId: overrides.unitId ?? "0xunit-1",

--- a/generator/test/server.test.ts
+++ b/generator/test/server.test.ts
@@ -170,7 +170,6 @@ describe("generator server", () => {
           [DISPATCH_SECRET_HEADER]: "shared-secret",
         },
         body: JSON.stringify({
-          athleteId: 12,
           blobId: "target-blob-12",
           displayMaxSlots: 2000,
           displayName: "Demo Athlete Twelve",
@@ -187,7 +186,6 @@ describe("generator server", () => {
         unitId: VALID_UNIT_ID,
       });
       expect(createUnitMock).toHaveBeenCalledWith({
-        athleteId: 12,
         blobId: "target-blob-12",
         displayMaxSlots: 2000,
         displayName: "Demo Athlete Twelve",

--- a/generator/test/sui.test.ts
+++ b/generator/test/sui.test.ts
@@ -30,7 +30,7 @@ describe("createUnitSnapshotLoader", () => {
 
     expect(snapshot).toEqual({
       unitId: UNIT_ID,
-      athleteId: 1,
+      displayName: "Demo Athlete",
       displayMaxSlots: 2000,
       targetWalrusBlobId: "target-blob",
       submissions: [],
@@ -74,7 +74,7 @@ describe("createSeedingSnapshotLoader", () => {
 
     expect(snapshot).toEqual({
       unitId: UNIT_ID,
-      athleteId: 1,
+      displayName: "Demo Athlete",
       displayMaxSlots: 5,
       targetWalrusBlobId: "target-blob",
       submissions: [
@@ -192,7 +192,6 @@ describe("createCreateUnitTransactionExecutor", () => {
 
     await expect(
       createUnit({
-        athleteId: 12,
         blobId: "target-blob-12",
         displayMaxSlots: 2000,
         displayName: "Demo Athlete Twelve",
@@ -232,7 +231,7 @@ function unitData(fields: Record<string, unknown>) {
       type: "0xpkg::unit::Unit",
       fields: {
         id: { id: UNIT_ID },
-        athlete_id: 1,
+        display_name: Array.from(new TextEncoder().encode("Demo Athlete")),
         target_walrus_blob: Array.from(new TextEncoder().encode("target-blob")),
         display_max_slots: "4",
         max_slots: "4",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -24,7 +24,7 @@ export type GeneratorSubmissionRef = {
 };
 
 export type GeneratorUnitSnapshot = {
-  readonly athleteId: number;
+  readonly displayName: string;
   readonly displayMaxSlots: number;
   readonly submissions: readonly GeneratorSubmissionRef[];
   readonly targetWalrusBlobId: string;


### PR DESCRIPTION
## 概要

`athlete_id` / `athleteId` を廃止します。

admin、contract、web、generator の識別を `unit_id` に寄せます。
表示名は Unit の `display_name` を正本にします。

これにより、デモ運用ではアスリート ID を入力せず、
アスリート名だけで Unit を作成できます。

## 変更内容

- `contracts/sources`
  - `Unit`、`Kakera`、`MasterPortrait` から `athlete_id` を削除
  - `SubmittedEvent`、`UnitFilledEvent`、`MosaicReadyEvent` から `athlete_id` を削除
  - `admin_api::create_unit` と `unit::create_unit` の引数から `athlete_id` を削除

- `generator` / `shared`
  - create-unit payload から `athleteId` を削除
  - Move call から `bcs.u16()` の athlete ID 引数を削除
  - snapshot、manifest、prepare、seeding を `displayName` ベースに更新

- `apps/web`
  - `/admin` の Unit 作成フォームから athlete ID 入力を削除
  - Web admin API の payload から `athleteId` を削除
  - Sui parser と view model から chain 由来の `athletePublicId` を削除
  - home / unit / admin / gallery を `unitId` と `displayName` ベースに更新
  - catalog / demo のキーを `unitId` に変更

- `README.md` / `docs`
  - Registry、Unit、Kakera の説明を新 schema に更新
  - 古い `athlete_id -> current_unit_id` 前提を削除

## 関連する Issue やチケット

Close #80

## 動作確認

- `cd contracts && sui move test --test`
- `corepack pnpm --filter web test`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter generator test`
- `corepack pnpm --filter generator typecheck`
- `corepack pnpm run check`

## 注意点

Contract ABI が変わります。
反映時は新規 publish と、対応する package / AdminCap / Registry 設定の更新が必要です。
