### PR TITLE
feat: Cloudflare deployにmanifest値を反映

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,46 @@
+name: deploy-web
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Deploy Web Worker
+        run: corepack pnpm --filter web run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          OP_GENERATOR_BASE_URL: ${{ vars.OP_GENERATOR_BASE_URL }}
+          OP_FINALIZE_DISPATCH_URL: ${{ vars.OP_FINALIZE_DISPATCH_URL }}
+          OP_GENERATOR_RUNTIME_URL_OVERRIDE: ${{ vars.OP_GENERATOR_RUNTIME_URL_OVERRIDE }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
 
+      - name: Check deployment manifest drift
+        run: corepack pnpm run check:deployment
+
       - name: Biome check
         run: corepack pnpm run lint
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "apps/**"
+      - "contracts/**"
       - "shared/**"
       - "generator/**"
       - "ops/**"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "build:cf": "node ./scripts/run-cloudflare-build.mjs",
     "start": "OP_GENERATOR_RUNTIME_STATE_PATH=${OP_GENERATOR_RUNTIME_STATE_PATH:-$PWD/.cache/generator-runtime.json} next start",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run --passWithNoTests && node --test scripts/check-build-public-env.test.mjs",
+    "test": "vitest run --passWithNoTests && node --test scripts/check-build-public-env.test.mjs scripts/run-cloudflare-deploy.test.mjs",
     "test:watch": "vitest --passWithNoTests",
     "test:e2e:readiness": "playwright test tests/e2e/readiness-regression.spec.ts",
     "test:e2e:live": "playwright test --config=playwright.live.config.ts",
@@ -27,7 +27,7 @@
     "generator:tunnel": "node ./scripts/run-generator-stack-tunnel.mjs",
     "generator:smoke": "node ./scripts/run-generator-stack-dispatch-smoke.mjs",
     "preview": "pnpm run build:cf && OP_GENERATOR_RUNTIME_STATE_PATH=${OP_GENERATOR_RUNTIME_STATE_PATH:-$PWD/.cache/generator-runtime.json} PATH=$PWD/scripts:$PATH XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} opennextjs-cloudflare preview -- --ip 0.0.0.0",
-    "deploy": "pnpm run build:cf && PATH=$PWD/scripts:$PATH XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} opennextjs-cloudflare deploy -- --keep-vars",
+    "deploy": "pnpm run build:cf && node ./scripts/run-cloudflare-deploy.mjs",
     "upload": "pnpm run build:cf && PATH=$PWD/scripts:$PATH XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} opennextjs-cloudflare upload",
     "cf-typegen": "XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },

--- a/apps/web/scripts/run-cloudflare-deploy.mjs
+++ b/apps/web/scripts/run-cloudflare-deploy.mjs
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  readDeploymentManifest,
+  toWebPublicEnv,
+  toWranglerVarArgs,
+} from "../../../scripts/deployment-env.mjs";
+
+export const runtimeUrlVarKeys = [
+  "OP_GENERATOR_BASE_URL",
+  "OP_FINALIZE_DISPATCH_URL",
+  "OP_GENERATOR_RUNTIME_URL_OVERRIDE",
+];
+
+export function buildCloudflareDeployArgs({
+  env = process.env,
+  manifest,
+} = {}) {
+  return [
+    "deploy",
+    "--",
+    ...toWranglerVarArgs(toWebPublicEnv(manifest)),
+    ...toRuntimeUrlVarArgs(env),
+  ];
+}
+
+export function buildCloudflareDeployEnv({
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  return {
+    ...env,
+    PATH: `${path.join(cwd, "scripts")}:${env.PATH ?? ""}`,
+    XDG_CONFIG_HOME: env.XDG_CONFIG_HOME ?? path.join(cwd, ".wrangler"),
+  };
+}
+
+function runCloudflareDeploy({
+  cwd = process.cwd(),
+  env = process.env,
+  spawnImpl = spawn,
+} = {}) {
+  const manifest = readDeploymentManifest();
+  const child = spawnImpl(
+    "opennextjs-cloudflare",
+    buildCloudflareDeployArgs({ env, manifest }),
+    {
+      cwd,
+      env: buildCloudflareDeployEnv({ cwd, env }),
+      shell: process.platform === "win32",
+      stdio: "inherit",
+    },
+  );
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 1);
+  });
+
+  child.on("error", (error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+
+  return child;
+}
+
+function toRuntimeUrlVarArgs(env) {
+  return runtimeUrlVarKeys.flatMap((key) => {
+    const value = env?.[key];
+    const normalized = typeof value === "string" ? value.trim() : "";
+    return normalized.length > 0 ? ["--var", `${key}:${normalized}`] : [];
+  });
+}
+
+if (import.meta.url === pathToFileUrl(process.argv[1])) {
+  runCloudflareDeploy();
+}
+
+function pathToFileUrl(value) {
+  return value ? pathToFileURL(path.resolve(value)).href : "";
+}

--- a/apps/web/scripts/run-cloudflare-deploy.test.mjs
+++ b/apps/web/scripts/run-cloudflare-deploy.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  buildCloudflareDeployArgs,
+  buildCloudflareDeployEnv,
+} from "./run-cloudflare-deploy.mjs";
+
+const manifest = {
+  adminCapId:
+    "0x3799b336f8163162451f4583c9213c432df2bd5145514fcc8089cc3f67de416e",
+  enokiPublicApiKey: "enoki-public-manifest",
+  googleClientId: "google-manifest",
+  network: "testnet",
+  originalPackageId:
+    "0x7568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
+  packageId:
+    "0x8568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
+  registryObjectId:
+    "0x22cca7fbd9392a1fc24c4b1e038c99d23c5a23d72ed63a67893c39ce8374533f",
+  walrusAggregator: "https://aggregator.walrus-testnet.walrus.space",
+  walrusPublisher: "https://publisher.walrus-testnet.walrus.space",
+};
+
+test("buildCloudflareDeployArgs passes manifest public vars without keep-vars", () => {
+  const args = buildCloudflareDeployArgs({ env: {}, manifest });
+
+  assert.deepEqual(args.slice(0, 2), ["deploy", "--"]);
+  assert.equal(args.includes("--keep-vars"), false);
+  assert.equal(args.includes("NEXT_PUBLIC_SUI_NETWORK:testnet"), true);
+  assert.equal(
+    args.includes(
+      "NEXT_PUBLIC_ORIGINAL_PACKAGE_ID:0x7568f91f71674184b5c8711b550ec6b001e88f09adbc22c7ad31e1173f02ffbf",
+    ),
+    true,
+  );
+  assert.equal(
+    args.includes(
+      "NEXT_PUBLIC_REGISTRY_OBJECT_ID:0x22cca7fbd9392a1fc24c4b1e038c99d23c5a23d72ed63a67893c39ce8374533f",
+    ),
+    true,
+  );
+});
+
+test("buildCloudflareDeployArgs includes only non-empty optional runtime URL vars", () => {
+  const args = buildCloudflareDeployArgs({
+    env: {
+      OP_FINALIZE_DISPATCH_URL: "   ",
+      OP_GENERATOR_BASE_URL: " https://generator.example.com ",
+      OP_GENERATOR_RUNTIME_URL_OVERRIDE: "https://runtime.example.com",
+    },
+    manifest,
+  });
+
+  assert.equal(
+    args.includes("OP_GENERATOR_BASE_URL:https://generator.example.com"),
+    true,
+  );
+  assert.equal(
+    args.includes(
+      "OP_GENERATOR_RUNTIME_URL_OVERRIDE:https://runtime.example.com",
+    ),
+    true,
+  );
+  assert.equal(
+    args.some((arg) => arg.startsWith("OP_FINALIZE_DISPATCH_URL:")),
+    false,
+  );
+});
+
+test("buildCloudflareDeployArgs excludes secret names from deploy args", () => {
+  const args = buildCloudflareDeployArgs({
+    env: {
+      ADMIN_SUI_PRIVATE_KEY: "admin-secret",
+      CLOUDFLARE_ACCOUNT_ID: "account-id",
+      CLOUDFLARE_API_TOKEN: "cf-token",
+      ENOKI_PRIVATE_API_KEY: "enoki-secret",
+      OP_FINALIZE_DISPATCH_SECRET: "dispatch-secret",
+    },
+    manifest,
+  });
+  const serialized = args.join("\n");
+
+  for (const secretName of [
+    "ADMIN_SUI_PRIVATE_KEY",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+    "ENOKI_PRIVATE_API_KEY",
+    "OP_FINALIZE_DISPATCH_SECRET",
+  ]) {
+    assert.doesNotMatch(serialized, new RegExp(secretName));
+  }
+});
+
+test("buildCloudflareDeployEnv uses the cloudflare build PATH and XDG_CONFIG_HOME convention", () => {
+  const cwd = "/repo/apps/web";
+  const env = buildCloudflareDeployEnv({
+    cwd,
+    env: { PATH: "/usr/bin" },
+  });
+
+  assert.equal(env.PATH, `${path.join(cwd, "scripts")}:/usr/bin`);
+  assert.equal(env.XDG_CONFIG_HOME, path.join(cwd, ".wrangler"));
+});

