### PR TITLE
fix: Cloudflare deploy credentials を事前検証する

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -13,17 +13,32 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      HAS_CLOUDFLARE_DEPLOY_CREDENTIALS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
 
     steps:
+      - name: Check Cloudflare deploy credentials
+        id: cloudflare-credentials
+        run: |
+          if [ "$HAS_CLOUDFLARE_DEPLOY_CREDENTIALS" != "true" ]; then
+            echo "::notice title=Cloudflare deploy skipped::Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repository secrets to enable deploy-web."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         uses: actions/checkout@v5
 
       - name: Setup pnpm
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         uses: pnpm/action-setup@v5
         with:
           version: 10.33.0
 
       - name: Setup Node
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -31,12 +46,15 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Enable Corepack
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         run: corepack enable
 
       - name: Install dependencies
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         run: corepack pnpm install --frozen-lockfile
 
       - name: Deploy Web Worker
+        if: steps.cloudflare-credentials.outputs.enabled == 'true'
         run: corepack pnpm --filter web run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "generator:tunnel": "node ./scripts/run-generator-stack-tunnel.mjs",
     "generator:smoke": "node ./scripts/run-generator-stack-dispatch-smoke.mjs",
     "preview": "pnpm run build:cf && OP_GENERATOR_RUNTIME_STATE_PATH=${OP_GENERATOR_RUNTIME_STATE_PATH:-$PWD/.cache/generator-runtime.json} PATH=$PWD/scripts:$PATH XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} opennextjs-cloudflare preview -- --ip 0.0.0.0",
-    "deploy": "pnpm run build:cf && node ./scripts/run-cloudflare-deploy.mjs",
+    "deploy": "node ./scripts/run-cloudflare-deploy.mjs --check && pnpm run build:cf && node ./scripts/run-cloudflare-deploy.mjs",
     "upload": "pnpm run build:cf && PATH=$PWD/scripts:$PATH XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} opennextjs-cloudflare upload",
     "cf-typegen": "XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$PWD/.wrangler} wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },

--- a/apps/web/scripts/run-cloudflare-deploy.mjs
+++ b/apps/web/scripts/run-cloudflare-deploy.mjs
@@ -14,6 +14,11 @@ export const runtimeUrlVarKeys = [
   "OP_GENERATOR_RUNTIME_URL_OVERRIDE",
 ];
 
