### PR TITLE
feat: 0枚デモunitの作成とfinalizeに対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ apps/web/.cache
 **/e2e/reports
 **/e2e/artifacts
 **/test-results
-**/playwright-report
+**/playwright-report*
 **/.e2e-xdg
 
 # Devcontainer / agent runtime state

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Node / Next.js
 **/node_modules
 **/.pnpm-store
+**/.pnpm-store/**
 **/.next
 **/.open-next
 **/.wrangler

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "test": "vitest run --passWithNoTests && node --test scripts/check-build-public-env.test.mjs",
     "test:watch": "vitest --passWithNoTests",
     "test:e2e:readiness": "playwright test tests/e2e/readiness-regression.spec.ts",
+    "test:e2e:live": "playwright test --config=playwright.live.config.ts",
     "test:bundle-size": "node scripts/check-cloudflare-bundle-size.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui-host=0.0.0.0 --ui-port=9323",

--- a/apps/web/playwright.live.config.ts
+++ b/apps/web/playwright.live.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const LIVE_BASE_URL =
+  process.env.OP_LIVE_E2E_BASE_URL ??
+  "https://one-portrait-web.bububutasan00.workers.dev/";
+
+export default defineConfig({
+  testDir: "./tests/live",
+  timeout: 180_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  workers: 1,
+  reporter: [
+    [
+      "html",
+      {
+        host: "0.0.0.0",
+        port: 9324,
+        open: "never",
+        outputFolder: "playwright-report-live",
+      },
+    ],
+    ["list"],
+  ],
+  use: {
+    baseURL: LIVE_BASE_URL,
+    trace: "on",
+    screenshot: "on",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "live-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -275,4 +275,88 @@ describe("AdminClient", () => {
       thumbnailUrl: "https://example.com/12.png",
     });
   });
