### PR TITLE
feat: Kakera NFT の Object Display を追加

### DIFF
--- a/apps/web/scripts/run-local-generator.mjs
+++ b/apps/web/scripts/run-local-generator.mjs
@@ -224,7 +224,10 @@ function defaultRunDockerRemove({ containerName }) {
   });
 }
 
-function attachDockerContainerCleanup(child, { containerName, runDockerRemove }) {
+function attachDockerContainerCleanup(
+  child,
+  { containerName, runDockerRemove },
+) {
   if (!child || typeof child.kill !== "function") {
     return;
   }

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -422,6 +422,11 @@ describe("GalleryClient", () => {
     expect(screen.getByText(/Waiting for reveal/i)).toBeTruthy();
     expect(screen.getByText(/Submission #17/i)).toBeTruthy();
     expect(
+      screen
+        .getByAltText(/Demo Athlete One original submission/i)
+        .getAttribute("src"),
+    ).toBe(`${WALRUS_AGGREGATOR}/v1/blobs/walrus-original-1`);
+    expect(
       screen.queryByRole("link", { name: /unit ページで位置を見る/i }),
     ).toBeNull();
   });

--- a/apps/web/src/lib/admin/health.test.ts
+++ b/apps/web/src/lib/admin/health.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import testnetDeploymentManifest from "../../../../../ops/deployments/testnet.json";
 import { getAdminHealth } from "./health";
 
-const MANIFEST_PACKAGE_ID =
-  "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf";
+const MANIFEST_PACKAGE_ID = testnetDeploymentManifest.packageId;
 
 const EXPECTED_DEPLOYMENT = {
-  network: "testnet",
+  network: testnetDeploymentManifest.network,
   packageId: MANIFEST_PACKAGE_ID,
 };
 

--- a/apps/web/src/lib/enoki/submit-photo.test.ts
+++ b/apps/web/src/lib/enoki/submit-photo.test.ts
@@ -115,6 +115,10 @@ describe("resolveRuntimeEnv", () => {
 });
 
 describe("sponsorSubmitPhoto", () => {
+  it("keeps the sponsored target pinned to accessors::submit_photo only", () => {
+    expect(submitPhotoTarget("0xpkg")).toBe("0xpkg::accessors::submit_photo");
+  });
+
   it("validates the JWT and restricts sponsorship to submit_photo", async () => {
     const getZkLogin = vi.fn(async () => ({
       address: "0xsender",

--- a/contracts/Published.toml
+++ b/contracts/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf"
-original-id = "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf"
+published-at = "0xf00703a89a105784ef6728e8160bc4a8b20646d39b037e7233340ee431412be3"
+original-id = "0xf00703a89a105784ef6728e8160bc4a8b20646d39b037e7233340ee431412be3"
 version = 1
 toolchain-version = "1.70.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x626f219a716a86cfc449f2ac2cca50426663ed5c5572a8ca32badc2654bd1639"
+upgrade-capability = "0xf036379de649918f409e6ab944167cb2fdc3e00554cc456137d9d9cd5f41d84c"

--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -1,5 +1,11 @@
 module one_portrait::registry;
 
+use std::string::{Self as string, String};
+use sui::display;
+use sui::package;
+
+use one_portrait::kakera::Kakera;
+
 public struct REGISTRY has drop {}
 
 public struct AdminCap has key, store {
@@ -11,15 +17,43 @@ public struct Registry has key {
     unit_ids: vector<ID>,
 }
 
-fun init(_witness: REGISTRY, ctx: &mut TxContext) {
+fun init(witness: REGISTRY, ctx: &mut TxContext) {
     let admin_cap = AdminCap { id: object::new(ctx) };
     let registry = Registry {
         id: object::new(ctx),
         unit_ids: vector[],
     };
+    let publisher = package::claim(witness, ctx);
+    let mut kakera_display = display::new_with_fields<Kakera>(
+        &publisher,
+        kakera_display_fields(),
+        kakera_display_values(),
+        ctx,
+    );
+    display::update_version(&mut kakera_display);
 
     transfer::transfer(admin_cap, tx_context::sender(ctx));
     transfer::share_object(registry);
+    transfer::public_transfer(publisher, tx_context::sender(ctx));
+    transfer::public_transfer(kakera_display, tx_context::sender(ctx));
+}
+
+fun kakera_display_fields(): vector<String> {
+    vector[
+        string::utf8(b"name"),
+        string::utf8(b"description"),
+        string::utf8(b"image_url"),
+        string::utf8(b"project_url"),
+    ]
+}
+
+fun kakera_display_values(): vector<String> {
+    vector[
+        string::utf8(b"ONE Portrait Kakera #{submission_no}"),
+        string::utf8(b"Soulbound proof of participation in ONE Portrait."),
+        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/demo/demo_mozaiku.png"),
+        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/"),
+    ]
 }
 
 public(package) fun record_unit(_admin_cap: &AdminCap, registry: &mut Registry, unit_id: ID) {

--- a/contracts/tests/registry_admin_tests.move
+++ b/contracts/tests/registry_admin_tests.move
@@ -3,12 +3,17 @@ module one_portrait::registry_admin_tests;
 
 use std::unit_test::assert_eq;
 use one_portrait::admin_api;
+use one_portrait::kakera::Kakera;
 use one_portrait::registry::{Self as registry, AdminCap, Registry};
 use one_portrait::unit::{Self as unit, Unit};
+use std::string::{Self as string};
+use sui::display::{Self as display, Display};
+use sui::package::Publisher;
 use sui::test_scenario;
+use sui::vec_map;
 
 #[test]
-fun init_creates_admin_cap_and_shared_registry() {
+fun init_creates_admin_cap_kakera_display_and_shared_registry() {
     let publisher = @0xA11CE;
     let mut scenario = test_scenario::begin(publisher);
 
@@ -17,11 +22,33 @@ fun init_creates_admin_cap_and_shared_registry() {
     scenario.next_tx(publisher);
 
     let admin_cap = scenario.take_from_sender<AdminCap>();
+    let publisher = scenario.take_from_sender<Publisher>();
+    let kakera_display = scenario.take_from_sender<Display<Kakera>>();
     let registry = scenario.take_shared<Registry>();
 
     assert_eq!(registry::unit_count_for_testing(&registry), 0);
+    assert_eq!(display::version(&kakera_display), 1);
+    assert_eq!(vec_map::length(display::fields(&kakera_display)), 4);
+    assert_eq!(
+        *vec_map::get(display::fields(&kakera_display), &string::utf8(b"name")),
+        string::utf8(b"ONE Portrait Kakera #{submission_no}")
+    );
+    assert_eq!(
+        *vec_map::get(display::fields(&kakera_display), &string::utf8(b"description")),
+        string::utf8(b"Soulbound proof of participation in ONE Portrait.")
+    );
+    assert_eq!(
+        *vec_map::get(display::fields(&kakera_display), &string::utf8(b"image_url")),
+        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/demo/demo_mozaiku.png")
+    );
+    assert_eq!(
+        *vec_map::get(display::fields(&kakera_display), &string::utf8(b"project_url")),
+        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/")
+    );
 
     scenario.return_to_sender(admin_cap);
+    scenario.return_to_sender(publisher);
+    scenario.return_to_sender(kakera_display);
     test_scenario::return_shared(registry);
     scenario.end();
 }

--- a/ops/deployments/testnet.json
+++ b/ops/deployments/testnet.json
@@ -1,8 +1,8 @@
 {
   "network": "testnet",
-  "packageId": "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
-  "registryObjectId": "0x22cca7fbd9392a1fc24c4b1e038c99d23c5a23d72ed63a67893c39ce8374533f",
-  "adminCapId": "0x3799b336f8163162451f4583c9213c432df2bd5145514fcc8089cc3f67de416e",
+  "packageId": "0xf00703a89a105784ef6728e8160bc4a8b20646d39b037e7233340ee431412be3",
+  "registryObjectId": "0x5cfbf8ddfb6b57dfc7a1506d9ab272a4b089a293f9f0a77487f2f97103a9f713",
+  "adminCapId": "0xbfbea978136dd6a6ffdf5f2e7fb33f66bbe20b81c7bb97fee744d979719c77b6",
   "walrusPublisher": "https://publisher.walrus-testnet.walrus.space",
   "walrusAggregator": "https://aggregator.walrus-testnet.walrus.space",
   "enokiPublicApiKey": "enoki_public_f6adc0082f791a0a226ac20f81a9f635",

--- a/test/deployment-env.test.ts
+++ b/test/deployment-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import testnetDeploymentManifest from "../ops/deployments/testnet.json";
 import {
   checkPublishedTomlDrift,
   parseDeploymentManifest,
@@ -7,19 +8,7 @@ import {
   toWebPublicEnv,
 } from "../scripts/deployment-env.mjs";
 
-const VALID_MANIFEST = {
-  network: "testnet",
-  packageId:
-    "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
-  registryObjectId:
-    "0x22cca7fbd9392a1fc24c4b1e038c99d23c5a23d72ed63a67893c39ce8374533f",
-  adminCapId:
-    "0x3799b336f8163162451f4583c9213c432df2bd5145514fcc8089cc3f67de416e",
-  walrusPublisher: "https://publisher.walrus-testnet.walrus.space",
-  walrusAggregator: "https://aggregator.walrus-testnet.walrus.space",
-  enokiPublicApiKey: "enoki_public_example",
-  googleClientId: "google-client-id.apps.googleusercontent.com",
-};
+const VALID_MANIFEST = testnetDeploymentManifest;
 
 describe("deployment manifest", () => {
   it("exports web public and generator env", () => {


### PR DESCRIPTION
## 概要
Kakera NFT に Sui Object Display を追加し、wallet や explorer で画像付きで表示できる土台を入れます。
Kakera の field や `submit_photo` の署名は変えず、`/gallery` と Sponsored Tx の既存動作は維持します。

あわせて新しい contract を testnet に publish し、manifest の deploy ID を最新化しました。

## 変更内容
- `contracts/sources/registry.move`
  - package init で `Publisher` を claim し、`Display<Kakera>` を作成
  - `name` `description` `image_url` `project_url` を設定
  - `Display<Kakera>` の version を更新して初期化者へ transfer
- `contracts/tests/registry_admin_tests.move`
  - init 直後に `Publisher` と `Display<Kakera>` が作られることを追加検証
  - Display の field 値と version を確認
- `apps/web/src/app/gallery/gallery-client.test.tsx`
  - pending Kakera の原画像が引き続き Walrus aggregator URL で描画されることを確認
- `apps/web/src/lib/enoki/submit-photo.test.ts`
  - Sponsored Tx の target が `accessors::submit_photo` のみであることを明示
- `apps/web/scripts/run-local-generator.mjs`
  - repo-wide `pnpm run check` を通すために既存の Biome 整形崩れを修正
- `contracts/Published.toml`
  - 最新の testnet publish 結果に `published-at` と `upgrade-capability` を更新
- `ops/deployments/testnet.json`
  - `packageId` `registryObjectId` `adminCapId` を最新 publish 結果へ更新

## 関連する Issue やチケット
Close #87

## 動作確認
- `curl -I --fail --silent --show-error https://one-portrait-web.bububutasan00.workers.dev/demo/demo_mozaiku.png`
- `cd contracts && sui move build`
- `cd contracts && sui move test --test`
- `corepack pnpm run typecheck`
- `corepack pnpm test`
- `corepack pnpm run check`
- `cd contracts && sui client publish . --json`
- `sui client object 0x5cfbf8ddfb6b57dfc7a1506d9ab272a4b089a293f9f0a77487f2f97103a9f713 --json`
- `corepack pnpm run check:deployment`

## Publish 結果
- digest: `9AcnBM2Neftu92uxv2pzyhyy9FQfmQCUZELx1jvjoCAe`
- packageId: `0xf00703a89a105784ef6728e8160bc4a8b20646d39b037e7233340ee431412be3`
- registryObjectId: `0x5cfbf8ddfb6b57dfc7a1506d9ab272a4b089a293f9f0a77487f2f97103a9f713`
- adminCapId: `0xbfbea978136dd6a6ffdf5f2e7fb33f66bbe20b81c7bb97fee744d979719c77b6`

## 補足
- `image_url` は既存の公開 asset を指し、PR 時点で HTTP 200 を確認済みです。
- `apps/web/.env.local` にも同じ最新 ID を反映しましたが、このファイルは ignore 対象のため PR には含めていません。
- testnet publish 後の `showDisplay: true` 実確認は未実施です。