+export const requiredCloudflareCredentialKeys = [
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_ACCOUNT_ID",
+];
+
 export function buildCloudflareDeployArgs({
   env = process.env,
   manifest,
@@ -37,11 +42,35 @@ export function buildCloudflareDeployEnv({
   };
 }
 
+export function getMissingCloudflareDeployCredentials({
+  env = process.env,
+} = {}) {
+  return requiredCloudflareCredentialKeys.filter((key) => {
+    const value = env?.[key];
+    return typeof value !== "string" || value.trim().length === 0;
+  });
+}
+
+export function assertCloudflareDeployCredentials({ env = process.env } = {}) {
+  const missing = getMissingCloudflareDeployCredentials({ env });
+
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        `Missing required Cloudflare deploy credentials: ${missing.join(", ")}`,
+        "Set these as GitHub Actions repository secrets, or attach the job to the GitHub Environment that owns them.",
+      ].join("\n"),
+    );
+  }
+}
+
 function runCloudflareDeploy({
   cwd = process.cwd(),
   env = process.env,
   spawnImpl = spawn,
 } = {}) {
+  assertCloudflareDeployCredentials({ env });
+
   const manifest = readDeploymentManifest();
   const child = spawnImpl(
     "opennextjs-cloudflare",
@@ -80,7 +109,18 @@ function toRuntimeUrlVarArgs(env) {
 }
 
 if (import.meta.url === pathToFileUrl(process.argv[1])) {
-  runCloudflareDeploy();
+  try {
+    assertCloudflareDeployCredentials();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (process.argv.includes("--check")) {
+    console.log("Cloudflare deploy credentials are configured.");
+  } else {
+    runCloudflareDeploy();
+  }
 }
 
 function pathToFileUrl(value) {

--- a/apps/web/scripts/run-cloudflare-deploy.test.mjs
+++ b/apps/web/scripts/run-cloudflare-deploy.test.mjs
@@ -3,8 +3,10 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  assertCloudflareDeployCredentials,
   buildCloudflareDeployArgs,
   buildCloudflareDeployEnv,
+  getMissingCloudflareDeployCredentials,
 } from "./run-cloudflare-deploy.mjs";
 
 const manifest = {
@@ -102,4 +104,38 @@ test("buildCloudflareDeployEnv uses the cloudflare build PATH and XDG_CONFIG_HOM
 
   assert.equal(env.PATH, `${path.join(cwd, "scripts")}:/usr/bin`);
   assert.equal(env.XDG_CONFIG_HOME, path.join(cwd, ".wrangler"));
+});
+
+test("getMissingCloudflareDeployCredentials reports missing or blank credentials", () => {
+  assert.deepEqual(
+    getMissingCloudflareDeployCredentials({
+      env: {
+        CLOUDFLARE_ACCOUNT_ID: "   ",
+        CLOUDFLARE_API_TOKEN: "token",
+      },
+    }),
+    ["CLOUDFLARE_ACCOUNT_ID"],
+  );
+  assert.deepEqual(
+    getMissingCloudflareDeployCredentials({
+      env: {
+        CLOUDFLARE_ACCOUNT_ID: "account-id",
+        CLOUDFLARE_API_TOKEN: "token",
+      },
+    }),
+    [],
+  );
+});
+
+test("assertCloudflareDeployCredentials fails with an actionable message", () => {
+  assert.throws(
+    () =>
+      assertCloudflareDeployCredentials({
+        env: {
+          CLOUDFLARE_ACCOUNT_ID: "",
+          CLOUDFLARE_API_TOKEN: "",
+        },
+      }),
+    /Missing required Cloudflare deploy credentials: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID/,
+  );
 });

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -6,6 +6,10 @@ const frontendCiWorkflow = readFileSync(
   "utf8",
 );
 
+const webPackageJson = JSON.parse(
+  readFileSync(new URL("../apps/web/package.json", import.meta.url), "utf8"),
+);
+
 const deployWebWorkflowUrl = new URL(
   "../.github/workflows/deploy-web.yml",
   import.meta.url,
@@ -57,6 +61,22 @@ describe("deploy-web workflow", () => {
   it("deploys the Web worker with the deploy wrapper", () => {
     expect(readDeployWebWorkflow()).toContain(
       "corepack pnpm --filter web run deploy",
+    );
+  });
+
+  it("checks Cloudflare credentials before building the Web worker", () => {
+    expect(webPackageJson.scripts.deploy).toMatch(
+      /^node \.\/scripts\/run-cloudflare-deploy\.mjs --check && pnpm run build:cf && node \.\/scripts\/run-cloudflare-deploy\.mjs$/,
+    );
+  });
+
+  it("skips deploy cleanly when Cloudflare credentials are not configured", () => {
+    const workflow = readDeployWebWorkflow();
+
+    expect(workflow).toContain("HAS_CLOUDFLARE_DEPLOY_CREDENTIALS:");
+    expect(workflow).toContain("Cloudflare deploy skipped");
+    expect(workflow).toContain(
+      "steps.cloudflare-credentials.outputs.enabled == 'true'",
     );
   });
 


### PR DESCRIPTION
## 概要
Cloudflare のデプロイ用シークレットが未設定のときに、Web Worker のビルドやデプロイが途中で失敗する前に検知できるようにします。

GitHub Actions では必要な repository secrets がない場合に deploy-web ジョブを notice 付きでスキップし、ローカル/CI の `deploy` スクリプトではビルド前に認証情報を検証します。

## 変更内容
- `.github/workflows/deploy-web.yml`
  - `CLOUDFLARE_API_TOKEN` と `CLOUDFLARE_ACCOUNT_ID` の有無を先に確認
  - 未設定時は deploy 関連ステップをスキップして notice を出力
- `apps/web/package.json`
  - `deploy` 実行時に Cloudflare 認証情報の事前チェックを追加
- `apps/web/scripts/run-cloudflare-deploy.mjs`
  - 必須 Cloudflare 認証情報の検証処理と `--check` を追加
- `apps/web/scripts/run-cloudflare-deploy.test.mjs`
  - 認証情報検証の単体テストを追加
- `test/workflows.test.ts`
  - deploy-web workflow と deploy script の回帰テストを追加

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm vitest run test/workflows.test.ts`
- `node --test scripts/run-cloudflare-deploy.test.mjs`（`apps/web`）
- `corepack pnpm test` は `apps/web/scripts/run-generator-stack-dispatch-smoke.test.ts` の既存 smoke test が、ローカル環境の generator URL と期待値 `https://generator.example/` の不一致で 1 件失敗