+
+  it("submits a zero-upload demo unit", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    let createPayload: Record<string, unknown> | null = null;
+
+    fetchMock.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url.endsWith("/api/admin/create-unit")) {
+          createPayload = JSON.parse(String(init?.body ?? "{}")) as Record<
+            string,
+            unknown
+          >;
+          return new Response(
+            JSON.stringify({
+              digest: "0xcreate-demo-zero",
+              status: "created",
+              unitId: "0xunit-demo-zero",
+            }),
+            {
+              headers: { "content-type": "application/json" },
+              status: 200,
+            },
+          );
+        }
+
+        if (url.endsWith("/api/admin/status")) {
+          return new Response(JSON.stringify({ athletes: [] }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          });
+        }
+
+        return new Response(JSON.stringify(HEALTH_OK), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
+      },
+    );
+
+    render(
+      <AdminClient
+        initialAthletes={[
+          {
+            currentUnit: null,
+            displayName: "Demo Athlete Zero",
+            entryId: "draft-0",
+            lookupState: "ready",
+            metadataState: "ready",
+            slug: "unit-draft-0",
+            thumbnailUrl: "https://example.com/0.png",
+          },
+        ]}
+        initialHealth={HEALTH_OK}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /デモ/ }));
+    fireEvent.change(screen.getByLabelText("デモ実アップロード枚数"), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
+      target: { value: "target-blob-demo-zero" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /ユニットを作成/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
+    });
+    expect(screen.getByText(/0 枚作成直後/)).toBeTruthy();
+    expect(createPayload).toEqual({
+      blobId: "target-blob-demo-zero",
+      displayMaxSlots: unitTileCount,
+      displayName: "Demo Athlete Zero",
+      maxSlots: 0,
+      thumbnailUrl: "https://example.com/0.png",
+    });
+  });
 });

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -45,7 +45,9 @@ export function AdminClient({
   const [isUploading, setIsUploading] = useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
 
-  const parsedDemoRealUploadCount = parsePositiveInteger(createRealUploadCount);
+  const parsedDemoRealUploadCount = parseNonNegativeInteger(
+    createRealUploadCount,
+  );
   const isDemoRealUploadCountValid =
     parsedDemoRealUploadCount !== null &&
     parsedDemoRealUploadCount < unitTileCount;
@@ -353,11 +355,10 @@ export function AdminClient({
             <p className="text-xs leading-6 text-stone-400">
               {createMode === "demo"
                 ? isDemoRealUploadCountValid
-                  ? `5 枚完了の時点で残り ${effectiveDisplayMaxSlots - effectiveMaxSlots} 枚をダミー画像としてロックし、実投稿分だけを元データとしてモザイク生成します。`.replace(
-                      "5",
-                      String(effectiveMaxSlots),
-                    )
-                  : `デモでは 1 以上 ${unitTileCount - 1} 以下の実アップロード枚数を指定してください。`
+                  ? effectiveMaxSlots === 0
+                    ? `0 枚作成直後に filled として扱い、${effectiveDisplayMaxSlots} 枚すべてをダミー画像としてモザイク生成します。`
+                    : `${effectiveMaxSlots} 枚完了の時点で残り ${effectiveDisplayMaxSlots - effectiveMaxSlots} 枚をダミー画像としてロックし、実投稿分だけを元データとしてモザイク生成します。`
+                  : `デモでは 0 以上 ${unitTileCount - 1} 以下の実アップロード枚数を指定してください。`
                 : "通常では 2,000 枚すべてが実投稿対象です。"}
             </p>
           </fieldset>
@@ -587,13 +588,13 @@ function formatActionDetail(payload: Record<string, unknown>): string {
   return parts.join(" / ");
 }
 
-function parsePositiveInteger(value: string): number | null {
+function parseNonNegativeInteger(value: string): number | null {
   if (!/^[0-9]+$/.test(value.trim())) {
     return null;
   }
 
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed < 0) {
     return null;
   }
 

--- a/apps/web/src/lib/admin/api.test.ts
+++ b/apps/web/src/lib/admin/api.test.ts
@@ -27,6 +27,36 @@ describe("parseCreateUnitInput", () => {
     });
   });
 
+  it("accepts zero real upload slots for a demo unit", () => {
+    expect(
+      parseCreateUnitInput({
+        blobId: "target-blob-12",
+        displayMaxSlots: 2000,
+        displayName: "Demo Athlete Twelve",
+        maxSlots: 0,
+        thumbnailUrl: "https://example.com/12.png",
+      }),
+    ).toEqual({
+      blobId: "target-blob-12",
+      displayMaxSlots: 2000,
+      displayName: "Demo Athlete Twelve",
+      maxSlots: 0,
+      thumbnailUrl: "https://example.com/12.png",
+    });
+  });
+
+  it("rejects a zero display slot unit", () => {
+    expect(() =>
+      parseCreateUnitInput({
+        blobId: "target-blob-12",
+        displayMaxSlots: 0,
+        displayName: "Demo Athlete Twelve",
+        maxSlots: 0,
+        thumbnailUrl: "https://example.com/12.png",
+      }),
+    ).toThrowError(AdminApiError);
+  });
+
   it("rejects create-unit input that still includes athleteId", () => {
     expect(() =>
       parseCreateUnitInput({

--- a/apps/web/src/lib/admin/api.ts
+++ b/apps/web/src/lib/admin/api.ts
@@ -36,8 +36,8 @@ export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
     "thumbnailUrl",
   ]);
 
-  const maxSlots = parseMaxSlots(record.maxSlots, "maxSlots");
-  const displayMaxSlots = parseMaxSlots(
+  const maxSlots = parseNonNegativeInteger(record.maxSlots, "maxSlots");
+  const displayMaxSlots = parsePositiveInteger(
     record.displayMaxSlots,
     "displayMaxSlots",
   );
@@ -149,15 +149,29 @@ function parseNonEmptyTrimmedString(value: unknown, fieldName: string): string {
   return parsed;
 }
 
-function parseMaxSlots(value: unknown, fieldName: string): number {
-  const maxSlots =
+function parseNonNegativeInteger(value: unknown, fieldName: string): number {
+  const parsed =
     typeof value === "number"
       ? value
       : typeof value === "string" && /^[0-9]+$/.test(value)
         ? Number(value)
         : NaN;
 
-  if (!Number.isInteger(maxSlots) || maxSlots <= 0) {
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new AdminApiError(
+      400,
+      "invalid_args",
+      `\`${fieldName}\` は 0 以上の整数で送ってください。`,
+    );
+  }
+
+  return parsed;
+}
+
+function parsePositiveInteger(value: unknown, fieldName: string): number {
+  const parsed = parseNonNegativeInteger(value, fieldName);
+
+  if (parsed === 0) {
     throw new AdminApiError(
       400,
       "invalid_args",
@@ -165,5 +179,5 @@ function parseMaxSlots(value: unknown, fieldName: string): number {
     );
   }
 
-  return maxSlots;
+  return parsed;
 }

--- a/apps/web/src/lib/walrus/put-target.test.ts
+++ b/apps/web/src/lib/walrus/put-target.test.ts
@@ -78,7 +78,7 @@ function baseDeps(fetchFn: typeof fetch) {
 }
 
 describe("putTargetBlobToWalrus", () => {
-  it("PUTs the target blob with epochs=100", async () => {
+  it("PUTs the target blob with epochs=50", async () => {
     const { calls, fetchFn } = queuedFetch([
       {
         kind: "ok",
@@ -97,8 +97,8 @@ describe("putTargetBlobToWalrus", () => {
     );
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=100`);
-    expect(calls[0]?.url).not.toContain("epochs=5");
+    expect(calls[0]?.url).toBe(`${PUBLISHER}/v1/blobs?epochs=50`);
+    expect(calls[0]?.url).not.toContain("epochs=100");
     expect(result.blobId).toBe("target-blob");
     expect(result.aggregatorUrl).toBe(`${AGGREGATOR}/v1/blobs/target-blob`);
   });

--- a/apps/web/src/lib/walrus/put-target.ts
+++ b/apps/web/src/lib/walrus/put-target.ts
@@ -5,7 +5,7 @@ import type { PreprocessedPhoto } from "../image/preprocess";
 import type { WalrusEnv, WalrusPutDeps, WalrusPutResult } from "./put";
 import { WalrusPutError } from "./put";
 
-const TARGET_WALRUS_EPOCHS = 100;
+const TARGET_WALRUS_EPOCHS = 50;
 const WALRUS_MAX_ATTEMPTS = 3;
 const WALRUS_BASE_BACKOFF_MS = 200;
 const WALRUS_REQUEST_TIMEOUT_MS = 30_000;

--- a/apps/web/tests/live/admin-zero-upload-demo.spec.ts
+++ b/apps/web/tests/live/admin-zero-upload-demo.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from "@playwright/test";
 const displayName = `Live Zero Demo ${Date.now()}`;
 const thumbnailUrl =
   "https://images.unsplash.com/photo-1521412644187-c49fa049e84d?w=320";
-const targetPng = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVRoge3PQQ3AIADAQMA+LfqX5FGBwVSgeNPM5mZ2fQF8G2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYPsF2QExRwLFdQAAAABJRU5ErkJggg==",
+const targetJpeg = Buffer.from(
+  "/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCABAAEADAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAbEAACAgMBAAAAAAAAAAAAAAAAFQFiUpGhYf/EABYBAQEBAAAAAAAAAAAAAAAAAAAFCP/EABcRAQEBAQAAAAAAAAAAAAAAAAATFGH/2gAMAwEAAhEDEQA/AKln70ydBru4z96IFxn70QLjP3ogXGfvRAuM/eiBcZ+9EC4z96IF0i0nIrwRtA0nIQNA0nIQNA0nIQNA0nIQNA0nIQNA0nIQNA0nIQNCRZxlGyxBGuM4yjYgXGcZRsQLjOMo2IFxnGUbEC4zjKNiBcZxlGxAuM4yjYgXSTS/SxBF0DS/RA0DS/RA0DS/RA0DS/RA0DS/RA0DS/RA0DS/RA0JFnaNliCPfoztGxAv0Z2jYgX6M7RsQL9Gdo2IF+jO0bEC/RnaNiBfoztGxAv1JM7dK8EW4zt0QLjO3RAuM7dEC4zt0QLjO3RAuM7dEC4zt0QLpFpGRZgjX6NIyEC/RpGQgX6NIyEC/RpGQgX6NIyEC/RpGQgX6NIyEC/Ui0sWII1xpYQLjSwgXGlhAuNLCBcaWEC40sIFxpYQLv/Z",
   "base64",
 );
 
@@ -31,13 +31,22 @@ test("creates and finalizes a zero-upload demo unit from the live admin page", a
   await expect(
     page.getByRole("heading", { name: "デモ管理コンソール" }),
   ).toBeVisible();
+  await expect
+    .poll(
+      async () => {
+        await page.getByRole("button", { name: "状態を更新" }).click();
+        return await page.getByText("worker_kv").count();
+      },
+      { timeout: 60_000 },
+    )
+    .toBeGreaterThan(0);
 
   await page.getByLabel("displayName").fill(displayName);
   await page.getByLabel("thumbnail URL").fill(thumbnailUrl);
   await page.getByLabel("対象画像").setInputFiles({
-    name: "target.png",
-    mimeType: "image/png",
-    buffer: targetPng,
+    name: "target.jpg",
+    mimeType: "image/jpeg",
+    buffer: targetJpeg,
   });
   await expect(page.getByText("対象画像をアップロードしました")).toBeVisible({
     timeout: 60_000,

--- a/apps/web/tests/live/admin-zero-upload-demo.spec.ts
+++ b/apps/web/tests/live/admin-zero-upload-demo.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+const displayName = `Live Zero Demo ${Date.now()}`;
+const thumbnailUrl =
+  "https://images.unsplash.com/photo-1521412644187-c49fa049e84d?w=320";
+const targetPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVRoge3PQQ3AIADAQMA+LfqX5FGBwVSgeNPM5mZ2fQF8G2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYPsF2QExRwLFdQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+test.describe.configure({ mode: "serial" });
+
+test.skip(
+  process.env.OP_LIVE_E2E !== "1",
+  "Set OP_LIVE_E2E=1 to run the live Cloudflare/Sui/Walrus admin flow.",
+);
+
+test("creates and finalizes a zero-upload demo unit from the live admin page", async ({
+  page,
+  request,
+}) => {
+  const health = await request.get("/api/admin/health");
+  const healthText = await health.text();
+  expect(health.ok(), healthText).toBe(true);
+  expect(JSON.parse(healthText)).toMatchObject({
+    dispatchAuthorization: { status: "ok" },
+    generatorReadiness: { status: "ok" },
+  });
+
+  await page.goto("/admin");
+  await expect(
+    page.getByRole("heading", { name: "デモ管理コンソール" }),
+  ).toBeVisible();
+
+  await page.getByLabel("displayName").fill(displayName);
+  await page.getByLabel("thumbnail URL").fill(thumbnailUrl);
+  await page.getByLabel("対象画像").setInputFiles({
+    name: "target.png",
+    mimeType: "image/png",
+    buffer: targetPng,
+  });
+  await expect(page.getByText("対象画像をアップロードしました")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  await page.getByRole("radio", { name: /デモ/ }).check();
+  await page.getByLabel("デモ実アップロード枚数").fill("0");
+  await expect(page.getByText(/0 枚作成直後/)).toBeVisible();
+  await page.getByRole("button", { name: "ユニットを作成" }).click();
+
+  const action = page.getByText(/ユニットID: 0x[0-9a-fA-F]+/);
+  await expect(action).toBeVisible({ timeout: 120_000 });
+  const unitId = extractUnitId((await action.textContent()) ?? "");
+
+  await expect
+    .poll(
+      async () => {
+        await page.getByRole("button", { name: "状態を更新" }).click();
+        const unitCard = page.locator("article").filter({ hasText: unitId });
+        return (await unitCard.count()) > 0
+          ? await unitCard.first().textContent()
+          : "";
+      },
+      { timeout: 120_000 },
+    )
+    .toContain("filled");
+
+  const unitCard = page.locator("article").filter({ hasText: unitId }).first();
+  await expect(unitCard).toContainText("2000 / 2000");
+  await expect(unitCard).toContainText("0 / 0");
+  await unitCard.getByRole("button", { name: /finalize を再試行/ }).click();
+  await expect(page.getByText("finalize を再試行しました")).toBeVisible({
+    timeout: 180_000,
+  });
+  await expect(page.getByText(/ステータス: finalized/)).toBeVisible();
+
+  await page.goto(
+    `/units/${unitId}?athleteName=${encodeURIComponent(displayName)}`,
+  );
+  await expect(page.locator(".op-big-counter")).toContainText(
+    /2000\s*\/\s*2000/,
+    { timeout: 60_000 },
+  );
+  await expect(page.getByTestId("reveal-image")).toBeVisible({
+    timeout: 120_000,
+  });
+});
+
+function extractUnitId(value: string): string {
+  const match = value.match(/0x[0-9a-fA-F]+/);
+  if (!match) {
+    throw new Error(`Could not find unit id in action detail: ${value}`);
+  }
+  return match[0];
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -13,9 +13,9 @@
   ],
   "vars": {
     "NEXT_PUBLIC_SUI_NETWORK": "testnet",
-    // Published on testnet 2026-04-23 and verified to expose `unit_ids`.
-    "NEXT_PUBLIC_PACKAGE_ID": "0x5c3805e6c6308a04802b003bc8039ff27dbe88aaf7e137b13940a124fdf02d95",
-    "NEXT_PUBLIC_REGISTRY_OBJECT_ID": "0x37a0db048a0cf733712a15f8941c8a6103cc1a70ec5c7089ca108bd98a7bc339",
+    // Published on testnet 2026-04-24 and verified to expose `unit_ids`.
+    "NEXT_PUBLIC_PACKAGE_ID": "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
+    "NEXT_PUBLIC_REGISTRY_OBJECT_ID": "0x22cca7fbd9392a1fc24c4b1e038c99d23c5a23d72ed63a67893c39ce8374533f",
     "NEXT_PUBLIC_ENOKI_API_KEY": "enoki_public_f6adc0082f791a0a226ac20f81a9f635",
     "NEXT_PUBLIC_GOOGLE_CLIENT_ID": "317939856639-5m1cu2msauk1s66q6u6jj35ja0ir1mar.apps.googleusercontent.com",
     "NEXT_PUBLIC_WALRUS_PUBLISHER": "https://publisher.walrus-testnet.walrus.space",

--- a/biome.json
+++ b/biome.json
@@ -17,10 +17,12 @@
       "!apps/web/.open-next",
       "!apps/web/.e2e-xdg",
       "!apps/web/.wrangler",
-      "!apps/web/playwright-report",
+      "!apps/web/playwright-report*",
       "!apps/web/test-results",
       "!.claude",
       "!.codex",
+      "!.pnpm-store",
+      "!**/.pnpm-store",
       "!node_modules"
     ]
   },

--- a/contracts/Published.toml
+++ b/contracts/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x5c3805e6c6308a04802b003bc8039ff27dbe88aaf7e137b13940a124fdf02d95"
-original-id = "0x5c3805e6c6308a04802b003bc8039ff27dbe88aaf7e137b13940a124fdf02d95"
+published-at = "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf"
+original-id = "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf"
 version = 1
 toolchain-version = "1.70.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x8b8baa37fdcfaa74973b82854636cd2092bd9ede41083149bb7dd93121f346e3"
+upgrade-capability = "0x626f219a716a86cfc449f2ac2cca50426663ed5c5572a8ca32badc2654bd1639"

--- a/contracts/sources/admin_api.move
+++ b/contracts/sources/admin_api.move
@@ -35,3 +35,12 @@ public fun finalize(
 ) {
     unit::finalize(admin_cap, unit, mosaic_blob_id, placements, ctx);
 }
+
+public fun finalize_empty(
+    admin_cap: &AdminCap,
+    unit: &mut Unit,
+    mosaic_blob_id: vector<u8>,
+    ctx: &mut TxContext,
+) {
+    unit::finalize(admin_cap, unit, mosaic_blob_id, vector[], ctx);
+}

--- a/contracts/sources/unit.move
+++ b/contracts/sources/unit.move
@@ -50,7 +50,7 @@ public(package) fun create_unit(
     display_max_slots: u64,
     ctx: &mut TxContext,
 ): ID {
-    assert!(max_slots > 0, EINVALID_MAX_SLOTS);
+    assert!(display_max_slots > 0, EINVALID_DISPLAY_MAX_SLOTS);
     assert!(
         display_max_slots >= max_slots,
         EINVALID_DISPLAY_MAX_SLOTS,
@@ -63,7 +63,7 @@ public(package) fun create_unit(
         target_walrus_blob,
         max_slots,
         display_max_slots,
-        status: STATUS_PENDING,
+        status: if (max_slots == 0) { STATUS_FILLED } else { STATUS_PENDING },
         master_id: option::none(),
         submitters: table::new(ctx),
         submissions: vector[],

--- a/contracts/tests/finalize_tests.move
+++ b/contracts/tests/finalize_tests.move
@@ -150,6 +150,65 @@ fun finalize_creates_master_updates_unit_and_emits_mosaic_ready_event() {
     scenario.end();
 }
 
+#[test]
+fun finalize_zero_submission_demo_unit_with_empty_placements() {
+    let publisher = @0xA11CE;
+    let mosaic_blob_id = b"mosaic-blob-zero";
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = admin_api::create_unit(
+        &admin_cap,
+        &mut registry,
+        b"Demo Athlete Zero",
+        b"https://example.com/0.png",
+        b"target-blob-zero",
+        0,
+        2_000,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
+    admin_api::finalize(
+        &admin_cap,
+        &mut unit,
+        mosaic_blob_id,
+        vector[],
+        scenario.ctx(),
+    );
+
+    assert!(unit::is_finalized_for_testing(&unit));
+    let master_id = unit::master_id_for_testing(&unit);
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(unit);
+
+    let finalize_effects = scenario.next_tx(publisher);
+    assert_eq!(finalize_effects.num_user_events(), 1);
+
+    let master = scenario.take_from_sender<MasterPortrait>();
+    assert_eq!(object::id(&master), master_id);
+    assert_eq!(master_portrait::unit_id_for_testing(&master), unit_id);
+    assert_eq!(
+        master_portrait::mosaic_walrus_blob_id_for_testing(&master),
+        mosaic_blob_id
+    );
+    scenario.return_to_sender(master);
+
+    scenario.end();
+}
+
 #[test, expected_failure(abort_code = unit::EUNIT_NOT_FILLED)]
 fun finalize_rejects_pending_unit() {
     let publisher = @0xA11CE;

--- a/contracts/tests/finalize_tests.move
+++ b/contracts/tests/finalize_tests.move
@@ -180,11 +180,10 @@ fun finalize_zero_submission_demo_unit_with_empty_placements() {
 
     let admin_cap = scenario.take_from_sender<AdminCap>();
     let mut unit = scenario.take_shared_by_id<Unit>(unit_id);
-    admin_api::finalize(
+    admin_api::finalize_empty(
         &admin_cap,
         &mut unit,
         mosaic_blob_id,
-        vector[],
         scenario.ctx(),
     );
 

--- a/contracts/tests/registry_admin_tests.move
+++ b/contracts/tests/registry_admin_tests.move
@@ -79,6 +79,51 @@ fun create_unit_sets_initial_state_and_appends_registry_index() {
 }
 
 #[test]
+fun create_zero_submission_demo_unit_starts_filled() {
+    let publisher = @0xA11CE;
+    let max_slots = 0;
+    let display_max_slots = 2_000;
+
+    let mut scenario = test_scenario::begin(publisher);
+    registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(publisher);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let mut registry = scenario.take_shared<Registry>();
+    let unit_id = admin_api::create_unit(
+        &admin_cap,
+        &mut registry,
+        b"Demo Athlete Zero",
+        b"https://example.com/0.png",
+        b"target-blob-zero",
+        max_slots,
+        display_max_slots,
+        scenario.ctx(),
+    );
+
+    scenario.return_to_sender(admin_cap);
+    test_scenario::return_shared(registry);
+
+    scenario.next_tx(publisher);
+
+    let registry = scenario.take_shared<Registry>();
+    let unit = scenario.take_shared_by_id<Unit>(unit_id);
+
+    assert_eq!(unit::max_slots_for_testing(&unit), max_slots);
+    assert_eq!(unit::display_max_slots_for_testing(&unit), display_max_slots);
+    assert!(unit::is_filled_for_testing(&unit));
+    assert_eq!(unit::submitter_count_for_testing(&unit), 0);
+    assert_eq!(unit::submission_count_for_testing(&unit), 0);
+    assert_eq!(registry::unit_count_for_testing(&registry), 1);
+    assert_eq!(registry::unit_id_for_testing(&registry, 0), unit_id);
+
+    test_scenario::return_shared(unit);
+    test_scenario::return_shared(registry);
+    scenario.end();
+}
+
+#[test]
 fun create_unit_keeps_existing_units_in_registry_order() {
     let publisher = @0xA11CE;
 

--- a/generator/src/prepare.ts
+++ b/generator/src/prepare.ts
@@ -1,9 +1,9 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import type {
   GeneratorSubmissionRef,

--- a/generator/src/prepare.ts
+++ b/generator/src/prepare.ts
@@ -1,4 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 
 import type {
   GeneratorSubmissionRef,
@@ -34,6 +39,7 @@ export type WalrusReadClient = {
 
 export type PrepareFinalizeDeps = {
   readonly demoFinalizeManifestPath?: string | null;
+  readonly loadBundledDemoTiles?: () => Promise<SeedingInputEntry[]>;
   readonly loadSeedingInputFromManifest?: (
     manifestPath: string,
   ) => Promise<SeedingInputEntry[]>;
@@ -45,6 +51,30 @@ export type PrepareFinalizeDeps = {
 type DisplayAwareFinalizeSnapshot = GeneratorUnitSnapshot & {
   readonly displayMaxSlots?: number;
 };
+
+const execFileAsync = promisify(execFile);
+const generatorRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const bundledDemoTilesArchivePath = path.join(
+  generatorRoot,
+  "assets",
+  "archives",
+  "merged-generator-tiles.tar.gz",
+);
+const bundledDemoTilesCacheDir = path.join(
+  os.tmpdir(),
+  "one-portrait-bundled-demo-tiles",
+);
+const bundledDemoTilesExtractedDir = path.join(
+  bundledDemoTilesCacheDir,
+  "merged-generator-tiles",
+);
+const bundledDemoTilesReadyMarker = path.join(
+  bundledDemoTilesCacheDir,
+  ".ready",
+);
 
 export async function prepareFinalizeInput(
   snapshot: DisplayAwareFinalizeSnapshot,
@@ -107,16 +137,7 @@ async function loadPreparedDummySubmissions(
     return [];
   }
 
-  const manifestPath = deps.demoFinalizeManifestPath?.trim() ?? "";
-  if (manifestPath.length === 0) {
-    throw new Error(
-      "Demo finalize requires OP_DEMO_FINALIZE_MANIFEST when displayMaxSlots exceeds real submissions.",
-    );
-  }
-
-  const manifestEntries = await (
-    deps.loadSeedingInputFromManifest ?? loadSeedingInputFromManifest
-  )(manifestPath);
+  const manifestEntries = await loadDummyManifestEntries(deps);
 
   if (manifestEntries.length < dummyCount) {
     throw new Error(
@@ -143,4 +164,72 @@ async function loadPreparedDummySubmissions(
       } satisfies PreparedSubmission;
     }),
   );
+}
+
+async function loadDummyManifestEntries(
+  deps: PrepareFinalizeDeps,
+): Promise<SeedingInputEntry[]> {
+  const manifestPath = deps.demoFinalizeManifestPath?.trim() ?? "";
+  if (manifestPath.length > 0) {
+    return (deps.loadSeedingInputFromManifest ?? loadSeedingInputFromManifest)(
+      manifestPath,
+    );
+  }
+
+  return (deps.loadBundledDemoTiles ?? loadBundledDemoTiles)();
+}
+
+export async function loadBundledDemoTiles(): Promise<SeedingInputEntry[]> {
+  await ensureBundledDemoTilesExtracted();
+  return loadImageEntriesFromDirectory(bundledDemoTilesExtractedDir);
+}
+
+async function ensureBundledDemoTilesExtracted(): Promise<void> {
+  try {
+    await access(bundledDemoTilesReadyMarker);
+    return;
+  } catch {
+    // Fall through and rebuild the cache from the bundled archive.
+  }
+
+  await mkdir(bundledDemoTilesCacheDir, { recursive: true });
+  await execFileAsync("tar", [
+    "-xzf",
+    bundledDemoTilesArchivePath,
+    "-C",
+    bundledDemoTilesCacheDir,
+  ]);
+  await writeFile(bundledDemoTilesReadyMarker, "ready\n");
+}
+
+async function loadImageEntriesFromDirectory(
+  directoryPath: string,
+): Promise<SeedingInputEntry[]> {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(directoryPath, entry.name))
+    .filter(isSupportedImageFile)
+    .sort(compareImagePaths)
+    .map((filePath) => ({
+      imageKey: path.basename(filePath),
+      filePath,
+    }));
+}
+
+function isSupportedImageFile(filePath: string): boolean {
+  const extension = path.extname(filePath).toLowerCase();
+  return (
+    extension === ".png" ||
+    extension === ".jpg" ||
+    extension === ".jpeg" ||
+    extension === ".webp"
+  );
+}
+
+function compareImagePaths(left: string, right: string): number {
+  return path.basename(left).localeCompare(path.basename(right), undefined, {
+    numeric: true,
+  });
 }

--- a/generator/src/server.ts
+++ b/generator/src/server.ts
@@ -215,7 +215,7 @@ function parseCreateUnitInput(input: unknown): {
   readonly thumbnailUrl: string;
 } {
   const record = parseJsonRecord(input);
-  const maxSlots = parsePositiveInteger(record.maxSlots, "maxSlots");
+  const maxSlots = parseNonNegativeInteger(record.maxSlots, "maxSlots");
   const displayMaxSlots = parsePositiveInteger(
     record.displayMaxSlots,
     "displayMaxSlots",
@@ -248,6 +248,18 @@ function parseJsonRecord(input: unknown): Record<string, unknown> {
 }
 
 function parsePositiveInteger(value: unknown, fieldName: string): number {
+  const parsed = parseNonNegativeInteger(value, fieldName);
+
+  if (parsed === 0) {
+    throw new InvalidPayloadError(
+      `Payload requires ${fieldName} as a positive integer.`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: unknown, fieldName: string): number {
   const parsed =
     typeof value === "number"
       ? value
@@ -255,9 +267,9 @@ function parsePositiveInteger(value: unknown, fieldName: string): number {
         ? Number(value)
         : NaN;
 
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed < 0) {
     throw new InvalidPayloadError(
-      `Payload requires ${fieldName} as a positive integer.`,
+      `Payload requires ${fieldName} as a non-negative integer.`,
     );
   }
 

--- a/generator/src/sui.ts
+++ b/generator/src/sui.ts
@@ -111,30 +111,43 @@ export function createFinalizeTransactionExecutor(input: {
   return async (args) => {
     const tx = new Transaction();
 
-    tx.moveCall({
-      target: `${input.packageId}::admin_api::finalize`,
-      arguments: [
-        tx.object(input.adminCapId),
-        tx.object(args.unitId),
-        tx.pure.vector(
-          "u8",
-          Array.from(new TextEncoder().encode(args.mosaicBlobId)),
-        ),
-        tx.pure(
-          bcs.vector(placementInputBcs).serialize(
-            args.placements.map((placement) => ({
-              blob_id: Array.from(
-                new TextEncoder().encode(placement.walrusBlobId),
-              ),
-              x: placement.x,
-              y: placement.y,
-              submitter: placement.submitter,
-              submission_no: placement.submissionNo,
-            })),
+    const encodedMosaicBlobId = tx.pure.vector(
+      "u8",
+      Array.from(new TextEncoder().encode(args.mosaicBlobId)),
+    );
+
+    if (args.placements.length === 0) {
+      tx.moveCall({
+        target: `${input.packageId}::admin_api::finalize_empty`,
+        arguments: [
+          tx.object(input.adminCapId),
+          tx.object(args.unitId),
+          encodedMosaicBlobId,
+        ],
+      });
+    } else {
+      tx.moveCall({
+        target: `${input.packageId}::admin_api::finalize`,
+        arguments: [
+          tx.object(input.adminCapId),
+          tx.object(args.unitId),
+          encodedMosaicBlobId,
+          tx.pure(
+            bcs.vector(placementInputBcs).serialize(
+              args.placements.map((placement) => ({
+                blob_id: Array.from(
+                  new TextEncoder().encode(placement.walrusBlobId),
+                ),
+                x: placement.x,
+                y: placement.y,
+                submitter: placement.submitter,
+                submission_no: placement.submissionNo,
+              })),
+            ),
           ),
-        ),
-      ],
-    });
+        ],
+      });
+    }
 
     const execution = await input.client.signAndExecuteTransaction({
       signer,

--- a/generator/test/prepare.test.ts
+++ b/generator/test/prepare.test.ts
@@ -150,6 +150,47 @@ describe("prepareFinalizeInput", () => {
     ]);
   });
 
+  it("prepares a zero-submission demo unit entirely from dummy tiles", async () => {
+    const loadBundledDemoTiles = vi.fn(async () =>
+      Array.from({ length: 2000 }, (_, index) => ({
+        imageKey: `bundled-${index + 1}.webp`,
+        filePath: `/tmp/bundled-${index + 1}.webp`,
+      })),
+    );
+    const readLocalFile = vi.fn(async (filePath: string) => encode(filePath));
+
+    const prepared = await prepareFinalizeInput(
+      {
+        displayName: "Demo Athlete Zero",
+        displayMaxSlots: 2000,
+        targetWalrusBlobId: "target-blob-zero",
+        unitId: "0xunit-zero",
+        submissions: [],
+      },
+      {
+        loadBundledDemoTiles,
+        readLocalFile,
+        sampleAverageColor: vi.fn(() => ({ red: 1, green: 2, blue: 3 })),
+        walrus: { getBlob: vi.fn(async (blobId: string) => encode(blobId)) },
+      },
+    );
+
+    expect(loadBundledDemoTiles).toHaveBeenCalledTimes(1);
+    expect(readLocalFile).toHaveBeenCalledTimes(2000);
+    expect(prepared.submissions).toHaveLength(2000);
+    expect(prepared.submissions.every((entry) => entry.isDummy)).toBe(true);
+    expect(prepared.submissions[0]).toMatchObject({
+      submissionNo: 1,
+      submitter: "0xdemo-dummy-0001",
+      walrusBlobId: "demo-dummy:bundled-1.webp",
+    });
+    expect(prepared.submissions.at(-1)).toMatchObject({
+      submissionNo: 2000,
+      submitter: "0xdemo-dummy-2000",
+      walrusBlobId: "demo-dummy:bundled-2000.webp",
+    });
+  });
+
   it("fails clearly when the manifest does not have enough dummy tiles", async () => {
     await expect(
       prepareFinalizeInput(

--- a/generator/test/prepare.test.ts
+++ b/generator/test/prepare.test.ts
@@ -119,19 +119,35 @@ describe("prepareFinalizeInput", () => {
     );
   });
 
-  it("fails clearly when a demo unit is missing OP_DEMO_FINALIZE_MANIFEST", async () => {
-    await expect(
-      prepareFinalizeInput(
-        {
-          ...snapshot(),
-          displayMaxSlots: 3,
-        },
-        {
-          sampleAverageColor: vi.fn(() => ({ red: 1, green: 2, blue: 3 })),
-          walrus: { getBlob: vi.fn(async (blobId: string) => encode(blobId)) },
-        },
-      ),
-    ).rejects.toThrow(/OP_DEMO_FINALIZE_MANIFEST/);
+  it("falls back to bundled dummy tiles when OP_DEMO_FINALIZE_MANIFEST is unset", async () => {
+    const prepared = await prepareFinalizeInput(
+      {
+        ...snapshot(),
+        displayMaxSlots: 4,
+      },
+      {
+        loadBundledDemoTiles: vi.fn(async () => [
+          {
+            imageKey: "bundled-1.webp",
+            filePath: "/tmp/bundled-1.webp",
+          },
+          {
+            imageKey: "bundled-2.webp",
+            filePath: "/tmp/bundled-2.webp",
+          },
+        ]),
+        readLocalFile: vi.fn(async (filePath: string) => encode(filePath)),
+        sampleAverageColor: vi.fn(() => ({ red: 1, green: 2, blue: 3 })),
+        walrus: { getBlob: vi.fn(async (blobId: string) => encode(blobId)) },
+      },
+    );
+
+    expect(prepared.submissions.map((entry) => entry.walrusBlobId)).toEqual([
+      "submission-a",
+      "submission-b",
+      "demo-dummy:bundled-1.webp",
+      "demo-dummy:bundled-2.webp",
+    ]);
   });
 
   it("fails clearly when the manifest does not have enough dummy tiles", async () => {

--- a/generator/test/runtime.test.ts
+++ b/generator/test/runtime.test.ts
@@ -193,6 +193,77 @@ describe("createFinalizeRunner", () => {
       placements: [placements[0]],
     });
   });
+
+  it("finalizes a zero-submission demo unit with empty on-chain placements", async () => {
+    const placements = [
+      {
+        walrusBlobId: "demo-dummy:dummy-1.png",
+        submissionNo: 1,
+        submitter: "0xdemo-dummy-0001",
+        x: 0,
+        y: 0,
+        targetColor: { red: 4, green: 5, blue: 6 },
+      },
+    ];
+    const finalizeTransaction = vi.fn(async () => ({ digest: "0xdigest" }));
+
+    const runner = createFinalizeRunner({
+      readUnitSnapshot: vi.fn(async () => ({
+        displayName: "Demo Athlete Zero",
+        displayMaxSlots: 1,
+        targetWalrusBlobId: "target-blob-zero",
+        unitId: "0xunit-zero",
+        submissions: [],
+        status: "filled" as const,
+        masterId: null,
+      })),
+      prepareInput: vi.fn(async () => ({
+        displayName: "Demo Athlete Zero",
+        unitId: "0xunit-zero",
+        targetWalrusBlobId: "target-blob-zero",
+        targetImageBytes: new Uint8Array([1, 2, 3]),
+        submissions: [
+          {
+            submissionNo: 1,
+            submitter: "0xdemo-dummy-0001",
+            submittedAtMs: 0,
+            walrusBlobId: "demo-dummy:dummy-1.png",
+            averageColor: { red: 4, green: 5, blue: 6 },
+            imageBytes: new Uint8Array([7, 8, 9]),
+            isDummy: true,
+          },
+        ],
+      })),
+      extractTargetTiles: vi.fn(async () => [
+        {
+          index: 0,
+          x: 0,
+          y: 0,
+          averageColor: { red: 1, green: 2, blue: 3 },
+        },
+      ]),
+      assignPlacements: vi.fn(() => placements),
+      composeMosaicPng: vi.fn(async () => new Uint8Array([9, 9, 9])),
+      putMosaic: vi.fn(async () => ({
+        blobId: "mosaic-blob",
+        aggregatorUrl: "https://agg/v1/blobs/mosaic-blob",
+      })),
+      finalizeTransaction,
+    });
+
+    await expect(runner.run("0xunit-zero")).resolves.toEqual({
+      status: "finalized",
+      unitId: "0xunit-zero",
+      mosaicBlobId: "mosaic-blob",
+      digest: "0xdigest",
+      placementCount: 0,
+    });
+    expect(finalizeTransaction).toHaveBeenCalledWith({
+      unitId: "0xunit-zero",
+      mosaicBlobId: "mosaic-blob",
+      placements: [],
+    });
+  });
 });
 
 describe("createDefaultFinalizeRunner", () => {

--- a/generator/test/server.test.ts
+++ b/generator/test/server.test.ts
@@ -198,6 +198,75 @@ describe("generator server", () => {
     }
   });
 
+  it("accepts /admin/create-unit with zero real upload slots", async () => {
+    setReadyGeneratorEnv();
+
+    const server = createGeneratorServer();
+    const baseUrl = await listen(server);
+
+    try {
+      const response = await fetch(`${baseUrl}/admin/create-unit`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [DISPATCH_SECRET_HEADER]: "shared-secret",
+        },
+        body: JSON.stringify({
+          blobId: "target-blob-zero",
+          displayMaxSlots: 2000,
+          displayName: "Demo Athlete Zero",
+          maxSlots: 0,
+          registryObjectId: VALID_REGISTRY_ID,
+          thumbnailUrl: "https://example.com/0.png",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(createUnitMock).toHaveBeenCalledWith({
+        blobId: "target-blob-zero",
+        displayMaxSlots: 2000,
+        displayName: "Demo Athlete Zero",
+        maxSlots: 0,
+        registryObjectId: VALID_REGISTRY_ID,
+        thumbnailUrl: "https://example.com/0.png",
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("rejects /admin/create-unit when displayMaxSlots is zero", async () => {
+    setReadyGeneratorEnv();
+
+    const server = createGeneratorServer();
+    const baseUrl = await listen(server);
+
+    try {
+      const response = await fetch(`${baseUrl}/admin/create-unit`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [DISPATCH_SECRET_HEADER]: "shared-secret",
+        },
+        body: JSON.stringify({
+          blobId: "target-blob-zero",
+          displayMaxSlots: 0,
+          displayName: "Demo Athlete Zero",
+          maxSlots: 0,
+          registryObjectId: VALID_REGISTRY_ID,
+          thumbnailUrl: "https://example.com/0.png",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "invalid_args",
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
   it("accepts /dispatch-auth-probe with the shared secret and does not run finalize", async () => {
     setReadyGeneratorEnv();
 

--- a/generator/test/sui.test.ts
+++ b/generator/test/sui.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createCreateUnitTransactionExecutor,
+  createFinalizeTransactionExecutor,
   createSeedingSnapshotLoader,
   createUnitSnapshotLoader,
 } from "../src";
@@ -186,7 +187,7 @@ describe("createCreateUnitTransactionExecutor", () => {
         signAndExecuteTransaction,
         waitForTransaction,
       } as unknown as GeneratorSuiWriteClient,
-      packageId: "0xpackage",
+      packageId: PACKAGE_ID,
       privateKey: signer.getSecretKey(),
     });
 
@@ -217,7 +218,124 @@ describe("createCreateUnitTransactionExecutor", () => {
   });
 });
 
+describe("createFinalizeTransactionExecutor", () => {
+  it("uses finalize_empty for zero-placement demo units", async () => {
+    const signer = Ed25519Keypair.generate();
+    const signAndExecuteTransaction = vi.fn(async () => ({
+      digest: "0xfinalize",
+      effects: {
+        status: {
+          status: "success",
+        },
+      },
+    }));
+    const finalize = createFinalizeTransactionExecutor({
+      adminCapId:
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      client: {
+        signAndExecuteTransaction,
+        waitForTransaction: vi.fn(),
+      } as unknown as GeneratorSuiWriteClient,
+      packageId: PACKAGE_ID,
+      privateKey: signer.getSecretKey(),
+    });
+
+    await expect(
+      finalize({
+        mosaicBlobId: "mosaic-blob-zero",
+        placements: [],
+        unitId:
+          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      }),
+    ).resolves.toEqual({ digest: "0xfinalize" });
+
+    const command = firstTransactionCommand(signAndExecuteTransaction);
+    expect(command?.MoveCall).toMatchObject({
+      package: PACKAGE_ID,
+      module: "admin_api",
+      function: "finalize_empty",
+    });
+    expect(command?.MoveCall?.arguments).toHaveLength(3);
+  });
+
+  it("keeps the existing finalize entrypoint when placements are present", async () => {
+    const signer = Ed25519Keypair.generate();
+    const signAndExecuteTransaction = vi.fn(async () => ({
+      digest: "0xfinalize",
+      effects: {
+        status: {
+          status: "success",
+        },
+      },
+    }));
+    const finalize = createFinalizeTransactionExecutor({
+      adminCapId:
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      client: {
+        signAndExecuteTransaction,
+        waitForTransaction: vi.fn(),
+      } as unknown as GeneratorSuiWriteClient,
+      packageId: PACKAGE_ID,
+      privateKey: signer.getSecretKey(),
+    });
+
+    await expect(
+      finalize({
+        mosaicBlobId: "mosaic-blob",
+        placements: [
+          {
+            walrusBlobId: "submission-1",
+            submissionNo: 1,
+            submitter:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            x: 0,
+            y: 1,
+            targetColor: { red: 1, green: 2, blue: 3 },
+          },
+        ],
+        unitId:
+          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      }),
+    ).resolves.toEqual({ digest: "0xfinalize" });
+
+    const command = firstTransactionCommand(signAndExecuteTransaction);
+    expect(command?.MoveCall).toMatchObject({
+      package: PACKAGE_ID,
+      module: "admin_api",
+      function: "finalize",
+    });
+    expect(command?.MoveCall?.arguments).toHaveLength(4);
+  });
+});
+
 const UNIT_ID = "0xunit-1";
+const PACKAGE_ID =
+  "0x9999999999999999999999999999999999999999999999999999999999999999";
+
+function firstTransactionCommand(
+  signAndExecuteTransaction: ReturnType<typeof vi.fn>,
+) {
+  const calls = signAndExecuteTransaction.mock.calls as unknown as Array<
+    [
+      {
+        transaction: {
+          getData: () => {
+            commands: Array<{
+              MoveCall?: {
+                package: string;
+                module: string;
+                function: string;
+                arguments: readonly unknown[];
+              };
+            }>;
+          };
+        };
+      },
+    ]
+  >;
+
+  return calls[0]?.[0].transaction.getData().commands[0];
+}
 
 function unitData(fields: Record<string, unknown>) {
   return {


### PR DESCRIPTION
## 概要
0枚デモ unit を正式にサポートし、作成直後 filled、表示 2000/2000、実投稿 0/0、dummy tile だけでのモザイク生成と finalize まで通るようにしました。

## 変更内容
- `contracts/sources/unit.move`, `contracts/sources/admin_api.move`
  - `max_slots = 0` の unit 作成を許可し、0件 placements 用の `finalize_empty` entrypoint を追加
- `apps/web/src/app/admin/admin-client.tsx`, `apps/web/src/lib/admin/api.ts`
  - admin UI/API で demo 実アップロード数 0 を受け付け、説明文と validation を更新
- `generator/src/prepare.ts`, `generator/src/server.ts`, `generator/src/sui.ts`
  - bundled demo tiles fallback を追加し、0件 placements では `finalize_empty` を呼び出すよう変更
- `apps/web/playwright.live.config.ts`, `apps/web/tests/live/admin-zero-upload-demo.spec.ts`
  - 実URL against の opt-in live Playwright test を追加
- `apps/web/src/lib/walrus/put-target.ts`
  - Walrus testnet で有効な target upload retention に調整
- `contracts/Published.toml`, `apps/web/wrangler.jsonc`
  - testnet publish 済み package/registry ID を反映

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm run check`
- `cd contracts && sui move test --test`
- `corepack pnpm --filter web run build:cf`
- `OP_LIVE_E2E=1 corepack pnpm --filter web run test:e2e:live`

Live E2E では Cloudflare Worker / Sui testnet / Walrus testnet / generator tunnel を使い、実URL `/admin` から 0枚デモ unit 作成、finalize、unit page reveal まで確認済みです。
