### PR TITLE
feat: finalizeモザイクをWebPで軽量化

### DIFF
--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -63,8 +63,7 @@ const CATALOG = [
   },
 ] as const;
 const WALRUS_AGGREGATOR = "https://aggregator.example.com";
-const OPAQUE_MOSAIC_BLOB_ID =
-  "Bm7qyNqV3RcP6td9XSk4LeF0aZuH5Wj8GxYp1sMn";
+const OPAQUE_MOSAIC_BLOB_ID = "Bm7qyNqV3RcP6td9XSk4LeF0aZuH5Wj8GxYp1sMn";
 
 function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
   return {

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -62,6 +62,9 @@ const CATALOG = [
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
   },
 ] as const;
+const WALRUS_AGGREGATOR = "https://aggregator.example.com";
+const OPAQUE_MOSAIC_BLOB_ID =
+  "Bm7qyNqV3RcP6td9XSk4LeF0aZuH5Wj8GxYp1sMn";
 
 function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
   return {
@@ -105,7 +108,7 @@ function completedEntry(
     submissionNo: 17,
     mintedAtMs: 1700000000000,
     masterId: "0xmaster-1",
-    mosaicWalrusBlobId: "walrus-mosaic-1",
+    mosaicWalrusBlobId: OPAQUE_MOSAIC_BLOB_ID,
     placement: {
       x: 12,
       y: 8,
@@ -118,7 +121,7 @@ function completedEntry(
 }
 
 beforeEach(() => {
-  process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR = "https://aggregator.example.com";
+  process.env.NEXT_PUBLIC_WALRUS_AGGREGATOR = WALRUS_AGGREGATOR;
   useCurrentAccountMock.mockReturnValue(null);
   useCurrentWalletMock.mockReturnValue({
     connectionStatus: "disconnected",
@@ -444,7 +447,7 @@ describe("GalleryClient", () => {
       screen
         .getByAltText(/Demo Athlete One completed mosaic/i)
         .getAttribute("src"),
-    ).toContain("/v1/blobs/walrus-mosaic-1");
+    ).toBe(`${WALRUS_AGGREGATOR}/v1/blobs/${OPAQUE_MOSAIC_BLOB_ID}`);
   });
 
   it("adds a unit-page CTA link to completed entries", async () => {

--- a/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
@@ -78,6 +78,8 @@ vi.mock("./live-progress", () => ({
 import { UnitRevealClient } from "./unit-reveal-client";
 
 const AGGREGATOR_BASE = "https://aggregator.example.com";
+const OPAQUE_MOSAIC_BLOB_ID =
+  "H5f6KfQ7zYvX4mN8pRq2tL9cBd3Aes0WjU1VgSnP";
 
 function completedEntry(
   overrides: Partial<
@@ -91,7 +93,7 @@ function completedEntry(
     submissionNo: 42,
     mintedAtMs: 1700000000000,
     masterId: "0xmaster-1",
-    mosaicWalrusBlobId: "mosaic-gallery-blob",
+    mosaicWalrusBlobId: OPAQUE_MOSAIC_BLOB_ID,
     placement: {
       x: 12,
       y: 34,
@@ -192,8 +194,8 @@ describe("UnitRevealClient", () => {
       expect(screen.getByTestId("placement-highlight")).toBeTruthy();
     });
 
-    expect(screen.getByTestId("reveal-image").getAttribute("src")).toContain(
-      "/v1/blobs/mosaic-gallery-blob",
+    expect(screen.getByTestId("reveal-image").getAttribute("src")).toBe(
+      `${AGGREGATOR_BASE}/v1/blobs/${OPAQUE_MOSAIC_BLOB_ID}`,
     );
   });
 

--- a/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx
@@ -78,8 +78,7 @@ vi.mock("./live-progress", () => ({
 import { UnitRevealClient } from "./unit-reveal-client";
 
 const AGGREGATOR_BASE = "https://aggregator.example.com";
-const OPAQUE_MOSAIC_BLOB_ID =
-  "H5f6KfQ7zYvX4mN8pRq2tL9cBd3Aes0WjU1VgSnP";
+const OPAQUE_MOSAIC_BLOB_ID = "H5f6KfQ7zYvX4mN8pRq2tL9cBd3Aes0WjU1VgSnP";
 
 function completedEntry(
   overrides: Partial<

--- a/generator/src/core.ts
+++ b/generator/src/core.ts
@@ -34,7 +34,15 @@ export type {
   TargetAnalysis,
   TargetAnalysisCell,
 } from "./mosaic";
-export { generateFinalizeMosaic, generateMosaic } from "./mosaic";
+export {
+  FINALIZE_MOSAIC_CONTENT_TYPE,
+  FINALIZE_MOSAIC_HEIGHT,
+  FINALIZE_MOSAIC_TILE_SIZE,
+  FINALIZE_MOSAIC_WEBP_QUALITY,
+  FINALIZE_MOSAIC_WIDTH,
+  generateFinalizeMosaic,
+  generateMosaic,
+} from "./mosaic";
 export {
   type PreparedFinalizeInput,
   type PreparedSubmission,

--- a/generator/src/mosaic.ts
+++ b/generator/src/mosaic.ts
@@ -79,6 +79,7 @@ export type GenerateFinalizeMosaicInput = {
 
 export type GeneratedFinalizeMosaic = {
   image: Uint8Array;
+  contentType: typeof FINALIZE_MOSAIC_CONTENT_TYPE;
   width: number;
   height: number;
   placements: FinalizePlacement[];
@@ -116,10 +117,17 @@ type PreparedTile = {
 };
 
 const defaultTileSize = renderedMosaicTileSizePx;
+export const FINALIZE_MOSAIC_TILE_SIZE = 40;
+export const FINALIZE_MOSAIC_CONTENT_TYPE = "image/webp";
+export const FINALIZE_MOSAIC_WEBP_QUALITY = 88;
 const defaultColorMix = 0.26;
 const defaultOverlayOpacity = 0.12;
 const defaultOverlayBlur = 8;
 const defaultGrid = unitTileGrid;
+export const FINALIZE_MOSAIC_WIDTH =
+  defaultGrid.cols * FINALIZE_MOSAIC_TILE_SIZE;
+export const FINALIZE_MOSAIC_HEIGHT =
+  defaultGrid.rows * FINALIZE_MOSAIC_TILE_SIZE;
 const defaultSubjectPriority = 0.7;
 const defaultFacePriority = 0.22;
 const defaultBackgroundPriority = 0.06;
@@ -265,14 +273,18 @@ export async function generateFinalizeMosaic(
     grid:
       input.grid ??
       deriveFinalizeGridFromSubmissionCount(input.submissions.length),
-    tileSize: input.tileSize ?? defaultTileSize,
+    tileSize: input.tileSize ?? FINALIZE_MOSAIC_TILE_SIZE,
     colorMix: input.colorMix,
     overlayOpacity: input.overlayOpacity,
     overlayBlur: input.overlayBlur,
   });
+  const image = await sharp(result.image)
+    .webp({ quality: FINALIZE_MOSAIC_WEBP_QUALITY })
+    .toBuffer();
 
   return {
-    image: new Uint8Array(result.image),
+    image: new Uint8Array(image),
+    contentType: FINALIZE_MOSAIC_CONTENT_TYPE,
     width: result.width,
     height: result.height,
     metrics: result.metrics,

--- a/generator/src/runtime.ts
+++ b/generator/src/runtime.ts
@@ -64,7 +64,9 @@ export type DefaultFinalizeRunnerDeps = {
   readonly finalizeTransaction: FinalizeRunnerDeps["finalizeTransaction"];
   readonly generateFinalizeMosaic?: (
     prepared: PreparedFinalizeInput,
-  ) => Promise<Pick<GeneratedFinalizeMosaic, "image" | "placements">>;
+  ) => Promise<
+    Pick<GeneratedFinalizeMosaic, "contentType" | "image" | "placements">
+  >;
   readonly readUnitSnapshot: GeneratorUnitSnapshotLoader;
   readonly sampleAverageColor?: AverageColorSampler;
   readonly walrusRead: WalrusReadClient;
@@ -164,7 +166,10 @@ export function createDefaultFinalizeRunner(
         mosaicResult.placements,
         prepared.submissions,
       );
-      const mosaic = await deps.walrusWrite.putBlob(mosaicResult.image);
+      const mosaic = await deps.walrusWrite.putBlob(
+        mosaicResult.image,
+        mosaicResult.contentType,
+      );
       const finalized = await deps.finalizeTransaction({
         unitId,
         mosaicBlobId: mosaic.blobId,

--- a/generator/src/walrus-write.ts
+++ b/generator/src/walrus-write.ts
@@ -17,7 +17,7 @@ export class WalrusWriteError extends Error {
 }
 
 export type WalrusWriteClient = {
-  putBlob(bytes: Uint8Array): Promise<{
+  putBlob(bytes: Uint8Array, contentType?: string): Promise<{
     readonly blobId: string;
     readonly aggregatorUrl: string;
   }>;
@@ -30,7 +30,7 @@ export function createWalrusWriteClient(options: {
   readonly fetchFn?: typeof fetch;
 }): WalrusWriteClient {
   return {
-    async putBlob(bytes: Uint8Array) {
+    async putBlob(bytes: Uint8Array, contentType = "image/png") {
       const fetchFn = options.fetchFn ?? fetch;
       const publisherBaseUrl = trimTrailingSlashes(options.publisherBaseUrl);
       const aggregatorBaseUrl = trimTrailingSlashes(options.aggregatorBaseUrl);
@@ -41,7 +41,7 @@ export function createWalrusWriteClient(options: {
           method: "PUT",
           body: bytes,
           headers: {
-            "content-type": "image/png",
+            "content-type": contentType,
           },
         },
       );

--- a/generator/src/walrus-write.ts
+++ b/generator/src/walrus-write.ts
@@ -17,7 +17,10 @@ export class WalrusWriteError extends Error {
 }
 
 export type WalrusWriteClient = {
-  putBlob(bytes: Uint8Array, contentType?: string): Promise<{
+  putBlob(
+    bytes: Uint8Array,
+    contentType?: string,
+  ): Promise<{
     readonly blobId: string;
     readonly aggregatorUrl: string;
   }>;

--- a/generator/test/mosaic.test.ts
+++ b/generator/test/mosaic.test.ts
@@ -132,6 +132,55 @@ describe("generateMosaic", () => {
     expect(result.placements).toHaveLength(4);
   });
 
+  it(
+    "renders the default 2000-tile finalize mosaic as a compact 1600x2000 WebP",
+    async () => {
+      const targetImage = await solidPng(40, 50, { r: 112, g: 132, b: 156 });
+      const palette = await Promise.all(
+        [
+          { r: 72, g: 92, b: 118 },
+          { r: 112, g: 132, b: 156 },
+          { r: 148, g: 164, b: 184 },
+          { r: 184, g: 190, b: 196 },
+        ].map(async (rgb) => ({
+          rgb,
+          imageBytes: await solidPng(4, 4, rgb),
+        })),
+      );
+      const submissions = Array.from({ length: 40 * 50 }, (_, index) => {
+        const swatch = palette[index % palette.length];
+        const submissionNo = index + 1;
+
+        return {
+          walrusBlobId: `tile-${submissionNo.toString().padStart(4, "0")}`,
+          submissionNo,
+          submitter: `0x${submissionNo.toString(16).padStart(40, "0")}`,
+          submittedAtMs: 1_700_000_000_000 + submissionNo,
+          averageColor: {
+            red: swatch.rgb.r,
+            green: swatch.rgb.g,
+            blue: swatch.rgb.b,
+          },
+          imageBytes: swatch.imageBytes,
+        };
+      });
+
+      const result = await generateFinalizeMosaic({
+        targetImage,
+        submissions,
+      });
+      const metadata = await sharp(result.image).metadata();
+
+      expect(result.width).toBe(1600);
+      expect(result.height).toBe(2000);
+      expect(result.image.byteLength).toBeLessThanOrEqual(15 * 1024 * 1024);
+      expect(metadata.format).toBe("webp");
+      expect(metadata.width).toBe(1600);
+      expect(metadata.height).toBe(2000);
+    },
+    60_000,
+  );
+
   it("derives an exact fallback grid from submission count when none is provided", async () => {
     const submissions = [
       await buildSubmission("tile-a", 1, "0x1", { r: 20, g: 20, b: 20 }),

--- a/generator/test/mosaic.test.ts
+++ b/generator/test/mosaic.test.ts
@@ -132,54 +132,50 @@ describe("generateMosaic", () => {
     expect(result.placements).toHaveLength(4);
   });
 
-  it(
-    "renders the default 2000-tile finalize mosaic as a compact 1600x2000 WebP",
-    async () => {
-      const targetImage = await solidPng(40, 50, { r: 112, g: 132, b: 156 });
-      const palette = await Promise.all(
-        [
-          { r: 72, g: 92, b: 118 },
-          { r: 112, g: 132, b: 156 },
-          { r: 148, g: 164, b: 184 },
-          { r: 184, g: 190, b: 196 },
-        ].map(async (rgb) => ({
-          rgb,
-          imageBytes: await solidPng(4, 4, rgb),
-        })),
-      );
-      const submissions = Array.from({ length: 40 * 50 }, (_, index) => {
-        const swatch = palette[index % palette.length];
-        const submissionNo = index + 1;
+  it("renders the default 2000-tile finalize mosaic as a compact 1600x2000 WebP", async () => {
+    const targetImage = await solidPng(40, 50, { r: 112, g: 132, b: 156 });
+    const palette = await Promise.all(
+      [
+        { r: 72, g: 92, b: 118 },
+        { r: 112, g: 132, b: 156 },
+        { r: 148, g: 164, b: 184 },
+        { r: 184, g: 190, b: 196 },
+      ].map(async (rgb) => ({
+        rgb,
+        imageBytes: await solidPng(4, 4, rgb),
+      })),
+    );
+    const submissions = Array.from({ length: 40 * 50 }, (_, index) => {
+      const swatch = palette[index % palette.length];
+      const submissionNo = index + 1;
 
-        return {
-          walrusBlobId: `tile-${submissionNo.toString().padStart(4, "0")}`,
-          submissionNo,
-          submitter: `0x${submissionNo.toString(16).padStart(40, "0")}`,
-          submittedAtMs: 1_700_000_000_000 + submissionNo,
-          averageColor: {
-            red: swatch.rgb.r,
-            green: swatch.rgb.g,
-            blue: swatch.rgb.b,
-          },
-          imageBytes: swatch.imageBytes,
-        };
-      });
+      return {
+        walrusBlobId: `tile-${submissionNo.toString().padStart(4, "0")}`,
+        submissionNo,
+        submitter: `0x${submissionNo.toString(16).padStart(40, "0")}`,
+        submittedAtMs: 1_700_000_000_000 + submissionNo,
+        averageColor: {
+          red: swatch.rgb.r,
+          green: swatch.rgb.g,
+          blue: swatch.rgb.b,
+        },
+        imageBytes: swatch.imageBytes,
+      };
+    });
 
-      const result = await generateFinalizeMosaic({
-        targetImage,
-        submissions,
-      });
-      const metadata = await sharp(result.image).metadata();
+    const result = await generateFinalizeMosaic({
+      targetImage,
+      submissions,
+    });
+    const metadata = await sharp(result.image).metadata();
 
-      expect(result.width).toBe(1600);
-      expect(result.height).toBe(2000);
-      expect(result.image.byteLength).toBeLessThanOrEqual(15 * 1024 * 1024);
-      expect(metadata.format).toBe("webp");
-      expect(metadata.width).toBe(1600);
-      expect(metadata.height).toBe(2000);
-    },
-    60_000,
-  );
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(2000);
+    expect(result.image.byteLength).toBeLessThanOrEqual(15 * 1024 * 1024);
+    expect(metadata.format).toBe("webp");
+    expect(metadata.width).toBe(1600);
+    expect(metadata.height).toBe(2000);
+  }, 60_000);
 
   it("derives an exact fallback grid from submission count when none is provided", async () => {
     const submissions = [

--- a/generator/test/mosaic.test.ts
+++ b/generator/test/mosaic.test.ts
@@ -1,7 +1,14 @@
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 
-import { generateFinalizeMosaic, generateMosaic } from "../src";
+import {
+  FINALIZE_MOSAIC_CONTENT_TYPE,
+  FINALIZE_MOSAIC_HEIGHT,
+  FINALIZE_MOSAIC_TILE_SIZE,
+  FINALIZE_MOSAIC_WIDTH,
+  generateFinalizeMosaic,
+  generateMosaic,
+} from "../src";
 
 describe("generateMosaic", () => {
   it("renders a mosaic with unique tile placement and expected dimensions", async () => {
@@ -94,6 +101,35 @@ describe("generateMosaic", () => {
       x: 1,
       y: 1,
     });
+  });
+
+  it("uses finalize WebP defaults without changing the shared mosaic API", async () => {
+    const targetImage = await buildQuadrantTarget();
+    const submissions = [
+      await buildSubmission("tile-black", 1, "0x1", { r: 10, g: 10, b: 10 }),
+      await buildSubmission("tile-red", 2, "0x2", { r: 210, g: 40, b: 30 }),
+      await buildSubmission("tile-green", 3, "0x3", { r: 35, g: 180, b: 70 }),
+      await buildSubmission("tile-blue", 4, "0x4", { r: 30, g: 80, b: 210 }),
+    ];
+
+    const result = await generateFinalizeMosaic({
+      targetImage,
+      submissions,
+      grid: { cols: 2, rows: 2 },
+    });
+    const metadata = await sharp(result.image).metadata();
+
+    expect(FINALIZE_MOSAIC_TILE_SIZE).toBe(40);
+    expect(FINALIZE_MOSAIC_WIDTH).toBe(1600);
+    expect(FINALIZE_MOSAIC_HEIGHT).toBe(2000);
+    expect(FINALIZE_MOSAIC_CONTENT_TYPE).toBe("image/webp");
+    expect(result.width).toBe(80);
+    expect(result.height).toBe(80);
+    expect(result.contentType).toBe("image/webp");
+    expect(metadata.width).toBe(80);
+    expect(metadata.height).toBe(80);
+    expect(metadata.format).toBe("webp");
+    expect(result.placements).toHaveLength(4);
   });
 
   it("derives an exact fallback grid from submission count when none is provided", async () => {

--- a/generator/test/runtime.test.ts
+++ b/generator/test/runtime.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { PreparedFinalizeInput } from "../src";
-import { createDefaultFinalizeRunner, createFinalizeRunner } from "../src";
+import {
+  createDefaultFinalizeRunner,
+  createFinalizeRunner,
+  FINALIZE_MOSAIC_CONTENT_TYPE,
+} from "../src";
 
 describe("createFinalizeRunner", () => {
   it("absorbs units that are already finalized before any heavy work starts", async () => {
@@ -270,6 +274,7 @@ describe("createDefaultFinalizeRunner", () => {
   it("uses the improved mosaic generator result for walrus put and finalize", async () => {
     const generateFinalizeMosaic = vi.fn(async () => ({
       image: new Uint8Array([7, 8, 9]),
+      contentType: "image/webp" as const,
       placements: [
         {
           walrusBlobId: "submission-1",
@@ -314,7 +319,10 @@ describe("createDefaultFinalizeRunner", () => {
       placementCount: 1,
     });
     expect(generateFinalizeMosaic).toHaveBeenCalledTimes(1);
-    expect(putBlob).toHaveBeenCalledWith(new Uint8Array([7, 8, 9]));
+    expect(putBlob).toHaveBeenCalledWith(
+      new Uint8Array([7, 8, 9]),
+      FINALIZE_MOSAIC_CONTENT_TYPE,
+    );
     expect(finalizeTransaction).toHaveBeenCalledWith({
       unitId: "0xunit-1",
       mosaicBlobId: "mosaic-blob",
@@ -351,6 +359,7 @@ describe("createDefaultFinalizeRunner", () => {
       sampleAverageColor: vi.fn(() => ({ red: 1, green: 2, blue: 3 })),
       generateFinalizeMosaic: vi.fn(async () => ({
         image: new Uint8Array([7, 8, 9]),
+        contentType: "image/webp" as const,
         placements: [
           {
             walrusBlobId: "submission-1",

--- a/generator/test/walrus-write.test.ts
+++ b/generator/test/walrus-write.test.ts
@@ -30,6 +30,42 @@ describe("createWalrusWriteClient", () => {
       "https://publisher.example/v1/blobs?epochs=50",
       expect.objectContaining({
         method: "PUT",
+        headers: {
+          "content-type": "image/png",
+        },
+      }),
+    );
+  });
+
+  it("overrides the upload content type when provided", async () => {
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            alreadyCertified: {
+              blobId: "mosaic-blob-webp",
+            },
+          }),
+        ),
+    );
+    const client = createWalrusWriteClient({
+      publisherBaseUrl: "https://publisher.example",
+      aggregatorBaseUrl: "https://aggregator.example",
+      fetchFn,
+    });
+
+    await expect(
+      client.putBlob(new Uint8Array([1, 2, 3]), "image/webp"),
+    ).resolves.toEqual({
+      blobId: "mosaic-blob-webp",
+      aggregatorUrl: "https://aggregator.example/v1/blobs/mosaic-blob-webp",
+    });
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://publisher.example/v1/blobs?epochs=50",
+      expect.objectContaining({
+        headers: {
+          "content-type": "image/webp",
+        },
       }),
     );
   });


### PR DESCRIPTION
## 概要

finalize 後の完成モザイクを軽くします。

これまで完成画像は `8000 x 10000` の PNG でした。
Web 表示やデモ共有には大きすぎました。

この PR では、完成画像を `1600 x 2000` の WebP にします。
Walrus へ保存するときの content-type も `image/webp` にします。

## 変更内容

- `generator/src/mosaic.ts`
  - finalize 専用の tile size を `40` にしました。
  - 完成画像を WebP quality `88` で出力します。
  - 出力 bytes と content-type を一緒に返します。

- `generator/src/walrus-write.ts`
  - `putBlob()` で content-type を指定できるようにしました。
  - 省略時はこれまで通り `image/png` です。

- `generator/src/runtime.ts`
  - finalize モザイクの content-type を Walrus PUT に渡します。
  - on-chain finalize payload は blob ID のままです。

- `generator/test/mosaic.test.ts`
  - 既定出力が `1600 x 2000` の WebP になることを確認します。
  - 2000 tile 相当の出力が 15 MiB 以下になることを確認します。

- `generator/test/runtime.test.ts`
  - default finalize 経路が `image/webp` で PUT することを確認します。

- `generator/test/walrus-write.test.ts`
  - content-type の既定値と上書きを確認します。

- `apps/web/src/app/units/[unitId]/unit-reveal-client.test.tsx`
  - reveal 画像が aggregator URL をそのまま使うことを確認します。

- `apps/web/src/app/gallery/gallery-client.test.tsx`
  - gallery 画像が aggregator URL をそのまま使うことを確認します。

## 関連する Issue やチケット

Close #83

## 動作確認

- `corepack pnpm --filter generator test`
- `corepack pnpm --filter web test -- unit-reveal-client`
- `corepack pnpm --filter web test -- gallery-client`
- `corepack pnpm --filter generator typecheck`
- `corepack pnpm typecheck`
- `corepack pnpm run check`

PR 前レビュー:

- `verification_reviewer`: blocking なし