--- a/scripts/deployment-env.d.mts
+++ b/scripts/deployment-env.d.mts
@@ -28,6 +28,10 @@ export function toGeneratorEnv(
   manifest: DeploymentManifest,
 ): Record<string, string>;
 
+export function toWranglerVarArgs(
+  envOrManifestPublicEnv: Record<string, string>,
+): string[];
+
 export function checkPublishedTomlDrift(options?: {
   readonly manifest?: DeploymentManifest;
   readonly publishedTomlPath?: string;

--- a/scripts/deployment-env.mjs
+++ b/scripts/deployment-env.mjs
@@ -181,6 +181,13 @@ export function toGeneratorEnv(manifest) {
   };
 }
 
+export function toWranglerVarArgs(envOrManifestPublicEnv) {
+  return webPublicEnvKeys.flatMap((key) => {
+    const value = envOrManifestPublicEnv?.[key];
+    return typeof value === "string" ? ["--var", `${key}:${value}`] : [];
+  });
+}
+
 export function readDeploymentSecretsEnv({
   repoRoot = defaultRepoRoot,
   secretsPath,
@@ -351,6 +358,10 @@ if (import.meta.url === pathToFileUrl(process.argv[1])) {
       printEnv(toWebPublicEnv(manifest));
     } else if (command === "generator") {
       printEnv(toGeneratorEnv(manifest));
+    } else if (command === "wrangler-vars") {
+      console.log(
+        toWranglerVarArgs(toWebPublicEnv(manifest)).map(shellEscape).join(" "),
+      );
     } else if (command === "json") {
       console.log(JSON.stringify(manifest, null, 2));
     } else if (command === "check-drift") {
@@ -358,7 +369,7 @@ if (import.meta.url === pathToFileUrl(process.argv[1])) {
       console.log("deployment manifest drift check passed");
     } else {
       throw new Error(
-        `Unknown command "${command}". Use web, generator, json, or check-drift.`,
+        `Unknown command "${command}". Use web, web-public, generator, wrangler-vars, json, or check-drift.`,
       );
     }
   } catch (error) {

--- a/test/deployment-env.test.ts
+++ b/test/deployment-env.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import testnetDeploymentManifest from "../ops/deployments/testnet.json";
@@ -6,6 +7,7 @@ import {
   parseDeploymentManifest,
   toGeneratorEnv,
   toWebPublicEnv,
+  toWranglerVarArgs,
 } from "../scripts/deployment-env.mjs";
 
 const VALID_MANIFEST = testnetDeploymentManifest;
@@ -29,6 +31,60 @@ describe("deployment manifest", () => {
       WALRUS_AGGREGATOR: VALID_MANIFEST.walrusAggregator,
       WALRUS_PUBLISHER: VALID_MANIFEST.walrusPublisher,
     });
+  });
+
+  it("exports web public env as Wrangler var arguments", () => {
+    const manifest = parseDeploymentManifest(VALID_MANIFEST);
+    const args = toWranglerVarArgs({
+      ...toWebPublicEnv(manifest),
+      ADMIN_SUI_PRIVATE_KEY: "secret-admin-key",
+      ENOKI_PRIVATE_API_KEY: "secret-enoki-key",
+      OP_FINALIZE_DISPATCH_SECRET: "secret-dispatch-key",
+    });
+
+    expect(args).toContain(
+      `NEXT_PUBLIC_PACKAGE_ID:${VALID_MANIFEST.packageId}`,
+    );
+    expect(args).toContain(
+      `NEXT_PUBLIC_REGISTRY_OBJECT_ID:${VALID_MANIFEST.registryObjectId}`,
+    );
+    expect(args).toContain("NEXT_PUBLIC_SUI_NETWORK:testnet");
+    expect(args).not.toContain("ADMIN_SUI_PRIVATE_KEY:secret-admin-key");
+    expect(args).not.toContain(
+      "OP_FINALIZE_DISPATCH_SECRET:secret-dispatch-key",
+    );
+    expect(args).not.toContain("ENOKI_PRIVATE_API_KEY:secret-enoki-key");
+    expect(args.join(" ")).not.toMatch(/secret-/);
+  });
+
+  it("prints Wrangler var arguments from the CLI", () => {
+    const output = execFileSync("node", [
+      new URL("../scripts/deployment-env.mjs", import.meta.url).pathname,
+      "wrangler-vars",
+    ]).toString();
+
+    expect(output).toContain(
+      `--var NEXT_PUBLIC_PACKAGE_ID:${VALID_MANIFEST.packageId}`,
+    );
+    expect(output).toContain(
+      `--var NEXT_PUBLIC_REGISTRY_OBJECT_ID:${VALID_MANIFEST.registryObjectId}`,
+    );
+    expect(output).not.toMatch(/ADMIN_SUI_PRIVATE_KEY/);
+    expect(output).not.toMatch(/OP_FINALIZE_DISPATCH_SECRET/);
+    expect(output).not.toMatch(/ENOKI_PRIVATE_API_KEY/);
+  });
+
+  it("mentions wrangler-vars in unknown command help", () => {
+    expect(() =>
+      execFileSync(
+        "node",
+        [
+          new URL("../scripts/deployment-env.mjs", import.meta.url).pathname,
+          "unknown-command",
+        ],
+        { stdio: "pipe" },
+      ),
+    ).toThrow(/wrangler-vars/);
   });
 
   it("rejects missing required keys", () => {

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -21,6 +21,7 @@ describe("frontend-ci workflow", () => {
     expect(frontendCiWorkflow).toMatch(
       /\b(deployment-env\.mjs check-drift|pnpm run check:deployment)\b/,
     );
+    expect(frontendCiWorkflow).toContain('"contracts/**"');
   });
 
   it("runs the Web build in PR CI", () => {

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -1,10 +1,20 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const frontendCiWorkflow = readFileSync(
   new URL("../.github/workflows/frontend-ci.yml", import.meta.url),
   "utf8",
 );
+
+const deployWebWorkflowUrl = new URL(
+  "../.github/workflows/deploy-web.yml",
+  import.meta.url,
+);
+
+const readDeployWebWorkflow = () => readFileSync(deployWebWorkflowUrl, "utf8");
+
+const githubExpression = (scope: "secrets" | "vars", name: string) =>
+  ["$", "{{ ", scope, ".", name, " }}"].join("");
 
 describe("frontend-ci workflow", () => {
   it("validates the deployment manifest in PR CI", () => {
@@ -27,5 +37,50 @@ describe("frontend-ci workflow", () => {
   it("does not require Cloudflare credentials in PR CI", () => {
     expect(frontendCiWorkflow).not.toContain("CLOUDFLARE_API_TOKEN");
     expect(frontendCiWorkflow).not.toContain("CLOUDFLARE_ACCOUNT_ID");
+  });
+});
+
+describe("deploy-web workflow", () => {
+  it("exists", () => {
+    expect(existsSync(deployWebWorkflowUrl)).toBe(true);
+  });
+
+  it("runs only on main push and manual dispatch", () => {
+    const workflow = readDeployWebWorkflow();
+
+    expect(workflow).toMatch(/push:\s*\n\s*branches:\s*\n\s*-\s*main/);
+    expect(workflow).toMatch(/\bworkflow_dispatch:\s*(?:\n|$)/);
+    expect(workflow).not.toMatch(/\bpull_request:/);
+  });
+
+  it("deploys the Web worker with the deploy wrapper", () => {
+    expect(readDeployWebWorkflow()).toContain(
+      "corepack pnpm --filter web run deploy",
+    );
+  });
+
+  it("uses GitHub Secrets for Cloudflare credentials", () => {
+    const workflow = readDeployWebWorkflow();
+
+    expect(workflow).toContain(
+      `CLOUDFLARE_API_TOKEN: ${githubExpression("secrets", "CLOUDFLARE_API_TOKEN")}`,
+    );
+    expect(workflow).toContain(
+      `CLOUDFLARE_ACCOUNT_ID: ${githubExpression("secrets", "CLOUDFLARE_ACCOUNT_ID")}`,
+    );
+  });
+
+  it("uses GitHub Variables for optional runtime URLs", () => {
+    const workflow = readDeployWebWorkflow();
+
+    expect(workflow).toContain(
+      `OP_GENERATOR_BASE_URL: ${githubExpression("vars", "OP_GENERATOR_BASE_URL")}`,
+    );
+    expect(workflow).toContain(
+      `OP_FINALIZE_DISPATCH_URL: ${githubExpression("vars", "OP_FINALIZE_DISPATCH_URL")}`,
+    );
+    expect(workflow).toContain(
+      `OP_GENERATOR_RUNTIME_URL_OVERRIDE: ${githubExpression("vars", "OP_GENERATOR_RUNTIME_URL_OVERRIDE")}`,
+    );
   });
 });

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const frontendCiWorkflow = readFileSync(
+  new URL("../.github/workflows/frontend-ci.yml", import.meta.url),
+  "utf8",
+);
+
+describe("frontend-ci workflow", () => {
+  it("validates the deployment manifest in PR CI", () => {
+    expect(frontendCiWorkflow).toMatch(
+      /\b(deployment-env\.mjs check-drift|pnpm run check:deployment)\b/,
+    );
+  });
+
+  it("runs the Web build in PR CI", () => {
+    expect(frontendCiWorkflow).toContain("--filter web run build");
+  });
+
+  it("validates the Cloudflare dry-run bundle path without deploying", () => {
+    expect(frontendCiWorkflow).toContain("--filter web run test:bundle-size");
+    expect(frontendCiWorkflow).not.toMatch(
+      /\b(opennextjs-cloudflare upload|wrangler deploy|pnpm (?:run )?(?:deploy|upload)|--filter web run (?:deploy|upload))\b/,
+    );
+  });
+
+  it("does not require Cloudflare credentials in PR CI", () => {
+    expect(frontendCiWorkflow).not.toContain("CLOUDFLARE_API_TOKEN");
+    expect(frontendCiWorkflow).not.toContain("CLOUDFLARE_ACCOUNT_ID");
+  });
+});


### PR DESCRIPTION
## 概要

Cloudflare deploy で `ops/deployments/testnet.json` を正本にします。
正本とは、deploy に使う公開値の基準ファイルです。

PR では検証だけを行います。
main push では manifest 由来の `NEXT_PUBLIC_*` を Worker vars に渡します。
`--keep-vars` は使わず、古い Dashboard vars を残しません。

## 変更内容

- `scripts/deployment-env.mjs`
  - manifest の公開値を Wrangler `--var` 引数へ変換します。
  - `wrangler-vars` コマンドを追加します。

- `apps/web/scripts/run-cloudflare-deploy.mjs`
  - Web deploy 用 wrapper を追加します。
  - manifest 由来の `NEXT_PUBLIC_*` を deploy に渡します。
  - 任意の runtime URL だけを明示的に渡します。
  - secret 名は deploy 引数に含めません。

- `apps/web/package.json`
  - `deploy` を `build:cf` 後に新 wrapper を呼ぶ形へ変更します。
  - `--keep-vars` を deploy 経路から外します。

- `.github/workflows/frontend-ci.yml`
  - PR CI で deployment manifest drift を検証します。
  - `contracts/**` 変更でも drift check を走らせます。

- `.github/workflows/deploy-web.yml`
  - main push と手動実行で Web Worker を deploy します。
  - Cloudflare 認証は GitHub Secrets から読みます。
  - 任意の runtime URL は GitHub Variables から読みます。

- `test/deployment-env.test.ts` / `test/workflows.test.ts` / `apps/web/scripts/run-cloudflare-deploy.test.mjs`
  - var 生成、secret 除外、workflow trigger を検証します。

## 関連する Issue やチケット

Close #91

## 動作確認

- `corepack pnpm test`
- `corepack pnpm run typecheck`
- `node scripts/deployment-env.mjs check-drift`
- `node scripts/deployment-env.mjs wrangler-vars`
- `corepack pnpm --filter web run build`
- `corepack pnpm --filter web run build:cf`
- `corepack pnpm --filter web run test:bundle-size`
- `corepack pnpm vitest run test/workflows.test.ts`

補足:
- Web build では既存の Next/Turbopack NFT warning が出ました。
- `build:cf` では OpenNext の tsconfig base path warning が出ました。
- `test:bundle-size` は gzip 2694.99 KiB で 3.00 MiB 未満でした。
