### PR TITLE
fix: generator tunnelのKV heartbeatを追加

### DIFF
--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -150,6 +150,103 @@ describe("runGeneratorStackTunnel", () => {
     expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
+  it("writes named tunnel remote runtime after external health and keeps it fresh", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const generatorChild = createChildProcess("generator");
+    const tunnelChild = createChildProcess("tunnel");
+    const localHealth = createDeferred();
+    const externalHealth = createDeferred();
+
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      publicBaseUrl: "https://generator.example",
+      publicHostname: "generator.example",
+      tunnelName: "one-portrait-generator",
+      tunnelMode: "named",
+    });
+    const startLocalGenerator = vi.fn().mockResolvedValue({
+      child: generatorChild,
+    });
+    const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return localHealth.promise;
+      }
+
+      return externalHealth.promise;
+    });
+
+    const runPromise = runGeneratorStackTunnel({
+      env: {
+        OP_FINALIZE_DISPATCH_URL: "https://generator.example",
+        OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
+      },
+      heartbeatIntervalMs: 10,
+      logger,
+      preflight,
+      processImpl,
+      spawnImpl,
+      startLocalGenerator,
+      waitForHealth,
+    });
+
+    try {
+      await settle();
+      localHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][local][ready]",
+        ok: true,
+      });
+      await settle();
+
+      expect(writeRemoteGeneratorRuntimeMock).not.toHaveBeenCalled();
+
+      externalHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][external][ready]",
+        ok: true,
+      });
+      await settle();
+
+      expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "named",
+          url: "https://generator.example",
+        }),
+      );
+      expect(
+        writeRemoteGeneratorRuntimeMock.mock.invocationCallOrder[0],
+      ).toBeGreaterThan(waitForHealth.mock.invocationCallOrder[1]);
+      expect(logger.info).toHaveBeenCalledWith("[generator-stack][ready]");
+      expect(
+        logger.info.mock.invocationCallOrder.find(
+          (_order, index) =>
+            logger.info.mock.calls[index]?.[0] === "[generator-stack][ready]",
+        ),
+      ).toBeGreaterThan(
+        writeRemoteGeneratorRuntimeMock.mock.invocationCallOrder[0],
+      );
+
+      await delay(25);
+
+      expect(writeRemoteGeneratorRuntimeMock.mock.calls.length).toBeGreaterThan(
+        1,
+      );
+      expect(
+        writeRemoteGeneratorRuntimeMock.mock.calls.every(
+          ([input]) =>
+            input.mode === "named" && input.url === "https://generator.example",
+        ),
+      ).toBe(true);
+    } finally {
+      tunnelChild.emit("exit", 1, null);
+      await runPromise;
+    }
+  });
+
   it("keeps waiting on local health timeouts until interrupted by SIGINT", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
@@ -696,6 +793,94 @@ describe("runGeneratorStackTunnel", () => {
     }
   });
 
+  it("waits for quick tunnel external health before writing remote runtime", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const generatorChild = createChildProcess("generator");
+    const tunnelChild = createChildProcess("tunnel");
+    const appRootPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "one-portrait-quick-tunnel-order-"),
+    );
+    const localHealth = createDeferred();
+    const externalHealth = createDeferred();
+
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      tunnelMode: "quick",
+    });
+    const startLocalGenerator = vi.fn().mockResolvedValue({
+      child: generatorChild,
+    });
+    const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return localHealth.promise;
+      }
+
+      return externalHealth.promise;
+    });
+
+    const runPromise = runGeneratorStackTunnel({
+      appRootPath,
+      env: {},
+      heartbeatIntervalMs: 10,
+      logger,
+      preflight,
+      processImpl,
+      spawnImpl,
+      startLocalGenerator,
+      waitForHealth,
+    });
+
+    try {
+      await settle();
+      localHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][local][ready]",
+        ok: true,
+      });
+      await settle();
+
+      tunnelChild.stdout.emit(
+        "data",
+        "Quick Tunnel ready: https://fresh-runtime.trycloudflare.com\n",
+      );
+      await settle();
+
+      expect(waitForHealth).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          label: "external",
+          url: "https://fresh-runtime.trycloudflare.com/health",
+        }),
+      );
+      expect(writeRemoteGeneratorRuntimeMock).not.toHaveBeenCalled();
+
+      externalHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][external][ready]",
+        ok: true,
+      });
+      await settle();
+
+      expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "quick",
+          url: "https://fresh-runtime.trycloudflare.com",
+        }),
+      );
+      expect(
+        writeRemoteGeneratorRuntimeMock.mock.invocationCallOrder[0],
+      ).toBeGreaterThan(waitForHealth.mock.invocationCallOrder[1]);
+    } finally {
+      tunnelChild.emit("exit", 1, null);
+      await runPromise;
+      fs.rmSync(appRootPath, { force: true, recursive: true });
+    }
+  });
+
   it("respects a custom runtime state path from merged env", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
@@ -951,5 +1136,11 @@ function createProcessMock() {
 async function settle() {
   await new Promise((resolve) => {
     setImmediate(resolve);
+  });
+}
+
+async function delay(ms: number) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
 }

--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -755,14 +755,7 @@ describe("runGeneratorStackTunnel", () => {
           url: "https://fresh-runtime.trycloudflare.com/health",
         }),
       );
