### PR TITLE
fix: 2,000枚到達時の投稿導線を閉じる

### DIFF
--- a/apps/web/src/app/units/[unitId]/live-progress.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.tsx
@@ -27,6 +27,7 @@ import type {
   UnitFilledEvent,
 } from "../../../lib/sui";
 import { useUnitEvents } from "../../../lib/sui/react";
+import { useUnitFullState } from "./unit-full-state";
 
 function formatProgressCount(value: number): string {
   return String(value);
@@ -87,6 +88,7 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
     needsInitialFinalize ? { status: "running" } : { status: "idle" },
   );
   const finalizeTriggeredRef = useRef(false);
+  const { markFullIfAtCap } = useUnitFullState();
 
   const startFinalize = (): void => {
     if (finalizeTriggeredRef.current) {
@@ -125,18 +127,26 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
     startFinalize();
   });
 
+  useEffect(() => {
+    markFullIfAtCap(initialSubmittedCount, maxSlots);
+  }, [initialSubmittedCount, markFullIfAtCap, maxSlots]);
+
   useUnitEvents({
     packageId: eventSubscriptionEnabled ? packageId : "",
     unitId,
     onSubmitted: (event: SubmittedEvent) => {
       // Events can arrive out of order from the RPC poll — guard against
       // a stale event clobbering a newer server/server-event count.
-      setSubmittedCount((current) =>
-        event.submittedCount > current ? event.submittedCount : current,
-      );
+      setSubmittedCount((current) => {
+        const next =
+          event.submittedCount > current ? event.submittedCount : current;
+        markFullIfAtCap(next, maxSlots);
+        return next;
+      });
     },
     onFilled: (_event: UnitFilledEvent) => {
       setFilled(true);
+      markFullIfAtCap(maxSlots, maxSlots);
       startFinalize();
     },
     onMosaicReady: (event: MosaicReadyEvent) => {

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -11,11 +11,13 @@ const {
   getUnitProgressMock,
   loadPublicEnvMock,
   participationAccessMock,
+  unitFullStateProviderMock,
   unitRevealClientMock,
 } = vi.hoisted(() => ({
   getUnitProgressMock: vi.fn(),
   loadPublicEnvMock: vi.fn(),
   participationAccessMock: vi.fn(),
+  unitFullStateProviderMock: vi.fn(),
   unitRevealClientMock: vi.fn(),
 }));
 
@@ -81,6 +83,24 @@ vi.mock("./participation-access", () => ({
   },
 }));
 
+vi.mock("./unit-full-state", () => ({
+  UnitFullStateProvider: (props: {
+    readonly children: React.ReactNode;
+    readonly initialFull: boolean;
+  }) => {
+    unitFullStateProviderMock(props);
+
+    return (
+      <div
+        data-initial-full={String(props.initialFull)}
+        data-testid="unit-full-state"
+      >
+        {props.children}
+      </div>
+    );
+  },
+}));
+
 import UnitPage from "./page";
 
 function buildProgress(
@@ -128,6 +148,7 @@ afterEach(() => {
   loadPublicEnvMock.mockReset();
   participationAccessMock.mockReset();
   unitRevealClientMock.mockReset();
+  unitFullStateProviderMock.mockReset();
 });
 
 describe("UnitPage", () => {
@@ -216,6 +237,33 @@ describe("UnitPage", () => {
         },
       }),
     );
+  });
+
+  it("closes participation access when initial server progress is already full", async () => {
+    getUnitProgressMock.mockResolvedValue(
+      buildProgress({ submittedCount: 2000, maxSlots: 2000 }),
+    );
+    loadPublicEnvMock.mockReturnValue({
+      suiNetwork: "testnet",
+      registryObjectId: "0xreg",
+      packageId: "0xignored",
+    });
+
+    const ui = await UnitPage({
+      params: Promise.resolve({ unitId: "0xunit-1" }),
+      searchParams: Promise.resolve({}),
+    });
+    render(ui);
+
+    expect(
+      screen.getByTestId("unit-full-state").getAttribute("data-initial-full"),
+    ).toBe("true");
+    expect(unitFullStateProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialFull: true,
+      }),
+    );
+    expect(screen.getByTestId("participation-access")).toBeTruthy();
   });
 
   it("shows the route athleteName when unit progress cannot be fetched", async () => {

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -19,6 +19,7 @@ import { getUnitProgress } from "../../../lib/sui";
 import type { WalrusEnv } from "../../../lib/walrus/put";
 
 import { ParticipationAccess } from "./participation-access";
+import { UnitFullStateProvider } from "./unit-full-state";
 import { UnitRevealClient } from "./unit-reveal-client";
 
 type UnitPageProps = {
@@ -75,128 +76,133 @@ export default async function UnitPage(
 
   const hasProgress = progress.submittedCount >= 0;
 
+  const initialUnitFull =
+    hasProgress && progress.submittedCount >= progress.maxSlots;
+
   return (
-    <main className="grain relative min-h-screen overflow-hidden text-[var(--ink)]">
-      <div className="mx-auto grid max-w-6xl gap-px bg-[var(--rule)] lg:grid-cols-[1fr_380px]">
-        <section className="relative flex min-h-[80vh] flex-col justify-between gap-10 bg-[var(--bg-2)] p-8 md:p-12 lg:p-14">
-          <div
-            className="pointer-events-none absolute inset-0"
-            style={{
-              background:
-                "radial-gradient(ellipse at 50% 45%, rgba(255, 122, 26, 0.08), transparent 65%)",
-            }}
-          />
-          <div className="relative z-10 flex flex-wrap items-start justify-between gap-4">
-            <nav className="flex flex-wrap items-center gap-4">
-              <Link
-                className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
-                href="/"
-              >
-                ← All athletes
-              </Link>
-              <Link
-                className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
-                href="/gallery"
-              >
-                Participation history
-              </Link>
-            </nav>
-            <div className="text-right font-mono-op text-[11px] text-[var(--ink-dim)]">
-              <div>
-                {displayName}{" "}
-                <span className="text-[var(--ember)]">— UNIT</span>
-              </div>
-              <div className="mt-1 break-all text-[var(--ink-faint)]">
-                one_portrait::unit · {unitId.slice(0, 10)}…
-              </div>
-            </div>
-          </div>
-
-          <div className="relative z-10 grid justify-items-center gap-6 text-center">
-            <div className="op-eyebrow">
-              <span className="bar" />
-              <span
-                className="h-2 w-2 rounded-full bg-[var(--ember)]"
-                style={{
-                  boxShadow: "0 0 14px var(--ember)",
-                  animation: "op-pulse 1s infinite",
-                }}
-              />
-              <span>UNIT ACTIVE — HIDDEN UNTIL REVEAL</span>
-            </div>
-
-            {thumbnailUrl ? (
-              // biome-ignore lint: external placeholder thumbnail
-              <img
-                alt={displayName}
-                className="h-24 w-24 rounded-none border border-[var(--rule-strong)] object-cover"
-                src={thumbnailUrl}
-              />
-            ) : null}
-
-            <h1 className="font-display text-[clamp(40px,7vw,88px)] leading-[0.9] tracking-[-0.01em] text-[var(--ink)]">
-              {displayName}
-            </h1>
-            <p className="font-mono-op text-[11px] break-all text-[var(--ink-faint)]">
-              {unitId}
-            </p>
-
-            <div className="mt-4 w-full">
-              {hasProgress ? (
-                <UnitRevealClient
-                  aggregatorBase={aggregatorBase}
-                  displayName={displayName}
-                  eventSubscriptionEnabled={
-                    startupEnabled && typePackageId !== null
-                  }
-                  initialMasterId={progress.masterId}
-                  initialSubmittedCount={progress.submittedCount}
-                  maxSlots={progress.maxSlots}
-                  packageId={typePackageId}
-                  startupEnabled={startupEnabled}
-                  unitId={unitId}
-                />
-              ) : (
-                <p className="font-serif-display italic text-lg text-[var(--ink-dim)]">
-                  待機中 / No active unit — on-chain progress is not available
-                  right now.
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div className="relative z-10 text-right font-mono-op text-[11px] uppercase tracking-[0.12em] text-[var(--ink-dim)]">
-            Sponsored transaction · 0 SUI required
-            <br />
-            Soulbound mint on submit · Walrus blob storage
-          </div>
-        </section>
-
-        <aside className="flex flex-col gap-6 bg-[var(--bg-2)] p-6 lg:p-7">
-          {demoMode ? (
-            <DemoParticipationPreview />
-          ) : (
-            <ParticipationAccess
-              packageId={packageId}
-              startupEnabled={startupEnabled}
-              typePackageId={typePackageId}
-              unitId={unitId}
-              walrusEnv={walrusEnv}
+    <UnitFullStateProvider initialFull={initialUnitFull}>
+      <main className="grain relative min-h-screen overflow-hidden text-[var(--ink)]">
+        <div className="mx-auto grid max-w-6xl gap-px bg-[var(--rule)] lg:grid-cols-[1fr_380px]">
+          <section className="relative flex min-h-[80vh] flex-col justify-between gap-10 bg-[var(--bg-2)] p-8 md:p-12 lg:p-14">
+            <div
+              className="pointer-events-none absolute inset-0"
+              style={{
+                background:
+                  "radial-gradient(ellipse at 50% 45%, rgba(255, 122, 26, 0.08), transparent 65%)",
+              }}
             />
-          )}
-        </aside>
-      </div>
+            <div className="relative z-10 flex flex-wrap items-start justify-between gap-4">
+              <nav className="flex flex-wrap items-center gap-4">
+                <Link
+                  className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
+                  href="/"
+                >
+                  ← All athletes
+                </Link>
+                <Link
+                  className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
+                  href="/gallery"
+                >
+                  Participation history
+                </Link>
+              </nav>
+              <div className="text-right font-mono-op text-[11px] text-[var(--ink-dim)]">
+                <div>
+                  {displayName}{" "}
+                  <span className="text-[var(--ember)]">— UNIT</span>
+                </div>
+                <div className="mt-1 break-all text-[var(--ink-faint)]">
+                  one_portrait::unit · {unitId.slice(0, 10)}…
+                </div>
+              </div>
+            </div>
 
-      {/*
-       * Hook points for follow-up issues (kept as comments so reviewers can
-       * see the intended seams without dead components floating around):
-       *   - Submit button: zkLogin login + Enoki Sponsored Tx invoking
-       *     `PACKAGE_ID::accessors::submit_photo`.
-       *   - Reveal overlay: listen for MosaicReadyEvent on LiveProgress and
-       *     render the mosaic blob from Walrus (client-only).
-       *   - /api/finalize trigger: fire-and-forget POST on UnitFilledEvent.
-       */}
-    </main>
+            <div className="relative z-10 grid justify-items-center gap-6 text-center">
+              <div className="op-eyebrow">
+                <span className="bar" />
+                <span
+                  className="h-2 w-2 rounded-full bg-[var(--ember)]"
+                  style={{
+                    boxShadow: "0 0 14px var(--ember)",
+                    animation: "op-pulse 1s infinite",
+                  }}
+                />
+                <span>UNIT ACTIVE — HIDDEN UNTIL REVEAL</span>
+              </div>
+
+              {thumbnailUrl ? (
+                // biome-ignore lint: external placeholder thumbnail
+                <img
+                  alt={displayName}
+                  className="h-24 w-24 rounded-none border border-[var(--rule-strong)] object-cover"
+                  src={thumbnailUrl}
+                />
+              ) : null}
+
+              <h1 className="font-display text-[clamp(40px,7vw,88px)] leading-[0.9] tracking-[-0.01em] text-[var(--ink)]">
+                {displayName}
+              </h1>
+              <p className="font-mono-op text-[11px] break-all text-[var(--ink-faint)]">
+                {unitId}
+              </p>
+
+              <div className="mt-4 w-full">
+                {hasProgress ? (
+                  <UnitRevealClient
+                    aggregatorBase={aggregatorBase}
+                    displayName={displayName}
+                    eventSubscriptionEnabled={
+                      startupEnabled && typePackageId !== null
+                    }
+                    initialMasterId={progress.masterId}
+                    initialSubmittedCount={progress.submittedCount}
+                    maxSlots={progress.maxSlots}
+                    packageId={typePackageId}
+                    startupEnabled={startupEnabled}
+                    unitId={unitId}
+                  />
+                ) : (
+                  <p className="font-serif-display italic text-lg text-[var(--ink-dim)]">
+                    待機中 / No active unit — on-chain progress is not available
+                    right now.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="relative z-10 text-right font-mono-op text-[11px] uppercase tracking-[0.12em] text-[var(--ink-dim)]">
+              Sponsored transaction · 0 SUI required
+              <br />
+              Soulbound mint on submit · Walrus blob storage
+            </div>
+          </section>
+
+          <aside className="flex flex-col gap-6 bg-[var(--bg-2)] p-6 lg:p-7">
+            {demoMode ? (
+              <DemoParticipationPreview />
+            ) : (
+              <ParticipationAccess
+                packageId={packageId}
+                startupEnabled={startupEnabled}
+                typePackageId={typePackageId}
+                unitId={unitId}
+                walrusEnv={walrusEnv}
+              />
+            )}
+          </aside>
+        </div>
+
+        {/*
+         * Hook points for follow-up issues (kept as comments so reviewers can
+         * see the intended seams without dead components floating around):
+         *   - Submit button: zkLogin login + Enoki Sponsored Tx invoking
+         *     `PACKAGE_ID::accessors::submit_photo`.
+         *   - Reveal overlay: listen for MosaicReadyEvent on LiveProgress and
+         *     render the mosaic blob from Walrus (client-only).
+         *   - /api/finalize trigger: fire-and-forget POST on UnitFilledEvent.
+         */}
+      </main>
+    </UnitFullStateProvider>
   );
 }
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -108,6 +108,7 @@ vi.mock("../../../lib/sui", () => ({
 
 import { LiveProgress } from "./live-progress";
 import { ParticipationAccess } from "./participation-access";
+import { UnitFullStateProvider } from "./unit-full-state";
 
 const FILE_INPUT_LABEL = "写真を選択";
 
@@ -251,6 +252,37 @@ describe("ParticipationAccess", () => {
     expect(screen.getByRole("button", { name: "Sui wallet" })).toBeTruthy();
   });
 
+  it("hides signed-out upload start buttons when the unit is full", () => {
+    useEnokiConfigStateMock.mockReturnValue({
+      submitEnabled: true,
+      config: {},
+    });
+    useWalletsMock.mockReturnValue([
+      { id: "google-wallet" },
+      { id: "sui-wallet" },
+    ]);
+    useCurrentAccountMock.mockReturnValue(null);
+    useCurrentWalletMock.mockReturnValue({
+      connectionStatus: "disconnected",
+    });
+    useConnectWalletMock.mockReturnValue({ mutateAsync: vi.fn() });
+    useDisconnectWalletMock.mockReturnValue({ mutate: vi.fn() });
+    useSubmitPhotoMock.mockReturnValue({
+      isSubmitting: false,
+      submitPhoto: vi.fn(),
+    });
+
+    render(
+      <UnitFullStateProvider initialFull={true}>
+        <ParticipationAccess unitId="0xunit-1" />
+      </UnitFullStateProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Google zkLogin" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Sui wallet" })).toBeNull();
+    expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+  });
+
   it("keeps the signed-out Sui wallet modal controlled", async () => {
     useEnokiConfigStateMock.mockReturnValue({
       submitEnabled: true,
@@ -355,6 +387,21 @@ describe("ParticipationAccess", () => {
     fireEvent.click(consent);
     expect(consent.checked).toBe(true);
     expect(fileInput.disabled).toBe(false);
+  });
+
+  it("hides signed-in consent and file upload controls when the unit is full", () => {
+    setupSignedInEnv();
+
+    render(
+      <UnitFullStateProvider initialFull={true}>
+        <ParticipationAccess unitId="0xunit-1" />
+      </UnitFullStateProvider>,
+    );
+
+    expect(screen.queryByRole("checkbox", { name: /同意/ })).toBeNull();
+    expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
+    expect(screen.queryByRole("button", { name: /投稿を確定/ })).toBeNull();
+    expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
   });
 
   it("calls preprocessPhoto with the chosen file and renders the preview URL", async () => {
@@ -1320,6 +1367,58 @@ describe("ParticipationAccess", () => {
       expect(
         screen.getByText(new RegExp(`42\\s*/\\s*${unitTileCount}`)),
       ).toBeTruthy();
+    });
+
+    it("closes upload access when a SubmittedEvent reaches maxSlots while keeping it open below cap", async () => {
+      setupSignedInEnv();
+
+      let capturedOnSubmitted: ((event: SubmittedEvent) => void) | undefined;
+      useUnitEventsMock.mockImplementation((args: UseUnitEventsArgs) => {
+        capturedOnSubmitted = args.onSubmitted;
+      });
+
+      render(
+        <UnitFullStateProvider initialFull={false}>
+          <LiveProgress
+            initialSubmittedCount={1998}
+            maxSlots={2000}
+            packageId="0xpkg"
+            unitId="0xunit-1"
+          />
+          <ParticipationAccess unitId="0xunit-1" />
+        </UnitFullStateProvider>,
+      );
+
+      expect(screen.getByLabelText(FILE_INPUT_LABEL)).toBeTruthy();
+
+      act(() => {
+        capturedOnSubmitted?.({
+          kind: "submitted",
+          unitId: "0xunit-1",
+          submitter: "0xabc123",
+          walrusBlobId: [],
+          submissionNo: 1999,
+          submittedCount: 1999,
+          maxSlots: 2000,
+        });
+      });
+
+      expect(screen.getByLabelText(FILE_INPUT_LABEL)).toBeTruthy();
+
+      act(() => {
+        capturedOnSubmitted?.({
+          kind: "submitted",
+          unitId: "0xunit-1",
+          submitter: "0xabc123",
+          walrusBlobId: [],
+          submissionNo: 2000,
+          submittedCount: 2000,
+          maxSlots: 2000,
+        });
+      });
+
+      expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
+      expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
     });
   });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -792,6 +792,70 @@ describe("ParticipationAccess", () => {
       });
     });
 
+    it("hides the retry button when live progress reaches maxSlots", async () => {
+      const { preprocessPhoto } = setupPreviewingEnv();
+      const { WalrusPutError } = await import("../../../lib/walrus/put");
+      let capturedOnSubmitted: ((event: SubmittedEvent) => void) | undefined;
+      useUnitEventsMock.mockImplementation((args: UseUnitEventsArgs) => {
+        capturedOnSubmitted = args.onSubmitted;
+      });
+      const putBlob = vi
+        .fn<PutMock>()
+        .mockRejectedValue(
+          new WalrusPutError(
+            "final",
+            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+          ),
+        );
+
+      render(
+        <UnitFullStateProvider initialFull={false}>
+          <LiveProgress
+            initialSubmittedCount={1999}
+            maxSlots={2000}
+            packageId="0xpkg"
+            unitId="0xunit-1"
+          />
+          <ParticipationAccess
+            preprocessPhoto={preprocessPhoto}
+            putBlob={putBlob}
+            unitId="0xunit-1"
+            walrusEnv={{
+              NEXT_PUBLIC_WALRUS_PUBLISHER: "https://publisher.example.com",
+              NEXT_PUBLIC_WALRUS_AGGREGATOR: "https://aggregator.example.com",
+            }}
+          />
+        </UnitFullStateProvider>,
+      );
+
+      await advanceToPreview(preprocessPhoto);
+      fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /もう一度送信する/ }),
+        ).toBeTruthy();
+      });
+
+      act(() => {
+        capturedOnSubmitted?.({
+          kind: "submitted",
+          unitId: "0xunit-1",
+          submitter: "0xabc123",
+          walrusBlobId: [],
+          submissionNo: 2000,
+          submittedCount: 2000,
+          maxSlots: 2000,
+        });
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /もう一度送信する/ }),
+      ).toBeNull();
+      expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+      expect(putBlob).toHaveBeenCalledTimes(1);
+    });
+
     it("disconnects and returns to the login step when submitPhoto fails with auth_expired", async () => {
       const { preprocessPhoto, submitPhoto } = setupPreviewingEnv();
       const disconnectMutate = vi.fn();

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -111,6 +111,8 @@ import { ParticipationAccess } from "./participation-access";
 import { UnitFullStateProvider } from "./unit-full-state";
 
 const FILE_INPUT_LABEL = "写真を選択";
+const CONSENT_LABEL =
+  /I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id\. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation\./;
 
 function makeFile(name = "photo.jpg", size = 1024): File {
   const blob = new Blob([new Uint8Array(size)], { type: "image/jpeg" });
@@ -381,7 +383,7 @@ describe("ParticipationAccess", () => {
     expect(fileInput.disabled).toBe(true);
 
     const consent = screen.getByRole("checkbox", {
-      name: /同意/,
+      name: CONSENT_LABEL,
     }) as HTMLInputElement;
     expect(consent.checked).toBe(false);
     fireEvent.click(consent);
@@ -398,7 +400,7 @@ describe("ParticipationAccess", () => {
       </UnitFullStateProvider>,
     );
 
-    expect(screen.queryByRole("checkbox", { name: /同意/ })).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: CONSENT_LABEL })).toBeNull();
     expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
     expect(screen.queryByRole("button", { name: /投稿を確定/ })).toBeNull();
     expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
@@ -423,7 +425,7 @@ describe("ParticipationAccess", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: CONSENT_LABEL }));
 
     const file = makeFile();
     const fileInput = screen.getByLabelText(
@@ -460,7 +462,7 @@ describe("ParticipationAccess", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: CONSENT_LABEL }));
 
     fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
       target: { files: [makeFile()] },
@@ -500,7 +502,7 @@ describe("ParticipationAccess", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: CONSENT_LABEL }));
     fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
       target: { files: [makeFile("big.jpg", 11 * 1024 * 1024)] },
     });
@@ -561,7 +563,7 @@ describe("ParticipationAccess", () => {
     async function advanceToPreview(
       preprocessPhoto: ReturnType<typeof vi.fn<PreprocessMock>>,
     ): Promise<void> {
-      fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+      fireEvent.click(screen.getByRole("checkbox", { name: CONSENT_LABEL }));
       fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
         target: { files: [makeFile()] },
       });
@@ -1327,7 +1329,7 @@ describe("ParticipationAccess", () => {
         screen.getByText(new RegExp(`41\\s*/\\s*${unitTileCount}`)),
       ).toBeTruthy();
 
-      fireEvent.click(screen.getByRole("checkbox", { name: /同意/ }));
+      fireEvent.click(screen.getByRole("checkbox", { name: CONSENT_LABEL }));
       fireEvent.change(screen.getByLabelText(FILE_INPUT_LABEL), {
         target: { files: [makeFile()] },
       });

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -35,6 +35,7 @@ import {
   type WalrusPutResult,
 } from "../../../lib/walrus/put";
 import { SuiWalletConnectModal } from "../../sui-wallet-connect-modal";
+import { useUnitFullState } from "./unit-full-state";
 
 /**
  * Waiting-room submission access.
@@ -186,6 +187,7 @@ function ParticipationAccessEnabled({
   const connectWallet = useConnectWallet();
   const disconnectWallet = useDisconnectWallet();
   const { submitPhoto } = useSubmitPhoto(unitId);
+  const { isFull: unitFull } = useUnitFullState();
 
   const [connectError, setConnectError] = useState<string | null>(null);
   const [consented, setConsented] = useState(false);
@@ -443,10 +445,11 @@ function ParticipationAccessEnabled({
       : null;
   const submitButtonDisabled = isUploading || isSubmitting || isRecovering;
   const showSubmitButton =
-    phase.kind === "previewing" ||
-    phase.kind === "uploading" ||
-    phase.kind === "submitting";
-  const showConsentAndFilePicker = !isDone && !isRecovering;
+    !unitFull &&
+    (phase.kind === "previewing" ||
+      phase.kind === "uploading" ||
+      phase.kind === "submitting");
+  const showConsentAndFilePicker = !unitFull && !isDone && !isRecovering;
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
   const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
@@ -475,6 +478,8 @@ function ParticipationAccessEnabled({
           <p className="font-mono-op text-[11px] break-all text-[var(--ember)]">
             {currentAccount.address}
           </p>
+
+          {unitFull ? <FullUnitMessage /> : null}
 
           {showConsentAndFilePicker ? (
             <>
@@ -654,6 +659,8 @@ function ParticipationAccessEnabled({
             </button>
           </div>
         </>
+      ) : unitFull ? (
+        <FullUnitMessage />
       ) : (
         <>
           <p className="text-sm text-[var(--ink-dim)]">
@@ -725,6 +732,14 @@ function ParticipationAccessEnabled({
         </div>
       ) : null}
     </section>
+  );
+}
+
+function FullUnitMessage(): React.ReactElement {
+  return (
+    <p className="text-sm text-[var(--ink-dim)]">
+      この Unit は満枠です。新しい投稿は受け付けていません。
+    </p>
   );
 }
 

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -454,7 +454,8 @@ function ParticipationAccessEnabled({
       phase.kind === "submitting");
   const showConsentAndFilePicker = !unitFull && !isDone && !isRecovering;
   const phaseErrorMessage = phase.kind === "error" ? phase.message : null;
-  const phaseRetry = phase.kind === "error" ? (phase.retry ?? null) : null;
+  const phaseRetry =
+    !unitFull && phase.kind === "error" ? (phase.retry ?? null) : null;
   const donePhase = phase.kind === "done" ? phase : null;
   const connectedWalletLabel = isGoogleConnected ? "zkLogin" : "Sui wallet";
   const connectedWalletMessage = isGoogleConnected

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -68,6 +68,9 @@ type PutBlobFn = (
   deps: { readonly env: WalrusEnv },
 ) => Promise<WalrusPutResult>;
 
+const CONSENT_COPY =
+  "I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation.";
+
 /**
  * Recoverable error context.
  *
@@ -492,12 +495,7 @@ function ParticipationAccessEnabled({
                   }}
                   type="checkbox"
                 />
-                <span>
-                  投稿した原画像は Walrus に保存され、blob_id
-                  を知る人は誰でも取得できます。 また、参加の証として
-                  Soulbound（譲渡不可）の Kakera NFT
-                  が自分のウォレットに発行されることに同意します。
-                </span>
+                <span>{CONSENT_COPY}</span>
               </label>
 
               <label className="grid gap-2 font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">

--- a/apps/web/src/app/units/[unitId]/unit-full-state.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-full-state.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+type UnitFullState = {
+  readonly isFull: boolean;
+  readonly markFullIfAtCap: (submittedCount: number, maxSlots: number) => void;
+};
+
+const UnitFullStateContext = createContext<UnitFullState>({
+  isFull: false,
+  markFullIfAtCap: () => undefined,
+});
+
+export function UnitFullStateProvider({
+  children,
+  initialFull,
+}: {
+  readonly children: React.ReactNode;
+  readonly initialFull: boolean;
+}): React.ReactElement {
+  const [isFull, setIsFull] = useState(initialFull);
+
+  const markFullIfAtCap = useCallback(
+    (submittedCount: number, maxSlots: number): void => {
+      if (maxSlots > 0 && submittedCount >= maxSlots) {
+        setIsFull(true);
+      }
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      isFull,
+      markFullIfAtCap,
+    }),
+    [isFull, markFullIfAtCap],
+  );
+
+  return (
+    <UnitFullStateContext.Provider value={value}>
+      {children}
+    </UnitFullStateContext.Provider>
+  );
+}
+
+export function useUnitFullState(): UnitFullState {
+  return useContext(UnitFullStateContext);
+}

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -11,6 +11,8 @@ const DEMO_UNIT_ID =
   "0x00000000000000000000000000000000000000000000000000000000000000d2";
 const DEMO_SECOND_UNIT_ID =
   "0x00000000000000000000000000000000000000000000000000000000000000d4";
+const CONSENT_LABEL =
+  /I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id\. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation\./;
 
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
@@ -21,7 +23,7 @@ async function submitPhoto(page: Page): Promise<void> {
 
   await page
     .getByRole("checkbox", {
-      name: /投稿した原画像は Walrus に保存され/,
+      name: CONSENT_LABEL,
     })
     .check();
 

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -11,6 +11,9 @@ import {
   TINY_JPEG_NAME,
 } from "./fixtures/tiny-jpeg";
 
+const CONSENT_LABEL =
+  /I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id\. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation\./;
+
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
@@ -20,7 +23,7 @@ async function submitPhoto(page: Page): Promise<void> {
 
   await page
     .getByRole("checkbox", {
-      name: /投稿した原画像は Walrus に保存され/,
+      name: CONSENT_LABEL,
     })
     .check();
 
@@ -45,7 +48,7 @@ async function submitPhotoWithExpectedWallet(
 
   await page
     .getByRole("checkbox", {
-      name: /投稿した原画像は Walrus に保存され/,
+      name: CONSENT_LABEL,
     })
     .check();
 

--- a/apps/web/tests/e2e/waiting-room-submit.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-submit.spec.ts
@@ -7,6 +7,9 @@ import {
   TINY_JPEG_NAME,
 } from "./fixtures/tiny-jpeg";
 
+const CONSENT_LABEL =
+  /I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id\. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation\./;
+
 async function prepareSubmission(page: Page): Promise<string> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
@@ -16,7 +19,7 @@ async function prepareSubmission(page: Page): Promise<string> {
 
   await page
     .getByRole("checkbox", {
-      name: /投稿した原画像は Walrus に保存され/,
+      name: CONSENT_LABEL,
     })
     .check();
 
@@ -50,7 +53,7 @@ test.describe("waiting room submit guards", () => {
       page.getByText(/zkLogin アドレスを確認できました/),
     ).toBeVisible();
 
-    const consent = page.getByRole("checkbox", { name: /同意/ });
+    const consent = page.getByRole("checkbox", { name: CONSENT_LABEL });
     const fileInput = page.locator('input[type="file"]');
 
     await expect(consent).not.toBeChecked();
@@ -71,7 +74,7 @@ test.describe("waiting room submit guards", () => {
     await expect(
       page.getByText(/zkLogin アドレスを確認できました/),
     ).toBeVisible();
-    await page.getByRole("checkbox", { name: /同意/ }).check();
+    await page.getByRole("checkbox", { name: CONSENT_LABEL }).check();
 
     await expect(page.locator('input[type="file"]')).toBeEnabled();
     await expect(page.getByRole("button", { name: "投稿を確定" })).toHaveCount(


### PR DESCRIPTION
## 概要
2,000 枚に達した Unit で、新しい画像投稿を始められないようにしました。

画面を開いた時点で満枠なら、投稿導線を閉じます。
画面を開いた後に 2,000 枚へ到達した場合も、同じように閉じます。

あわせて、画像アップロード前の同意文を英語にしました。

## 変更内容
- `apps/web/src/app/units/[unitId]/unit-full-state.tsx`
  - Unit が満枠かどうかを共有する状態を追加しました。
- `apps/web/src/app/units/[unitId]/page.tsx`
  - 初期進捗から満枠状態を作るようにしました。
- `apps/web/src/app/units/[unitId]/live-progress.tsx`
  - ライブ進捗が上限に達した時、満枠状態を更新します。
- `apps/web/src/app/units/[unitId]/participation-access.tsx`
  - 満枠時はログイン、画像選択、投稿、再送信の導線を隠します。
  - 同意文を英語に変更しました。
- `apps/web/tests/e2e/*.spec.ts`
  - 英語の同意文に合わせてセレクタを更新しました。

## 関連する Issue やチケット
Close #94

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/units/'[unitId]'/live-progress.test.tsx src/app/units/'[unitId]'/page.test.tsx src/app/units/'[unitId]'/participation-access.test.tsx`
  - 3 files / 65 tests passed
- `corepack pnpm --filter web run typecheck`
  - passed
- `corepack pnpm --filter web run lint`
  - passed
- `corepack pnpm --filter web exec playwright test tests/e2e/readiness-regression.spec.ts tests/e2e/waiting-room-submit.spec.ts tests/e2e/submit-happy.spec.ts`
  - 16 tests passed
- `git diff --check main...HEAD`
  - passed

補足: Playwright 実行時に既存の `NO_COLOR` / `FORCE_COLOR` と Next.js workspace root の警告が出ました。テスト結果は成功です。