-      expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          env: expect.objectContaining({}),
-          logger,
-          mode: "quick",
-          url: "https://fresh-runtime.trycloudflare.com",
-        }),
-      );
+      expect(writeRemoteGeneratorRuntimeMock).not.toHaveBeenCalled();
       expect(fs.existsSync(runtimeStatePath)).toBe(true);
 
       externalHealth.resolve({
@@ -771,6 +764,15 @@ describe("runGeneratorStackTunnel", () => {
         ok: true,
       });
       await settle();
+
+      expect(writeRemoteGeneratorRuntimeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({}),
+          logger,
+          mode: "quick",
+          url: "https://fresh-runtime.trycloudflare.com",
+        }),
+      );
 
       expect(logger.info).toHaveBeenCalledWith("[generator-stack][ready]");
 
@@ -1007,6 +1009,7 @@ describe("runGeneratorStackTunnel", () => {
     const generatorChild = createChildProcess("generator");
     const tunnelChild = createChildProcess("tunnel");
     const localHealth = createDeferred();
+    const externalHealth = createDeferred();
 
     const preflight = vi.fn().mockResolvedValue({
       exitCode: 0,
@@ -1023,7 +1026,7 @@ describe("runGeneratorStackTunnel", () => {
         return localHealth.promise;
       }
 
-      throw new Error(`unexpected health probe for ${label}`);
+      return externalHealth.promise;
     });
 
     writeRemoteGeneratorRuntimeMock.mockResolvedValueOnce({
@@ -1052,6 +1055,15 @@ describe("runGeneratorStackTunnel", () => {
       "data",
       "Quick Tunnel ready: https://failed-sync.trycloudflare.com\n",
     );
+    await settle();
+
+    expect(writeRemoteGeneratorRuntimeMock).not.toHaveBeenCalled();
+
+    externalHealth.resolve({
+      exitCode: 0,
+      marker: "[generator-stack][health][external][ready]",
+      ok: true,
+    });
 
     await expect(runPromise).resolves.toEqual({
       exitCode: 1,

--- a/apps/web/scripts/generator-stack-tunnel.test.ts
+++ b/apps/web/scripts/generator-stack-tunnel.test.ts
@@ -883,6 +883,164 @@ describe("runGeneratorStackTunnel", () => {
     }
   });
 
+  it("stops children, cleans remote runtime, and exits non-zero when heartbeat fails", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const generatorChild = createChildProcess("generator");
+    const tunnelChild = createChildProcess("tunnel");
+    const localHealth = createDeferred();
+    const externalHealth = createDeferred();
+
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      publicBaseUrl: "https://generator.example",
+      publicHostname: "generator.example",
+      tunnelName: "one-portrait-generator",
+      tunnelMode: "named",
+    });
+    const startLocalGenerator = vi.fn().mockResolvedValue({
+      child: generatorChild,
+    });
+    const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return localHealth.promise;
+      }
+
+      return externalHealth.promise;
+    });
+
+    writeRemoteGeneratorRuntimeMock
+      .mockResolvedValueOnce({
+        marker: "[generator-runtime][remote-kv][written]",
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        marker: "[generator-runtime][remote-kv][write-failed]",
+        ok: false,
+      });
+
+    const runPromise = runGeneratorStackTunnel({
+      env: {
+        OP_FINALIZE_DISPATCH_URL: "https://generator.example",
+        OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
+      },
+      heartbeatIntervalMs: 10,
+      logger,
+      preflight,
+      processImpl,
+      spawnImpl,
+      startLocalGenerator,
+      waitForHealth,
+    });
+
+    try {
+      await settle();
+      localHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][local][ready]",
+        ok: true,
+      });
+      await settle();
+      externalHealth.resolve({
+        exitCode: 0,
+        marker: "[generator-stack][health][external][ready]",
+        ok: true,
+      });
+      await settle();
+
+      await expect(withTimeout(runPromise, 80)).resolves.toEqual({
+        exitCode: 1,
+        marker: "[generator-stack][remote-kv][heartbeat-failed]",
+        ok: false,
+      });
+      expect(generatorChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(tunnelChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[generator-stack][remote-kv][heartbeat-failed] marker=[generator-runtime][remote-kv][write-failed]",
+      );
+      expect(deleteRemoteGeneratorRuntimeMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          logger,
+        }),
+      );
+    } finally {
+      tunnelChild.emit("exit", 1, null);
+      await runPromise;
+    }
+  });
+
+  it("stops heartbeat writes after tunnel exit", async () => {
+    const logger = createLogger();
+    const processImpl = createProcessMock();
+    const generatorChild = createChildProcess("generator");
+    const tunnelChild = createChildProcess("tunnel");
+    const localHealth = createDeferred();
+    const externalHealth = createDeferred();
+
+    const preflight = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      localPort: 8080,
+      ok: true,
+      publicBaseUrl: "https://generator.example",
+      publicHostname: "generator.example",
+      tunnelName: "one-portrait-generator",
+      tunnelMode: "named",
+    });
+    const startLocalGenerator = vi.fn().mockResolvedValue({
+      child: generatorChild,
+    });
+    const spawnImpl = vi.fn().mockReturnValue(tunnelChild);
+    const waitForHealth = vi.fn(({ label }: { label: string }) => {
+      if (label === "local") {
+        return localHealth.promise;
+      }
+
+      return externalHealth.promise;
+    });
+
+    const runPromise = runGeneratorStackTunnel({
+      env: {
+        OP_FINALIZE_DISPATCH_URL: "https://generator.example",
+        OP_LOCAL_TUNNEL_NAME: "one-portrait-generator",
+      },
+      heartbeatIntervalMs: 10,
+      logger,
+      preflight,
+      processImpl,
+      spawnImpl,
+      startLocalGenerator,
+      waitForHealth,
+    });
+
+    await settle();
+    localHealth.resolve({
+      exitCode: 0,
+      marker: "[generator-stack][health][local][ready]",
+      ok: true,
+    });
+    await settle();
+    externalHealth.resolve({
+      exitCode: 0,
+      marker: "[generator-stack][health][external][ready]",
+      ok: true,
+    });
+    await settle();
+    await delay(25);
+    const writeCountBeforeExit =
+      writeRemoteGeneratorRuntimeMock.mock.calls.length;
+
+    tunnelChild.emit("exit", 1, null);
+    await runPromise;
+    await delay(25);
+
+    expect(writeRemoteGeneratorRuntimeMock.mock.calls.length).toBe(
+      writeCountBeforeExit,
+    );
+  });
+
   it("respects a custom runtime state path from merged env", async () => {
     const logger = createLogger();
     const processImpl = createProcessMock();
@@ -1155,4 +1313,14 @@ async function delay(ms: number) {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number) {
+  return Promise.race([
+    promise,
+    delay(ms).then(() => ({
+      marker: "[test][timeout]",
+      ok: false,
+    })),
+  ]);
 }

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -24,10 +24,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const webRoot = path.resolve(__dirname, "..");
 const DEFAULT_LOCAL_PORT = 8080;
+const GENERATOR_RUNTIME_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 
 export async function runGeneratorStackTunnel({
   appRootPath = webRoot,
   env = process.env,
+  heartbeatIntervalMs = GENERATOR_RUNTIME_HEARTBEAT_INTERVAL_MS,
   logger = console,
   preflight = runGeneratorStackPreflight,
   processImpl = process,
@@ -41,6 +43,7 @@ export async function runGeneratorStackTunnel({
   let generator = null;
   let tunnel = null;
   let tunnelChild = null;
+  let remoteRuntimeHeartbeat = null;
   let remoteRuntimeInitialized = false;
   const mergedEnv = loadWebScriptEnv({
     env,
@@ -241,6 +244,14 @@ export async function runGeneratorStackTunnel({
         ok: false,
       };
     }
+    remoteRuntimeHeartbeat = createRemoteRuntimeHeartbeat({
+      env: mergedEnv,
+      intervalMs: heartbeatIntervalMs,
+      logger,
+      mode: preflightResult.tunnelMode,
+      url: publicBaseUrl,
+      writeRemoteRuntime,
+    });
 
     logger?.info?.("[generator-stack][ready]");
 
@@ -272,6 +283,7 @@ export async function runGeneratorStackTunnel({
       tunnel,
     });
   } finally {
+    await remoteRuntimeHeartbeat?.stop();
     if (remoteRuntimeInitialized) {
       await deleteRemoteRuntime({
         env: mergedEnv,
@@ -281,6 +293,48 @@ export async function runGeneratorStackTunnel({
     signalState.cleanup();
     removeGeneratorRuntimeState({ appRootPath, env: mergedEnv });
   }
+}
+
+function createRemoteRuntimeHeartbeat({
+  env,
+  intervalMs,
+  logger,
+  mode,
+  url,
+  writeRemoteRuntime,
+}) {
+  let inFlight = null;
+  let stopped = false;
+  const timer = setInterval(() => {
+    if (inFlight !== null || stopped) {
+      return;
+    }
+
+    inFlight = writeRemoteRuntime({
+      env,
+      logger,
+      mode,
+      url,
+    })
+      .then((result) => {
+        if (!result.ok) {
+          logger?.warn?.(
+            `[generator-stack][remote-kv][heartbeat-failed] marker=${result.marker}`,
+          );
+        }
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }, intervalMs);
+
+  return {
+    async stop() {
+      stopped = true;
+      clearInterval(timer);
+      await inFlight;
+    },
+  };
 }
 
 if (isExecutedDirectly()) {

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -188,24 +188,6 @@ export async function runGeneratorStackTunnel({
           : processImpl.pid,
       url: publicBaseUrl,
     });
-    if (preflightResult.tunnelMode === "quick") {
-      const writeRemoteRuntimeResult = await writeRemoteRuntime({
-        env: mergedEnv,
-        logger,
-        mode: "quick",
-        url: publicBaseUrl,
-      });
-      if (!writeRemoteRuntimeResult.ok) {
-        await stopTrackedChild(generator);
-        await stopTrackedChild(tunnel);
-        return {
-          exitCode: 1,
-          marker: "[generator-stack][remote-kv][write-failed]",
-          ok: false,
-        };
-      }
-    }
-
     const externalHealth = await waitForHealthUntilReady({
       healthFactory: () =>
         waitForHealth({
@@ -242,6 +224,22 @@ export async function runGeneratorStackTunnel({
       await stopTrackedChild(generator);
       await stopTrackedChild(tunnel);
       return externalHealth.result;
+    }
+
+    const writeRemoteRuntimeResult = await writeRemoteRuntime({
+      env: mergedEnv,
+      logger,
+      mode: preflightResult.tunnelMode,
+      url: publicBaseUrl,
+    });
+    if (!writeRemoteRuntimeResult.ok) {
+      await stopTrackedChild(generator);
+      await stopTrackedChild(tunnel);
+      return {
+        exitCode: 1,
+        marker: "[generator-stack][remote-kv][write-failed]",
+        ok: false,
+      };
     }
 
     logger?.info?.("[generator-stack][ready]");

--- a/apps/web/scripts/run-generator-stack-tunnel.mjs
+++ b/apps/web/scripts/run-generator-stack-tunnel.mjs
@@ -266,6 +266,7 @@ export async function runGeneratorStackTunnel({
         kind: "child-exit",
         result,
       })),
+      remoteRuntimeHeartbeat.promise,
       signalState.promise,
     ]);
 
@@ -273,6 +274,13 @@ export async function runGeneratorStackTunnel({
       return stopForSignal({
         generator,
         signal: terminalResult.signal,
+        tunnel,
+      });
+    }
+
+    if (isHeartbeatResult(terminalResult)) {
+      return stopForHeartbeatFailure({
+        generator,
         tunnel,
       });
     }
@@ -295,6 +303,18 @@ export async function runGeneratorStackTunnel({
   }
 }
 
+function createDeferredTerminal() {
+  let resolve;
+  const promise = new Promise((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
 function createRemoteRuntimeHeartbeat({
   env,
   intervalMs,
@@ -305,6 +325,7 @@ function createRemoteRuntimeHeartbeat({
 }) {
   let inFlight = null;
   let stopped = false;
+  const terminal = createDeferredTerminal();
   const timer = setInterval(() => {
     if (inFlight !== null || stopped) {
       return;
@@ -318,10 +339,25 @@ function createRemoteRuntimeHeartbeat({
     })
       .then((result) => {
         if (!result.ok) {
+          stopped = true;
+          clearInterval(timer);
           logger?.warn?.(
             `[generator-stack][remote-kv][heartbeat-failed] marker=${result.marker}`,
           );
+          terminal.resolve({
+            kind: "heartbeat-failed",
+          });
         }
+      })
+      .catch((error) => {
+        stopped = true;
+        clearInterval(timer);
+        logger?.warn?.(
+          `[generator-stack][remote-kv][heartbeat-failed] message=${formatError(error)}`,
+        );
+        terminal.resolve({
+          kind: "heartbeat-failed",
+        });
       })
       .finally(() => {
         inFlight = null;
@@ -329,6 +365,7 @@ function createRemoteRuntimeHeartbeat({
   }, intervalMs);
 
   return {
+    promise: terminal.promise,
     async stop() {
       stopped = true;
       clearInterval(timer);
@@ -587,6 +624,20 @@ async function handleTerminalResult({ generator, result, tunnel }) {
   };
 }
 
+function isHeartbeatResult(result) {
+  return result?.kind === "heartbeat-failed";
+}
+
+async function stopForHeartbeatFailure({ generator, tunnel }) {
+  await Promise.all([stopTrackedChild(generator), stopTrackedChild(tunnel)]);
+
+  return {
+    exitCode: 1,
+    marker: "[generator-stack][remote-kv][heartbeat-failed]",
+    ok: false,
+  };
+}
+
 async function stopForSignal({ generator, signal, tunnel }) {
   await Promise.all([stopTrackedChild(generator), stopTrackedChild(tunnel)]);
 
@@ -596,6 +647,14 @@ async function stopForSignal({ generator, signal, tunnel }) {
     ok: false,
     signal,
   };
+}
+
+function formatError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }
 
 async function stopTrackedChild(child) {


### PR DESCRIPTION
## 概要
`generator:tunnel` の Worker KV runtime state を延命します。

これで tunnel が生きている間、同じ URL を定期的に KV へ書き直します。
KV が stale になり、admin unit 作成が localhost へ fallback する問題を防ぎます。

## 変更内容
- `apps/web/scripts/run-generator-stack-tunnel.mjs`
  - remote KV の初回 write を external `/health` 成功後に統一しました。
  - named tunnel でも remote runtime state を書くようにしました。
  - 5 分間隔の heartbeat を追加しました。
  - heartbeat write は重ならないようにしました。
  - heartbeat 失敗時は children を止め、non-zero で終了します。
  - cleanup 前に heartbeat を止め、既存の KV 削除を走らせます。
- `apps/web/scripts/generator-stack-tunnel.test.ts`
  - named / quick の初回 write 順序を検証しました。
  - heartbeat の定期 write を検証しました。
  - heartbeat 失敗時の終了と cleanup を検証しました。
  - tunnel exit 後に追加 write しないことを検証しました。

## 関連する Issue やチケット
Close #92

## 動作確認
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web check`
- `corepack pnpm --filter web exec vitest run scripts/generator-stack-tunnel.test.ts`
- `corepack pnpm --filter web test`

## レビュー
- PR 前 gate review: blocking findings なし