### PR TITLE
fix: webアプリの日本語文言を英語化する

### DIFF
--- a/apps/web/scripts/generator-runtime.mjs
+++ b/apps/web/scripts/generator-runtime.mjs
@@ -109,7 +109,7 @@ export function resolveScriptGeneratorRuntime({
   ) {
     return {
       message:
-        "`OP_GENERATOR_BASE_URL` と `OP_FINALIZE_DISPATCH_URL` の値が一致していません。",
+        "`OP_GENERATOR_BASE_URL` and `OP_FINALIZE_DISPATCH_URL` must match.",
       source: "none",
       status: "misconfigured",
       url: null,

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -179,13 +179,13 @@ describe("AdminClient", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /finalize を再試行/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Retry finalize/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("finalize の再試行に失敗しました")).toBeTruthy();
+      expect(screen.getByText("Finalize retry failed")).toBeTruthy();
     });
-    expect(screen.getByText(/コード: generator_error/)).toBeTruthy();
-    expect(screen.getByText(/理由: mosaic source missing/)).toBeTruthy();
+    expect(screen.getByText(/Code: generator_error/)).toBeTruthy();
+    expect(screen.getByText(/Reason: mosaic source missing/)).toBeTruthy();
   });
 
   it("uploads a target image and shows the blob id", async () => {
@@ -204,7 +204,7 @@ describe("AdminClient", () => {
 
     render(<AdminClient initialAthletes={[]} initialHealth={HEALTH_OK} />);
 
-    const input = screen.getByLabelText(/対象画像/) as HTMLInputElement;
+    const input = screen.getByLabelText(/Target image/) as HTMLInputElement;
     const file = new File(["target"], "target.jpg", { type: "image/jpeg" });
 
     fireEvent.change(input, {
@@ -217,7 +217,7 @@ describe("AdminClient", () => {
       expect(screen.getByDisplayValue("target-blob-9")).toBeTruthy();
     });
     expect(
-      screen.getByAltText("アップロードした対象画像のプレビュー"),
+      screen.getByAltText("Uploaded target image preview"),
     ).toBeTruthy();
   });
 
@@ -284,16 +284,16 @@ describe("AdminClient", () => {
     );
 
     expect(screen.queryByLabelText(/unit ID/)).toBeNull();
-    fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
+    fireEvent.change(screen.getByLabelText(/Target blob ID/), {
       target: { value: "target-blob-7" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /ユニットを作成/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Create unit/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
+      expect(screen.getByText("Unit created")).toBeTruthy();
     });
-    expect(screen.getByText(/ユニットID: 0xunit-created/)).toBeTruthy();
-    expect(screen.getByText(/ステータス: created/)).toBeTruthy();
+    expect(screen.getByText(/Unit ID: 0xunit-created/)).toBeTruthy();
+    expect(screen.getByText(/Status: created/)).toBeTruthy();
     expect(screen.queryByText(/unit ID: 7/)).toBeNull();
     expect(createPayload).toEqual({
       blobId: "target-blob-7",
@@ -366,17 +366,17 @@ describe("AdminClient", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: /デモ/ }));
-    fireEvent.change(screen.getByLabelText("デモ実アップロード枚数"), {
+    fireEvent.click(screen.getByRole("radio", { name: /Demo/ }));
+    fireEvent.change(screen.getByLabelText("Demo real upload count"), {
       target: { value: "5" },
     });
-    fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
+    fireEvent.change(screen.getByLabelText(/Target blob ID/), {
       target: { value: "target-blob-demo" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /ユニットを作成/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Create unit/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
+      expect(screen.getByText("Unit created")).toBeTruthy();
     });
     expect(createPayload).toEqual({
       blobId: "target-blob-demo",
@@ -449,19 +449,19 @@ describe("AdminClient", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: /デモ/ }));
-    fireEvent.change(screen.getByLabelText("デモ実アップロード枚数"), {
+    fireEvent.click(screen.getByRole("radio", { name: /Demo/ }));
+    fireEvent.change(screen.getByLabelText("Demo real upload count"), {
       target: { value: "0" },
     });
-    fireEvent.change(screen.getByLabelText(/対象 blob ID/), {
+    fireEvent.change(screen.getByLabelText(/Target blob ID/), {
       target: { value: "target-blob-demo-zero" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /ユニットを作成/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Create unit/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("ユニットを作成しました")).toBeTruthy();
+      expect(screen.getByText("Unit created")).toBeTruthy();
     });
-    expect(screen.getByText(/0 枚作成直後/)).toBeTruthy();
+    expect(screen.getByText(/Immediately after creating 0 photos/)).toBeTruthy();
     expect(createPayload).toEqual({
       blobId: "target-blob-demo-zero",
       displayMaxSlots: unitTileCount,

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -216,9 +216,7 @@ describe("AdminClient", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("target-blob-9")).toBeTruthy();
     });
-    expect(
-      screen.getByAltText("Uploaded target image preview"),
-    ).toBeTruthy();
+    expect(screen.getByAltText("Uploaded target image preview")).toBeTruthy();
   });
 
   it("submits a normal unit with full display slots", async () => {
@@ -461,7 +459,9 @@ describe("AdminClient", () => {
     await waitFor(() => {
       expect(screen.getByText("Unit created")).toBeTruthy();
     });
-    expect(screen.getByText(/Immediately after creating 0 photos/)).toBeTruthy();
+    expect(
+      screen.getByText(/Treat as filled immediately after creating 0 photos/),
+    ).toBeTruthy();
     expect(createPayload).toEqual({
       blobId: "target-blob-demo-zero",
       displayMaxSlots: unitTileCount,

--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -216,7 +216,7 @@ describe("AdminClient", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("target-blob-9")).toBeTruthy();
     });
-    expect(screen.getByAltText("Uploaded target image preview")).toBeTruthy();
+    expect(screen.getByAltText("Uploaded target preview")).toBeTruthy();
   });
 
   it("submits a normal unit with full display slots", async () => {

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -81,7 +81,7 @@ export function AdminClient({
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "状態の更新に失敗しました",
+        summary: "Status refresh failed",
       });
     } finally {
       setIsRefreshing(false);
@@ -138,12 +138,12 @@ export function AdminClient({
       setTargetBlobId(uploaded.blobId);
       setLastAction({
         detail: uploaded.blobId,
-        summary: "対象画像をアップロードしました",
+        summary: "Target image uploaded",
       });
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "対象画像のアップロードに失敗しました",
+        summary: "Target image upload failed",
       });
     } finally {
       setIsUploading(false);
@@ -166,13 +166,13 @@ export function AdminClient({
 
       setLastAction({
         detail: formatActionDetail(payload),
-        summary: "ユニットを作成しました",
+        summary: "Unit created",
       });
       await refreshAll();
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "ユニットの作成に失敗しました",
+        summary: "Unit creation failed",
       });
     } finally {
       setPendingAction(null);
@@ -189,14 +189,14 @@ export function AdminClient({
         detail: formatActionDetail(payload),
         summary:
           payload.status === "ignored_dispatch_failed"
-            ? "finalize の再試行に失敗しました"
-            : "finalize を再試行しました",
+            ? "Finalize retry failed"
+            : "Finalize retried",
       });
       await refreshAll();
     } catch (error) {
       setLastAction({
         detail: error instanceof Error ? error.message : String(error),
-        summary: "finalize の再試行に失敗しました",
+        summary: "Finalize retry failed",
       });
     } finally {
       setPendingAction(null);
@@ -212,26 +212,26 @@ export function AdminClient({
           onClick={() => void refreshAll()}
           type="button"
         >
-          {isRefreshing ? "更新中..." : "状態を更新"}
+          {isRefreshing ? "Refreshing..." : "Refresh status"}
         </button>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <HealthCard
           detail={health.generatorReadiness.message}
-          label="ジェネレーター準備状態"
+          label="Generator readiness"
           value={health.generatorReadiness.status}
         />
         <HealthCard
           detail={health.dispatchAuthorization.message}
-          label="ディスパッチ認可"
+          label="Dispatch authorization"
           value={health.dispatchAuthorization.status}
         />
       </div>
 
       <section className="grid gap-3 rounded-[1.5rem] border border-white/10 bg-white/6 p-5">
         <h2 className="text-xs uppercase tracking-[0.25em] text-stone-300">
-          現在の generator 接続先
+          Current generator endpoint
         </h2>
         <dl className="grid gap-3 md:grid-cols-3">
           <InfoRow
@@ -257,7 +257,7 @@ export function AdminClient({
       {lastAction ? (
         <section className="grid gap-2 rounded-[1.5rem] border border-emerald-200/20 bg-emerald-300/10 p-5">
           <h2 className="text-sm uppercase tracking-[0.25em] text-emerald-200/80">
-            直近の操作
+            Latest operation
           </h2>
           <p className="text-xl font-semibold text-white">
             {lastAction.summary}
@@ -270,22 +270,23 @@ export function AdminClient({
 
       <section className="grid gap-4 rounded-[1.75rem] border border-white/10 bg-stone-950/60 p-6">
         <div className="grid gap-1">
-          <h2 className="font-serif text-2xl text-white">ユニットを作成</h2>
+          <h2 className="font-serif text-2xl text-white">Create unit</h2>
           <p className="text-sm leading-6 text-stone-300">
-            選手表示情報と対象画像をまとめて登録し、新しい unit を作成します。
-            デモでは表示 2,000 枚のまま、実投稿枚数だけを絞れます。
+            Register the athlete display information and target image together
+            to create a new unit. Demo mode keeps 2,000 displayed tiles while
+            reducing only the real submission count.
           </p>
         </div>
 
         {athletes.length > 0 ? (
           <label className="grid gap-2 text-sm text-stone-200">
-            既存 unit から入力をコピー
+            Copy inputs from existing unit
             <select
               className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
               onChange={(event) => loadCreateDraft(event.target.value)}
               value=""
             >
-              <option value="">選択してください</option>
+              <option value="">Select one</option>
               {athletes.map((athlete) => (
                 <option
                   key={athlete.entryId ?? athlete.currentUnit?.unitId}
@@ -326,7 +327,7 @@ export function AdminClient({
 
           <fieldset className="grid gap-3 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
             <legend className="px-2 text-sm font-medium text-stone-100">
-              作成モード
+              Creation mode
             </legend>
             <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-stone-900/70 p-4 text-sm text-stone-200">
               <input
@@ -336,8 +337,10 @@ export function AdminClient({
                 type="radio"
               />
               <span className="grid gap-1">
-                <span className="font-medium text-white">通常</span>
-                <span>表示 2,000 枚 / 実投稿 2,000 枚で作成します。</span>
+                <span className="font-medium text-white">Normal</span>
+                <span>
+                  Create with 2,000 displayed tiles and 2,000 real submissions.
+                </span>
               </span>
             </label>
             <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-stone-900/70 p-4 text-sm text-stone-200">
@@ -348,15 +351,15 @@ export function AdminClient({
                 type="radio"
               />
               <span className="grid gap-2">
-                <span className="font-medium text-white">デモ</span>
+                <span className="font-medium text-white">Demo</span>
                 <span>
-                  表示は 2,000
-                  枚のまま、実際にアップロードさせる枚数だけを指定します。
+                  Keep the display at 2,000 tiles and specify only how many
+                  photos are actually uploaded.
                 </span>
                 <label className="grid gap-2 text-sm text-stone-200">
-                  実アップロード枚数
+                  Real upload count
                   <input
-                    aria-label="デモ実アップロード枚数"
+                    aria-label="Demo real upload count"
                     className="rounded-2xl border border-white/10 bg-stone-950 px-4 py-3"
                     disabled={createMode !== "demo"}
                     inputMode="numeric"
@@ -372,15 +375,15 @@ export function AdminClient({
               {createMode === "demo"
                 ? isDemoRealUploadCountValid
                   ? effectiveMaxSlots === 0
-                    ? `0 枚作成直後に filled として扱い、${effectiveDisplayMaxSlots} 枚すべてをダミー画像としてモザイク生成します。`
-                    : `${effectiveMaxSlots} 枚完了の時点で残り ${effectiveDisplayMaxSlots - effectiveMaxSlots} 枚をダミー画像としてロックし、実投稿分だけを元データとしてモザイク生成します。`
-                  : `デモでは 0 以上 ${unitTileCount - 1} 以下の実アップロード枚数を指定してください。`
-                : "通常では 2,000 枚すべてが実投稿対象です。"}
+                    ? `Treat as filled immediately after creating 0 photos and use dummy images for all ${effectiveDisplayMaxSlots} tiles when generating the mosaic.`
+                    : `${effectiveMaxSlots}  photos are complete, lock the remaining ${effectiveDisplayMaxSlots - effectiveMaxSlots}  tiles as dummy images, and use only real submissions as source data for mosaic generation.`
+                  : `Demo mode requires a real upload count between 0 and ${unitTileCount - 1}.`
+                : "Normal mode makes all 2,000 tiles real submission targets."}
             </p>
           </fieldset>
 
           <label className="grid gap-2 text-sm text-stone-200">
-            対象画像
+            Target image
             <input
               accept="image/*"
               className="rounded-2xl border border-dashed border-white/20 bg-stone-900 px-4 py-3"
@@ -392,28 +395,31 @@ export function AdminClient({
           {targetPreviewUrl ? (
             // biome-ignore lint/performance/noImgElement: operator preview
             <img
-              alt="アップロードした対象画像のプレビュー"
+              alt="Uploaded target image preview"
               className="h-48 w-full rounded-2xl border border-white/10 object-cover"
               src={targetPreviewUrl}
             />
           ) : null}
 
           <label className="grid gap-2 text-sm text-stone-200">
-            対象 blob ID
+            Target blob ID
             <input
               className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3 font-mono text-xs"
               onChange={(event) => setTargetBlobId(event.target.value)}
-              placeholder="先にアップロードするか、blob ID を直接入力してください"
+              placeholder="Upload first, or enter a blob ID directly"
               value={targetBlobId}
             />
           </label>
 
           <dl className="grid gap-3 rounded-[1.5rem] border border-white/10 bg-white/5 p-4 md:grid-cols-2">
             <InfoRow
-              label="表示スロット"
+              label="Display slots"
               value={String(effectiveDisplayMaxSlots)}
             />
-            <InfoRow label="実投稿上限" value={String(effectiveMaxSlots)} />
+            <InfoRow
+              label="Real submission limit"
+              value={String(effectiveMaxSlots)}
+            />
           </dl>
 
           <button
@@ -429,20 +435,20 @@ export function AdminClient({
             type="submit"
           >
             {isUploading
-              ? "対象画像をアップロード中..."
+              ? "Uploading target image..."
               : pendingAction === "create"
-                ? "作成中..."
-                : "ユニットを作成"}
+                ? "Creating..."
+                : "Create unit"}
           </button>
         </form>
       </section>
 
       <section className="grid gap-4">
         <div className="grid gap-1">
-          <h2 className="font-serif text-2xl text-white">現在の状態</h2>
+          <h2 className="font-serif text-2xl text-white">Current status</h2>
           <p className="text-sm leading-6 text-stone-300">
-            作成済み unit の表示進捗と実投稿数を確認し、filled のまま停止した
-            unit で finalize を再試行できます。
+            Check display progress and real submissions for created units, and
+            retry finalize for units that are stopped in filled state.
           </p>
         </div>
 
@@ -535,18 +541,21 @@ function AdminAthleteCard({
       {currentUnit ? (
         <>
           <dl className="grid gap-2 text-sm text-stone-200">
-            <InfoRow label="ユニット ID" value={currentUnit.unitId} />
+            <InfoRow label="Unit ID" value={currentUnit.unitId} />
             <InfoRow
-              label="表示進行"
+              label="Display progress"
               value={`${currentUnit.submittedCount} / ${currentUnit.displayMaxSlots}`}
             />
             <InfoRow
-              label="実投稿数"
+              label="Real submissions"
               value={`${currentUnit.realSubmittedCount} / ${currentUnit.maxSlots}`}
             />
-            <InfoRow label="モード" value={modeLabel} />
-            <InfoRow label="ステータス" value={currentUnit.status} />
-            <InfoRow label="対象 blob" value={currentUnit.targetWalrusBlobId} />
+            <InfoRow label="Mode" value={modeLabel} />
+            <InfoRow label="Status" value={currentUnit.status} />
+            <InfoRow
+              label="Target blob"
+              value={currentUnit.targetWalrusBlobId}
+            />
           </dl>
           <button
             className="rounded-full border border-emerald-200/30 bg-emerald-300/20 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-300/30 disabled:cursor-not-allowed disabled:opacity-60"
@@ -555,13 +564,13 @@ function AdminAthleteCard({
             type="button"
           >
             {pendingAction === `finalize:${currentUnit.unitId}`
-              ? "再試行中..."
-              : "finalize を再試行"}
+              ? "Retrying..."
+              : "Retry finalize"}
           </button>
         </>
       ) : (
         <p className="text-sm leading-6 text-stone-300">
-          unit の状態を一時的に取得できません。
+          Unit status is temporarily unavailable.
         </p>
       )}
     </article>
@@ -585,9 +594,7 @@ async function postJson(
 
   if (!response.ok) {
     throw new Error(
-      typeof json.message === "string"
-        ? json.message
-        : "リクエストに失敗しました。",
+      typeof json.message === "string" ? json.message : "Request failed.",
     );
   }
 
@@ -596,15 +603,13 @@ async function postJson(
 
 function formatActionDetail(payload: Record<string, unknown>): string {
   const parts = [
-    typeof payload.unitId === "string" ? `ユニットID: ${payload.unitId}` : null,
-    typeof payload.status === "string" ? `ステータス: ${payload.status}` : null,
-    typeof payload.code === "string" ? `コード: ${payload.code}` : null,
-    typeof payload.message === "string" ? `理由: ${payload.message}` : null,
-    typeof payload.digest === "string"
-      ? `ダイジェスト: ${payload.digest}`
-      : null,
+    typeof payload.unitId === "string" ? `Unit ID: ${payload.unitId}` : null,
+    typeof payload.status === "string" ? `Status: ${payload.status}` : null,
+    typeof payload.code === "string" ? `Code: ${payload.code}` : null,
+    typeof payload.message === "string" ? `Reason: ${payload.message}` : null,
+    typeof payload.digest === "string" ? `Digest: ${payload.digest}` : null,
     typeof payload.mosaicBlobId === "string"
-      ? `モザイク Blob ID: ${payload.mosaicBlobId}`
+      ? `Mosaic Blob ID: ${payload.mosaicBlobId}`
       : null,
   ].filter((value): value is string => value !== null);
 

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -395,7 +395,7 @@ export function AdminClient({
           {targetPreviewUrl ? (
             // biome-ignore lint/performance/noImgElement: operator preview
             <img
-              alt="Uploaded target image preview"
+              alt="Uploaded target preview"
               className="h-48 w-full rounded-2xl border border-white/10 object-cover"
               src={targetPreviewUrl}
             />

--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -60,7 +60,7 @@ describe("AdminPage", () => {
     const ui = await AdminPage();
     render(ui);
 
-    expect(screen.getByText(/デモ管理コンソール/)).toBeTruthy();
+    expect(screen.getByText(/Demo admin console/)).toBeTruthy();
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -21,21 +21,21 @@ export default async function AdminPage(): Promise<React.ReactElement> {
             className="text-sm uppercase tracking-[0.3em] text-amber-200/80 hover:text-amber-100"
             href="/"
           >
-            ← デモホームへ
+            ← Demo home
           </Link>
         </nav>
 
         <header className="grid gap-4 rounded-[2rem] border border-white/10 bg-white/6 p-8 shadow-2xl shadow-black/30 backdrop-blur">
           <p className="text-xs uppercase tracking-[0.3em] text-amber-200/80">
-            管理者
+            Admin
           </p>
           <h1 className="font-serif text-4xl text-white md:text-5xl">
-            デモ管理コンソール
+            Demo admin console
           </h1>
           <p className="max-w-3xl text-base leading-7 text-stone-200">
-            unit 作成時に通常版かデモ版かを選び、表示 2,000
-            枚に対する実投稿枚数を 調整できます。作成済み unit の状態確認と
-            finalize の再試行もこの 1 ページで行います。
+            Choose normal or demo mode when creating a unit, and adjust the real
+            submission count for the displayed 2,000 tiles. You can also check
+            existing unit status and retry finalize from this page.
           </p>
         </header>
 

--- a/apps/web/src/app/api/enoki/submit-photo/execute/route.ts
+++ b/apps/web/src/app/api/enoki/submit-photo/execute/route.ts
@@ -38,7 +38,7 @@ function toResponse(error: unknown): Response {
     new EnokiApiError(
       500,
       "sponsor_failed",
-      "スポンサー処理に失敗しました。時間をおいて、もう一度お試しください。",
+      "Sponsorship failed. Please wait a moment and try again.",
     ),
   );
 }

--- a/apps/web/src/app/api/enoki/submit-photo/sponsor/route.ts
+++ b/apps/web/src/app/api/enoki/submit-photo/sponsor/route.ts
@@ -41,7 +41,7 @@ function toResponse(error: unknown): Response {
     new EnokiApiError(
       500,
       "sponsor_failed",
-      "スポンサー処理に失敗しました。時間をおいて、もう一度お試しください。",
+      "Sponsorship failed. Please wait a moment and try again.",
     ),
   );
 }

--- a/apps/web/src/app/auth/enoki/callback/page.tsx
+++ b/apps/web/src/app/auth/enoki/callback/page.tsx
@@ -5,9 +5,12 @@ export default function EnokiCallbackPage(): React.ReactElement {
         <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
           Google Login
         </p>
-        <h1 className="font-serif text-3xl text-white">認証を確認しています</h1>
+        <h1 className="font-serif text-3xl text-white">
+          Verifying authentication
+        </h1>
         <p className="text-sm text-slate-300">
-          このウィンドウは自動で閉じます。閉じない場合は、そのまま待つか手動で閉じてください。
+          This window closes automatically. If it does not close, wait here or
+          close it manually.
         </p>
       </div>
     </main>

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -155,7 +155,7 @@ describe("GalleryClient", () => {
 
     expect(
       screen.getByText(
-        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
+        /Connect Google zkLogin or Sui wallet to load your Kakera history./,
       ),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
@@ -215,7 +215,7 @@ describe("GalleryClient", () => {
     useConnectWalletMock.mockReturnValue({
       mutateAsync: vi
         .fn()
-        .mockRejectedValue(new Error("ログインに失敗しました。")),
+        .mockRejectedValue(new Error("Login failed.")),
     });
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
@@ -223,10 +223,10 @@ describe("GalleryClient", () => {
     fireEvent.click(screen.getByRole("button", { name: "Google zkLogin" }));
 
     expect((await screen.findByRole("alert")).textContent).toContain(
-      "ログインに失敗しました。",
+      "Login failed.",
     );
     expect(
-      screen.getByRole("button", { name: "Google zkLogin をやり直す" }),
+      screen.getByRole("button", { name: "Retry Google zkLogin" }),
     ).toBeTruthy();
   });
 
@@ -238,7 +238,7 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
     const button = screen.getByRole("button", {
-      name: "Google zkLogin 接続中…",
+      name: "Connecting Google zkLogin...",
     });
 
     expect(button.getAttribute("disabled")).not.toBeNull();
@@ -269,7 +269,7 @@ describe("GalleryClient", () => {
 
     expect(
       screen.getByText(
-        /ログインを確認できました。Sui から Kakera を読んでいます。/,
+        /Login confirmed. Reading Kakera from Sui./,
       ),
     ).toBeTruthy();
     expect(listOwnedKakeraMock).toHaveBeenCalledWith({
@@ -344,14 +344,14 @@ describe("GalleryClient", () => {
     });
 
     expect(screen.getByText("Empty")).toBeTruthy();
-    expect(screen.getByText(/まだ Kakera が見つかりません。/)).toBeTruthy();
+    expect(screen.getByText(/No Kakera found yet./)).toBeTruthy();
     expect(
       screen.getByText(
-        /投稿直後なら、少し待ってからもう一度確認してください。/,
+        /If you just submitted, wait a moment and check again./,
       ),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "もう一度確認する" }),
+      screen.getByRole("button", { name: "Check again" }),
     ).toBeTruthy();
   });
 
@@ -365,12 +365,12 @@ describe("GalleryClient", () => {
       expect(screen.getByText("Unavailable")).toBeTruthy();
     });
 
-    expect(screen.getByText(/履歴を読み込めませんでした。/)).toBeTruthy();
+    expect(screen.getByText(/Could not load history./)).toBeTruthy();
     expect(
-      screen.getByText(/時間をおいて、もう一度確認してください。/),
+      screen.getByText(/Wait a moment and check again./),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "もう一度確認する" }),
+      screen.getByRole("button", { name: "Check again" }),
     ).toBeTruthy();
   });
 
@@ -380,14 +380,14 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="" />);
 
     expect(screen.getByText("Unavailable")).toBeTruthy();
-    expect(screen.getByText(/公開設定を確認できません。/)).toBeTruthy();
+    expect(screen.getByText(/Could not verify public configuration./)).toBeTruthy();
     expect(
       screen.getByText(
-        /Sui 接続の公開設定が不足しているため、ギャラリーを開けません。/,
+        /The Sui connection public configuration is incomplete, so the gallery cannot open./,
       ),
     ).toBeTruthy();
     expect(
-      screen.queryByRole("button", { name: "もう一度確認する" }),
+      screen.queryByRole("button", { name: "Check again" }),
     ).toBeNull();
   });
 
@@ -401,7 +401,7 @@ describe("GalleryClient", () => {
       expect(listOwnedKakeraMock).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "もう一度確認する" }));
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
 
     await waitFor(() => {
       expect(listOwnedKakeraMock).toHaveBeenCalledTimes(2);
@@ -427,7 +427,7 @@ describe("GalleryClient", () => {
         .getAttribute("src"),
     ).toBe(`${WALRUS_AGGREGATOR}/v1/blobs/walrus-original-1`);
     expect(
-      screen.queryByRole("link", { name: /unit ページで位置を見る/i }),
+      screen.queryByRole("link", { name: /View position on Unit page/i }),
     ).toBeNull();
   });
 
@@ -462,7 +462,7 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
     const unitLink = await screen.findByRole("link", {
-      name: /unit ページで位置を見る/i,
+      name: /View position on Unit page/i,
     });
 
     expect(unitLink.getAttribute("href")).toBe(
@@ -479,7 +479,7 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
 
     const unitLink = await screen.findByRole("link", {
-      name: /unit ページで位置を見る/i,
+      name: /View position on Unit page/i,
     });
 
     expect(unitLink.getAttribute("href")).toBe(

--- a/apps/web/src/app/gallery/gallery-client.test.tsx
+++ b/apps/web/src/app/gallery/gallery-client.test.tsx
@@ -213,9 +213,7 @@ describe("GalleryClient", () => {
 
   it("shows a retry login action when wallet connection fails", async () => {
     useConnectWalletMock.mockReturnValue({
-      mutateAsync: vi
-        .fn()
-        .mockRejectedValue(new Error("Login failed.")),
+      mutateAsync: vi.fn().mockRejectedValue(new Error("Login failed.")),
     });
 
     render(<GalleryClient catalog={CATALOG} packageId="0xpkg" />);
@@ -268,9 +266,7 @@ describe("GalleryClient", () => {
     });
 
     expect(
-      screen.getByText(
-        /Login confirmed. Reading Kakera from Sui./,
-      ),
+      screen.getByText(/Login confirmed. Reading Kakera from Sui./),
     ).toBeTruthy();
     expect(listOwnedKakeraMock).toHaveBeenCalledWith({
       ownerAddress: "0xviewer",
@@ -346,13 +342,9 @@ describe("GalleryClient", () => {
     expect(screen.getByText("Empty")).toBeTruthy();
     expect(screen.getByText(/No Kakera found yet./)).toBeTruthy();
     expect(
-      screen.getByText(
-        /If you just submitted, wait a moment and check again./,
-      ),
+      screen.getByText(/If you just submitted, wait a moment and check again./),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Check again" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
   it("shows a fetch failure shell when Kakera loading fails", async () => {
@@ -366,12 +358,8 @@ describe("GalleryClient", () => {
     });
 
     expect(screen.getByText(/Could not load history./)).toBeTruthy();
-    expect(
-      screen.getByText(/Wait a moment and check again./),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Check again" }),
-    ).toBeTruthy();
+    expect(screen.getByText(/Wait a moment and check again./)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
   it("shows a config-missing shell without a retry action", () => {
@@ -380,15 +368,15 @@ describe("GalleryClient", () => {
     render(<GalleryClient catalog={CATALOG} packageId="" />);
 
     expect(screen.getByText("Unavailable")).toBeTruthy();
-    expect(screen.getByText(/Could not verify public configuration./)).toBeTruthy();
+    expect(
+      screen.getByText(/Could not verify public configuration./),
+    ).toBeTruthy();
     expect(
       screen.getByText(
         /The Sui connection public configuration is incomplete, so the gallery cannot open./,
       ),
     ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Check again" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
   });
 
   it("reloads the gallery when the user asks to check again", async () => {

--- a/apps/web/src/app/gallery/gallery-client.tsx
+++ b/apps/web/src/app/gallery/gallery-client.tsx
@@ -86,9 +86,9 @@ export function GalleryClient({
   if (!packageId) {
     return (
       <GalleryStatusShell
-        description="Sui 接続の公開設定が不足しているため、ギャラリーを開けません。"
+        description="The Sui connection public configuration is incomplete, so the gallery cannot open."
         label="Unavailable"
-        title="公開設定を確認できません。"
+        title="Could not verify public configuration."
         tone="warning"
       />
     );
@@ -120,7 +120,7 @@ function ConnectedGalleryClient({
 
   async function handleLogin(): Promise<void> {
     if (!googleWallet) {
-      setConnectError("Google ログインの設定が見つかりません。");
+      setConnectError("Google login configuration was not found.");
       return;
     }
 
@@ -208,7 +208,7 @@ function ConnectedGalleryClient({
   if (!currentAccount?.address) {
     return (
       <GalleryStatusShell
-        description="Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。"
+        description="Connect Google zkLogin or Sui wallet to load your Kakera history."
         label="Wallet required"
         tone="info"
       >
@@ -222,9 +222,9 @@ function ConnectedGalleryClient({
             type="button"
           >
             {isConnecting
-              ? "Google zkLogin 接続中…"
+              ? "Connecting Google zkLogin..."
               : connectError
-                ? "Google zkLogin をやり直す"
+                ? "Retry Google zkLogin"
                 : "Google zkLogin"}
           </button>
           <SuiWalletConnectModal
@@ -253,9 +253,9 @@ function ConnectedGalleryClient({
   if (state.kind === "error") {
     return (
       <GalleryStatusShell
-        description="時間をおいて、もう一度確認してください。"
+        description="Wait a moment and check again."
         label="Unavailable"
-        title="履歴を読み込めませんでした。"
+        title="Could not load history."
         tone="warning"
       >
         <div className="mt-4 flex flex-wrap gap-3">
@@ -266,7 +266,7 @@ function ConnectedGalleryClient({
             }}
             type="button"
           >
-            もう一度確認する
+            Check again
           </button>
         </div>
       </GalleryStatusShell>
@@ -276,7 +276,7 @@ function ConnectedGalleryClient({
   if (state.kind === "loading") {
     return (
       <GalleryStatusShell
-        description="ログインを確認できました。Sui から Kakera を読んでいます。"
+        description="Login confirmed. Reading Kakera from Sui."
         label="Loading"
         tone="info"
       />
@@ -286,10 +286,10 @@ function ConnectedGalleryClient({
   if (state.entries.length === 0) {
     return (
       <GalleryStatusShell
-        description="まだ Kakera が見つかりません。"
+        description="No Kakera found yet."
         label="Empty"
-        note="投稿直後なら、少し待ってからもう一度確認してください。"
-        title="このウォレットの履歴はまだ空です。"
+        note="If you just submitted, wait a moment and check again."
+        title="This wallet history is still empty."
         tone="empty"
       >
         <div className="mt-4 flex flex-wrap gap-3">
@@ -300,7 +300,7 @@ function ConnectedGalleryClient({
             }}
             type="button"
           >
-            もう一度確認する
+            Check again
           </button>
         </div>
       </GalleryStatusShell>
@@ -361,7 +361,7 @@ function toMessage(error: unknown): string {
     return error.message;
   }
 
-  return "処理に失敗しました。時間をおいて、もう一度お試しください。";
+  return "Processing failed. Please wait a moment and try again.";
 }
 
 type GalleryStatusShellProps = {
@@ -462,7 +462,7 @@ function GalleryCard({
           </p>
         </div>
         <div className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]">
-          KAKERA · 欠片
+          KAKERA · Fragment
         </div>
       </div>
 
@@ -475,7 +475,7 @@ function GalleryCard({
               unitId: entry.unitId,
             })}
           >
-            Unit ページで位置を見る
+            View position on Unit page
           </Link>
         </div>
       ) : null}

--- a/apps/web/src/app/gallery/gallery-page-client.tsx
+++ b/apps/web/src/app/gallery/gallery-page-client.tsx
@@ -13,7 +13,7 @@ const GalleryClient = dynamic<GalleryClientProps>(
         <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">
           Loading
         </p>
-        <p className="mt-3 text-slate-100">ギャラリーを準備しています。</p>
+        <p className="mt-3 text-slate-100">Preparing the gallery.</p>
       </section>
     ),
   },

--- a/apps/web/src/app/gallery/page.tsx
+++ b/apps/web/src/app/gallery/page.tsx
@@ -39,7 +39,7 @@ export default async function GalleryPage(
         <header className="flex flex-col gap-6 border-b border-[var(--rule)] pb-8">
           <div className="op-eyebrow">
             <span className="bar" />
-            <span>History · 参加の記録</span>
+            <span>History · Participation record</span>
           </div>
           <h1 className="font-display text-[clamp(48px,8vw,96px)] leading-[0.9] tracking-[-0.01em] text-[var(--ink)]">
             Participation{" "}

--- a/apps/web/src/app/global-wallet-entry.tsx
+++ b/apps/web/src/app/global-wallet-entry.tsx
@@ -74,7 +74,7 @@ function GlobalWalletEntryEnabled(): React.ReactElement {
 
   async function handleGoogleLogin(): Promise<void> {
     if (!googleWallet) {
-      setConnectError("Google zkLogin の設定が見つかりません。");
+      setConnectError("Google zkLogin configuration was not found.");
       return;
     }
 
@@ -260,5 +260,5 @@ function toMessage(error: unknown): string {
     return error.message;
   }
 
-  return "接続に失敗しました。時間をおいて、もう一度お試しください。";
+  return "Connection failed. Please wait a moment and try again.";
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -207,9 +207,11 @@ describe("HomePage", () => {
 
     expect(screen.getByText("Demo Athlete One")).toBeTruthy();
     expect(screen.getByText("Demo Athlete Two")).toBeTruthy();
-    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting \/ No active unit/i)).toBeTruthy();
     expect(
-      screen.getByText(/Progress temporarily unavailable|temporarily unavailable/i),
+      screen.getByText(
+        /Progress temporarily unavailable|temporarily unavailable/i,
+      ),
     ).toBeTruthy();
     expect(getActiveHomeUnitsMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -123,7 +123,7 @@ describe("HomePage", () => {
     render(ui);
 
     expect(
-      screen.getByText(/現在表示できる開催中ユニットはありません/),
+      screen.getByText(/No active units are available right now/),
     ).toBeTruthy();
   });
 
@@ -157,7 +157,7 @@ describe("HomePage", () => {
     render(ui);
 
     expect(
-      screen.getByText(/現在表示できる開催中ユニットはありません/),
+      screen.getByText(/No active units are available right now/),
     ).toBeTruthy();
   });
 
@@ -171,7 +171,7 @@ describe("HomePage", () => {
     render(ui);
 
     expect(
-      screen.getByText(/現在表示できる開催中ユニットはありません/),
+      screen.getByText(/No active units are available right now/),
     ).toBeTruthy();
   });
 
@@ -207,9 +207,9 @@ describe("HomePage", () => {
 
     expect(screen.getByText("Demo Athlete One")).toBeTruthy();
     expect(screen.getByText("Demo Athlete Two")).toBeTruthy();
-    expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
     expect(
-      screen.getByText(/進捗を一時取得できません|temporarily unavailable/i),
+      screen.getByText(/Progress temporarily unavailable|temporarily unavailable/i),
     ).toBeTruthy();
     expect(getActiveHomeUnitsMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -269,10 +269,10 @@ export default async function HomePage(
         {entries.length === 0 ? (
           <article className="op-surface grid gap-2 text-[var(--ink)]">
             <h3 className="font-display text-2xl">
-              現在表示できる開催中ユニットはありません
+              No active units are available right now
             </h3>
             <p className="text-sm leading-6 text-[var(--ink-dim)]">
-              `pending` な unit が作成されると、 ここに自動で表示されます。
+              When a pending unit is created, it will appear here automatically.
             </p>
           </article>
         ) : (
@@ -653,14 +653,14 @@ function ProgressLabel({
   if (progress.kind === "waiting") {
     return (
       <p className="font-mono-op text-[11px] uppercase tracking-[0.3em] text-[var(--ember)]">
-        待機中 / No active unit
+        Waiting / No active unit
       </p>
     );
   }
 
   return (
     <p className="font-mono-op text-[11px] uppercase tracking-[0.3em] text-[var(--ink-faint)]">
-      進捗を一時取得できません / Progress temporarily unavailable
+      Progress temporarily unavailable
     </p>
   );
 }

--- a/apps/web/src/app/units/[unitId]/live-progress.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.tsx
@@ -12,8 +12,9 @@
  *   `SubmittedEvent` is the ONLY source of truth for `submittedCount`.
  *   The submit flow (`ParticipationAccess`) must NOT optimistically bump this
  *   counter — the participant sees the number advance only after the chain
- *   event is observed. This keeps the waiting-room narrative ("観測できる
- *   まで待ち、駄目なら案内付きで再試行") honest.
+ *   event is observed. This keeps the waiting-room narrative honest: wait
+ *   until the chain can observe the submission, then retry with guidance if it
+ *   cannot.
  *
  * Follow-up issues can plug:
  *   - reveal animation (listen for MosaicReadyEvent here and fan out)

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -283,7 +283,7 @@ describe("UnitPage", () => {
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();
-    expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
   });
 
   it("shows a waiting-room link to the participation gallery", async () => {
@@ -323,7 +323,7 @@ describe("UnitPage", () => {
     render(ui);
 
     expect(
-      screen.getByRole("heading", { name: "選手情報を一時取得できません" }),
+      screen.getByRole("heading", { name: "Athlete information is temporarily unavailable" }),
     ).toBeTruthy();
   });
 
@@ -342,7 +342,7 @@ describe("UnitPage", () => {
     render(ui);
 
     expect(
-      screen.getByRole("heading", { name: "選手情報を一時取得できません" }),
+      screen.getByRole("heading", { name: "Athlete information is temporarily unavailable" }),
     ).toBeTruthy();
   });
 
@@ -543,7 +543,7 @@ describe("UnitPage", () => {
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();
-    expect(screen.getByText(/待機中|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
   });
 
   it("applies the active unit bootstrap only in stub E2E mode", async () => {

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -323,7 +323,9 @@ describe("UnitPage", () => {
     render(ui);
 
     expect(
-      screen.getByRole("heading", { name: "Athlete information is temporarily unavailable" }),
+      screen.getByRole("heading", {
+        name: "Athlete information is temporarily unavailable",
+      }),
     ).toBeTruthy();
   });
 
@@ -342,7 +344,9 @@ describe("UnitPage", () => {
     render(ui);
 
     expect(
-      screen.getByRole("heading", { name: "Athlete information is temporarily unavailable" }),
+      screen.getByRole("heading", {
+        name: "Athlete information is temporarily unavailable",
+      }),
     ).toBeTruthy();
   });
 

--- a/apps/web/src/app/units/[unitId]/page.test.tsx
+++ b/apps/web/src/app/units/[unitId]/page.test.tsx
@@ -283,7 +283,7 @@ describe("UnitPage", () => {
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();
-    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting \/ No active unit/i)).toBeTruthy();
   });
 
   it("shows a waiting-room link to the participation gallery", async () => {
@@ -547,7 +547,7 @@ describe("UnitPage", () => {
     expect(
       screen.getByRole("heading", { name: "Demo Athlete One" }),
     ).toBeTruthy();
-    expect(screen.getByText(/Waiting|No active unit/i)).toBeTruthy();
+    expect(screen.getByText(/Waiting \/ No active unit/i)).toBeTruthy();
   });
 
   it("applies the active unit bootstrap only in stub E2E mode", async () => {

--- a/apps/web/src/app/units/[unitId]/page.tsx
+++ b/apps/web/src/app/units/[unitId]/page.tsx
@@ -163,8 +163,8 @@ export default async function UnitPage(
                   />
                 ) : (
                   <p className="font-serif-display italic text-lg text-[var(--ink-dim)]">
-                    待機中 / No active unit — on-chain progress is not available
-                    right now.
+                    Waiting / No active unit — on-chain progress is not
+                    available right now.
                   </p>
                 )}
               </div>
@@ -214,7 +214,8 @@ function DemoParticipationPreview(): React.ReactElement {
         <span>Demo login preview</span>
       </p>
       <p className="text-sm text-[var(--ink-dim)]">
-        `dev:demo` では導線だけを確認します。実際のログインや投稿は行いません。
+        `dev:demo` only checks the navigation path. It does not perform real
+        login or submission.
       </p>
       <div className="flex flex-wrap gap-3">
         <button className="op-btn-primary" type="button">
@@ -295,7 +296,7 @@ function resolveDisplayName(
     catalogDisplayName ??
     (normalizedRouteAthleteName
       ? normalizedRouteAthleteName
-      : "選手情報を一時取得できません")
+      : "Athlete information is temporarily unavailable")
   );
 }
 

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -176,7 +176,7 @@ describe("ParticipationAccess", () => {
 
     render(<ParticipationAccess unitId="0xunit-1" />);
 
-    expect(screen.getByText(/only progress checking is available/)).toBeTruthy();
+    expect(screen.getByText(/only check progress/)).toBeTruthy();
   });
 
   it("uses the server-provided packageId for Kakera lookup by default", () => {
@@ -327,9 +327,7 @@ describe("ParticipationAccess", () => {
 
     render(<ParticipationAccess unitId="0xunit-1" />);
 
-    expect(
-      screen.getByText(/Sui wallet address confirmed/),
-    ).toBeTruthy();
+    expect(screen.getByText(/Sui wallet address confirmed/)).toBeTruthy();
     expect(screen.getByLabelText(FILE_INPUT_LABEL)).toBeTruthy();
     expect(
       screen.queryByText(/Only the history gallery is available./),
@@ -402,7 +400,9 @@ describe("ParticipationAccess", () => {
 
     expect(screen.queryByRole("checkbox", { name: CONSENT_LABEL })).toBeNull();
     expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
-    expect(screen.queryByRole("button", { name: /Confirm submission/ })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Confirm submission/ }),
+    ).toBeNull();
     expect(screen.getByText(/This Unit is full/)).toBeTruthy();
   });
 
@@ -439,7 +439,9 @@ describe("ParticipationAccess", () => {
     expect(preprocessPhoto.mock.calls[0][0]).toBe(file);
 
     await waitFor(() => {
-      const preview = screen.getByAltText("Submission preview") as HTMLImageElement;
+      const preview = screen.getByAltText(
+        "Submission preview",
+      ) as HTMLImageElement;
       expect(preview.src).toContain("blob:preview-abc");
     });
   });
@@ -491,9 +493,7 @@ describe("ParticipationAccess", () => {
 
     const preprocessPhoto = vi
       .fn()
-      .mockRejectedValue(
-        new Error("The photo exceeds the 10MB size limit."),
-      );
+      .mockRejectedValue(new Error("The photo exceeds the 10MB size limit."));
 
     render(
       <ParticipationAccess
@@ -509,7 +509,7 @@ describe("ParticipationAccess", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("alert").textContent).toContain(
-        "photo exceeds the size limit",
+        "photo exceeds the 10MB size limit",
       );
     });
   });
@@ -849,9 +849,7 @@ describe("ParticipationAccess", () => {
         });
       });
 
-      expect(
-        screen.queryByRole("button", { name: /Submit again/ }),
-      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /Submit again/ })).toBeNull();
       expect(screen.getByText(/This Unit is full/)).toBeTruthy();
       expect(putBlob).toHaveBeenCalledTimes(1);
     });
@@ -1012,9 +1010,7 @@ describe("ParticipationAccess", () => {
       expect(
         screen.getByText(/Checking the submission result. Please wait./),
       ).toBeTruthy();
-      expect(
-        screen.queryByRole("button", { name: /Submit again/ }),
-      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /Submit again/ })).toBeNull();
 
       resolveExecutionCheck({
         status: "failed",
@@ -1026,9 +1022,7 @@ describe("ParticipationAccess", () => {
           "Could not complete the submission",
         );
       });
-      expect(
-        screen.getByRole("button", { name: /Submit again/ }),
-      ).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Submit again/ })).toBeTruthy();
     });
 
     it("re-queries recovering execution and merges into the participation card once recovery succeeds", async () => {
@@ -1079,9 +1073,7 @@ describe("ParticipationAccess", () => {
       await waitFor(() => {
         expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(1);
       });
-      expect(
-        screen.queryByRole("button", { name: /Submit again/ }),
-      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /Submit again/ })).toBeNull();
 
       await waitFor(
         () => {
@@ -1182,9 +1174,7 @@ describe("ParticipationAccess", () => {
         },
         { timeout: 1_000 },
       );
-      expect(
-        screen.getByRole("button", { name: /Submit again/ }),
-      ).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Submit again/ })).toBeTruthy();
     });
 
     it("renders the participation card with preview, sender, and a pending submission_no while Kakera is being confirmed", async () => {
@@ -1238,9 +1228,7 @@ describe("ParticipationAccess", () => {
       const submissionHeading = screen.getByText(/submission_no/i);
       const submissionValue = submissionHeading.nextElementSibling;
       expect(submissionValue?.textContent).toMatch(/Checking/);
-      expect(
-        screen.getByText(/Checking Kakera/),
-      ).toBeTruthy();
+      expect(screen.getByText(/Checking Kakera/)).toBeTruthy();
     });
 
     it("shows the Kakera submission_no once the hook reports 'found'", async () => {

--- a/apps/web/src/app/units/[unitId]/participation-access.test.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.test.tsx
@@ -110,7 +110,7 @@ import { LiveProgress } from "./live-progress";
 import { ParticipationAccess } from "./participation-access";
 import { UnitFullStateProvider } from "./unit-full-state";
 
-const FILE_INPUT_LABEL = "写真を選択";
+const FILE_INPUT_LABEL = "Choose photo";
 const CONSENT_LABEL =
   /I understand that the original image I submit will be stored on Walrus and can be retrieved by anyone who knows the blob_id\. I also agree that a Soulbound, non-transferable Kakera NFT will be issued to my wallet as proof of participation\./;
 
@@ -176,7 +176,7 @@ describe("ParticipationAccess", () => {
 
     render(<ParticipationAccess unitId="0xunit-1" />);
 
-    expect(screen.getByText(/進捗の確認だけ使えます/)).toBeTruthy();
+    expect(screen.getByText(/only progress checking is available/)).toBeTruthy();
   });
 
   it("uses the server-provided packageId for Kakera lookup by default", () => {
@@ -247,7 +247,7 @@ describe("ParticipationAccess", () => {
 
     expect(
       screen.getByText(
-        /Google zkLogin または Sui wallet を接続すると、この待機室から投稿できます。/,
+        /Connect Google zkLogin or Sui wallet to submit from this waiting room./,
       ),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Google zkLogin" })).toBeTruthy();
@@ -282,7 +282,7 @@ describe("ParticipationAccess", () => {
 
     expect(screen.queryByRole("button", { name: "Google zkLogin" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Sui wallet" })).toBeNull();
-    expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+    expect(screen.getByText(/This Unit is full/)).toBeTruthy();
   });
 
   it("keeps the signed-out Sui wallet modal controlled", async () => {
@@ -328,11 +328,11 @@ describe("ParticipationAccess", () => {
     render(<ParticipationAccess unitId="0xunit-1" />);
 
     expect(
-      screen.getByText(/Sui wallet アドレスを確認できました/),
+      screen.getByText(/Sui wallet address confirmed/),
     ).toBeTruthy();
     expect(screen.getByLabelText(FILE_INPUT_LABEL)).toBeTruthy();
     expect(
-      screen.queryByText(/履歴ギャラリーの確認だけ利用できます。/),
+      screen.queryByText(/Only the history gallery is available./),
     ).toBeNull();
   });
 
@@ -368,7 +368,7 @@ describe("ParticipationAccess", () => {
       );
     });
     expect(
-      screen.getByRole("button", { name: "Google zkLogin をやり直す" }),
+      screen.getByRole("button", { name: "Retry Google zkLogin" }),
     ).toBeTruthy();
   });
 
@@ -402,8 +402,8 @@ describe("ParticipationAccess", () => {
 
     expect(screen.queryByRole("checkbox", { name: CONSENT_LABEL })).toBeNull();
     expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
-    expect(screen.queryByRole("button", { name: /投稿を確定/ })).toBeNull();
-    expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Confirm submission/ })).toBeNull();
+    expect(screen.getByText(/This Unit is full/)).toBeTruthy();
   });
 
   it("calls preprocessPhoto with the chosen file and renders the preview URL", async () => {
@@ -439,7 +439,7 @@ describe("ParticipationAccess", () => {
     expect(preprocessPhoto.mock.calls[0][0]).toBe(file);
 
     await waitFor(() => {
-      const preview = screen.getByAltText("投稿プレビュー") as HTMLImageElement;
+      const preview = screen.getByAltText("Submission preview") as HTMLImageElement;
       expect(preview.src).toContain("blob:preview-abc");
     });
   });
@@ -469,7 +469,7 @@ describe("ParticipationAccess", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/処理中/)).toBeTruthy();
+      expect(screen.getByText(/Processing/)).toBeTruthy();
     });
 
     resolvePreprocess({
@@ -482,7 +482,7 @@ describe("ParticipationAccess", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+      expect(screen.getByAltText("Submission preview")).toBeTruthy();
     });
   });
 
@@ -492,7 +492,7 @@ describe("ParticipationAccess", () => {
     const preprocessPhoto = vi
       .fn()
       .mockRejectedValue(
-        new Error("写真のサイズが上限（10MB）を超えています。"),
+        new Error("The photo exceeds the 10MB size limit."),
       );
 
     render(
@@ -509,13 +509,13 @@ describe("ParticipationAccess", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("alert").textContent).toContain(
-        "写真のサイズが上限",
+        "photo exceeds the size limit",
       );
     });
   });
 
   describe("submission flow (Walrus PUT + Sponsored Tx)", () => {
-    const SUBMIT_BUTTON_NAME = /投稿を確定/;
+    const SUBMIT_BUTTON_NAME = /Confirm submission/;
 
     type PreprocessedLike = {
       readonly blob: Blob;
@@ -571,7 +571,7 @@ describe("ParticipationAccess", () => {
         expect(preprocessPhoto).toHaveBeenCalledTimes(1);
       });
       await waitFor(() => {
-        expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+        expect(screen.getByAltText("Submission preview")).toBeTruthy();
       });
     }
 
@@ -693,7 +693,7 @@ describe("ParticipationAccess", () => {
         .mockRejectedValue(
           new WalrusPutError(
             "final",
-            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+            "Could not save the photo to Walrus. Please try again.",
           ),
         );
 
@@ -715,7 +715,7 @@ describe("ParticipationAccess", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toContain(
-          "Walrus への写真の保存に失敗",
+          "Could not save the photo to Walrus",
         );
       });
       expect(submitPhoto).not.toHaveBeenCalled();
@@ -729,7 +729,7 @@ describe("ParticipationAccess", () => {
         .mockRejectedValueOnce(
           new WalrusPutError(
             "final",
-            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+            "Could not save the photo to Walrus. Please try again.",
           ),
         )
         .mockResolvedValueOnce({
@@ -760,12 +760,12 @@ describe("ParticipationAccess", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toContain(
-          "Walrus への写真の保存に失敗",
+          "Could not save the photo to Walrus",
         );
       });
 
       const retryButton = screen.getByRole("button", {
-        name: /もう一度送信する/,
+        name: /Submit again/,
       });
       expect(retryButton).toBeTruthy();
 
@@ -788,7 +788,7 @@ describe("ParticipationAccess", () => {
         expect(submitPhoto).toHaveBeenCalledWith("walrus-blob-retry");
       });
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
     });
 
@@ -804,7 +804,7 @@ describe("ParticipationAccess", () => {
         .mockRejectedValue(
           new WalrusPutError(
             "final",
-            "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+            "Could not save the photo to Walrus. Please try again.",
           ),
         );
 
@@ -833,7 +833,7 @@ describe("ParticipationAccess", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /もう一度送信する/ }),
+          screen.getByRole("button", { name: /Submit again/ }),
         ).toBeTruthy();
       });
 
@@ -850,9 +850,9 @@ describe("ParticipationAccess", () => {
       });
 
       expect(
-        screen.queryByRole("button", { name: /もう一度送信する/ }),
+        screen.queryByRole("button", { name: /Submit again/ }),
       ).toBeNull();
-      expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+      expect(screen.getByText(/This Unit is full/)).toBeTruthy();
       expect(putBlob).toHaveBeenCalledTimes(1);
     });
 
@@ -872,7 +872,7 @@ describe("ParticipationAccess", () => {
         new EnokiSubmitClientError(
           401,
           "auth_expired",
-          "ログインが切れました。Google でもう一度ログインしてください。",
+          "Your login expired. Please sign in with Google again.",
         ),
       );
 
@@ -897,7 +897,7 @@ describe("ParticipationAccess", () => {
       });
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toContain(
-          "ログインが切れました",
+          "Your login expired",
         );
       });
     });
@@ -930,22 +930,22 @@ describe("ParticipationAccess", () => {
       fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
       expect(screen.getByText(/final-digest-XYZ/)).toBeTruthy();
       expect(
         screen.getByText(
-          /この Unit ページで reveal と finalize の状況を見ながら、履歴ギャラリーでも参加記録を確認できます。/,
+          /You can watch the reveal and finalize status on this Unit page, and review your participation record in the history gallery./,
         ),
       ).toBeTruthy();
       expect(
         screen
-          .getByRole("link", { name: "完成状況を確認" })
+          .getByRole("link", { name: "View completion status" })
           .getAttribute("href"),
       ).toBe("/units/0xunit-1");
       expect(
         screen
-          .getByRole("link", { name: "履歴ギャラリーを見る" })
+          .getByRole("link", { name: "View history gallery" })
           .getAttribute("href"),
       ).toBe("/gallery");
     });
@@ -1010,10 +1010,10 @@ describe("ParticipationAccess", () => {
       });
 
       expect(
-        screen.getByText(/投稿結果を確認しています。しばらくお待ちください。/),
+        screen.getByText(/Checking the submission result. Please wait./),
       ).toBeTruthy();
       expect(
-        screen.queryByRole("button", { name: /もう一度送信する/ }),
+        screen.queryByRole("button", { name: /Submit again/ }),
       ).toBeNull();
 
       resolveExecutionCheck({
@@ -1023,11 +1023,11 @@ describe("ParticipationAccess", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toContain(
-          "投稿を完了できませんでした",
+          "Could not complete the submission",
         );
       });
       expect(
-        screen.getByRole("button", { name: /もう一度送信する/ }),
+        screen.getByRole("button", { name: /Submit again/ }),
       ).toBeTruthy();
     });
 
@@ -1080,7 +1080,7 @@ describe("ParticipationAccess", () => {
         expect(checkSubmissionExecutionMock).toHaveBeenCalledTimes(1);
       });
       expect(
-        screen.queryByRole("button", { name: /もう一度送信する/ }),
+        screen.queryByRole("button", { name: /Submit again/ }),
       ).toBeNull();
 
       await waitFor(
@@ -1091,7 +1091,7 @@ describe("ParticipationAccess", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
       expect(screen.getByText(/recover-digest/)).toBeTruthy();
       expect(useOwnedKakeraMock).toHaveBeenLastCalledWith(
@@ -1177,13 +1177,13 @@ describe("ParticipationAccess", () => {
       await waitFor(
         () => {
           expect(screen.getByRole("alert").textContent).toContain(
-            "投稿結果を確認できませんでした",
+            "Could not confirm the submission result",
           );
         },
         { timeout: 1_000 },
       );
       expect(
-        screen.getByRole("button", { name: /もう一度送信する/ }),
+        screen.getByRole("button", { name: /Submit again/ }),
       ).toBeTruthy();
     });
 
@@ -1219,12 +1219,12 @@ describe("ParticipationAccess", () => {
       fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
 
-      // 参加証 card shows the locally-preprocessed preview image.
+      // The participation card shows the locally preprocessed preview image.
       const previews = screen.getAllByAltText(
-        "投稿プレビュー",
+        "Submission preview",
       ) as HTMLImageElement[];
       expect(previews.some((img) => img.src.includes("blob:preview-xyz"))).toBe(
         true,
@@ -1237,9 +1237,9 @@ describe("ParticipationAccess", () => {
       // submission_no is still being confirmed: show a pending indicator.
       const submissionHeading = screen.getByText(/submission_no/i);
       const submissionValue = submissionHeading.nextElementSibling;
-      expect(submissionValue?.textContent).toMatch(/確認中/);
+      expect(submissionValue?.textContent).toMatch(/Checking/);
       expect(
-        screen.getByText(/Kakera.*確認しています|Kakera を確認しています/),
+        screen.getByText(/Checking Kakera/),
       ).toBeTruthy();
     });
 
@@ -1280,12 +1280,12 @@ describe("ParticipationAccess", () => {
       fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
       await waitFor(() => {
         expect(screen.getByText(/#128/)).toBeTruthy();
       });
-      expect(screen.getByText(/Kakera を受け取りました/)).toBeTruthy();
+      expect(screen.getByText(/Kakera received/)).toBeTruthy();
     });
 
     it("shows a timeout notice when the Kakera lookup hits its retry budget", async () => {
@@ -1320,10 +1320,10 @@ describe("ParticipationAccess", () => {
       fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
       await waitFor(() => {
-        expect(screen.getByText(/確認できませんでした/)).toBeTruthy();
+        expect(screen.getByText(/Could not confirm/)).toBeTruthy();
       });
     });
   });
@@ -1337,7 +1337,7 @@ describe("ParticipationAccess", () => {
    *   - Only a `SubmittedEvent` observation increments the counter.
    */
   describe("integration with LiveProgress (SubmittedEvent is source of truth)", () => {
-    const SUBMIT_BUTTON_NAME = /投稿を確定/;
+    const SUBMIT_BUTTON_NAME = /Confirm submission/;
 
     it("keeps the counter flat after submit success, then increments on SubmittedEvent", async () => {
       setupSignedInEnv();
@@ -1398,13 +1398,13 @@ describe("ParticipationAccess", () => {
         target: { files: [makeFile()] },
       });
       await waitFor(() => {
-        expect(screen.getByAltText("投稿プレビュー")).toBeTruthy();
+        expect(screen.getByAltText("Submission preview")).toBeTruthy();
       });
 
       fireEvent.click(screen.getByRole("button", { name: SUBMIT_BUTTON_NAME }));
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿が完了しました/)).toBeTruthy();
+        expect(screen.getByText(/Submission complete/)).toBeTruthy();
       });
 
       // Progress counter MUST still be at its initial value — no optimistic
@@ -1484,7 +1484,7 @@ describe("ParticipationAccess", () => {
       });
 
       expect(screen.queryByLabelText(FILE_INPUT_LABEL)).toBeNull();
-      expect(screen.getByText(/この Unit は満枠です/)).toBeTruthy();
+      expect(screen.getByText(/This Unit is full/)).toBeTruthy();
     });
   });
 });

--- a/apps/web/src/app/units/[unitId]/participation-access.tsx
+++ b/apps/web/src/app/units/[unitId]/participation-access.tsx
@@ -76,7 +76,7 @@ const CONSENT_COPY =
  *
  * `retry.kind === "upload"` means the Walrus PUT failed after our internal
  * retries were exhausted, but the locally preprocessed photo is still valid.
- * The UI can offer a "もう一度送信する" button that jumps straight back to
+ * The UI can offer a "Submit again" button that jumps straight back to
  * the uploading phase with the same {@link PreprocessedPhoto}, skipping
  * preprocessing.
  */
@@ -143,7 +143,8 @@ export function ParticipationAccess({
           <span>Submit access</span>
         </p>
         <p className="text-sm text-[var(--ink-dim)]">
-          投稿ログインは未設定です。今は進捗の確認だけ使えます。
+          Submission login is not configured. You can only check progress for
+          now.
         </p>
       </section>
     );
@@ -260,7 +261,7 @@ function ParticipationAccessEnabled({
 
   async function handleLogin(): Promise<void> {
     if (!googleWallet) {
-      setConnectError("Google ログインの設定が見つかりません。");
+      setConnectError("Google login configuration was not found.");
       return;
     }
 
@@ -299,7 +300,7 @@ function ParticipationAccessEnabled({
       setPhase({
         kind: "error",
         message: classifyWalrusError(error),
-        // Keep the preprocessed photo so the "もう一度送信する" button can
+        // Keep the preprocessed photo so the "Submit again" button can
         // retry the Walrus PUT without re-running preprocessing.
         retry: isWalrusRetryable(error) ? { kind: "upload", photo } : undefined,
       });
@@ -318,8 +319,8 @@ function ParticipationAccessEnabled({
       });
     } catch (error) {
       if (isAuthExpired(error)) {
-        // 認証切れは再ログイン導線へ戻す。wallet を切断して
-        // <Google でログイン> ボタンが再表示される状態にする。
+        // Return expired sessions to the login path and disconnect the wallet
+        // so the Google login button is shown again.
         disconnectWallet.mutate();
         setConnectError(toMessage(error));
         setPhase({ kind: "ready" });
@@ -384,7 +385,7 @@ function ParticipationAccessEnabled({
       if (result.status === "failed") {
         setPhase({
           kind: "error",
-          message: "投稿を完了できませんでした。もう一度送信してください。",
+          message: "Could not complete the submission. Please submit again.",
           retry: { kind: "submit", photo: phase.photo },
         });
         return;
@@ -393,7 +394,8 @@ function ParticipationAccessEnabled({
       if (attempts >= recoveryMaxAttempts) {
         setPhase({
           kind: "error",
-          message: "投稿結果を確認できませんでした。もう一度送信してください。",
+          message:
+            "Could not confirm the submission result. Please submit again.",
           retry: { kind: "submit", photo: phase.photo },
         });
         return;
@@ -459,8 +461,8 @@ function ParticipationAccessEnabled({
   const donePhase = phase.kind === "done" ? phase : null;
   const connectedWalletLabel = isGoogleConnected ? "zkLogin" : "Sui wallet";
   const connectedWalletMessage = isGoogleConnected
-    ? "zkLogin アドレスを確認できました。投稿の署名に使うのはこの住所です。"
-    : "Sui wallet アドレスを確認できました。Sponsored Tx の署名に使うのはこの住所です。";
+    ? "zkLogin address confirmed. This address signs the submission."
+    : "Sui wallet address confirmed. This address signs the sponsored transaction.";
 
   return (
     <section className="grid gap-4 border border-[var(--rule)] bg-[rgba(245,239,227,0.03)] p-5">
@@ -500,7 +502,7 @@ function ParticipationAccessEnabled({
               </label>
 
               <label className="grid gap-2 font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
-                <span>写真を選択</span>
+                <span>Choose photo</span>
                 <input
                   accept="image/*"
                   className="op-file-input block w-full font-mono-op text-[11px] text-[var(--ink)]"
@@ -522,14 +524,14 @@ function ParticipationAccessEnabled({
               className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]"
               role="status"
             >
-              処理中…
+              Processing...
             </p>
           ) : null}
 
           {previewPhoto ? (
             // biome-ignore lint: client-side object URL preview, next/image not applicable.
             <img
-              alt="投稿プレビュー"
+              alt="Submission preview"
               className="max-w-full border border-[var(--rule-strong)]"
               src={previewPhoto.previewUrl}
             />
@@ -540,7 +542,7 @@ function ParticipationAccessEnabled({
               className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ember)]"
               role="status"
             >
-              Walrus に保存しています…
+              Saving to Walrus...
             </p>
           ) : null}
 
@@ -549,7 +551,7 @@ function ParticipationAccessEnabled({
               className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ember)]"
               role="status"
             >
-              オンチェーンに投稿しています…
+              Submitting on-chain...
             </p>
           ) : null}
 
@@ -558,7 +560,7 @@ function ParticipationAccessEnabled({
               className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]"
               role="status"
             >
-              投稿結果を確認しています。しばらくお待ちください。
+              Checking the submission result. Please wait.
             </p>
           ) : null}
 
@@ -574,7 +576,7 @@ function ParticipationAccessEnabled({
                 }}
                 type="button"
               >
-                投稿を確定
+                Confirm submission
               </button>
             </div>
           ) : null}
@@ -585,16 +587,16 @@ function ParticipationAccessEnabled({
               role="status"
             >
               <p className="font-display text-[20px] tracking-[0.02em] text-[var(--ok)]">
-                投稿が完了しました。
+                Submission complete.
               </p>
               <p className="text-sm text-[var(--ink-dim)]">
-                この Unit ページで reveal と finalize
-                の状況を見ながら、履歴ギャラリーでも参加記録を確認できます。
+                You can watch the reveal and finalize status on this Unit page,
+                and review your participation record in the history gallery.
               </p>
 
               {/* biome-ignore lint: local object URL preview, next/image N/A. */}
               <img
-                alt="投稿プレビュー"
+                alt="Submission preview"
                 className="max-w-full border border-[var(--rule-strong)]"
                 src={donePhase.photo.previewUrl}
               />
@@ -602,7 +604,7 @@ function ParticipationAccessEnabled({
               <dl className="grid gap-3">
                 <div className="grid gap-0.5">
                   <dt className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
-                    送信アドレス
+                    Sender address
                   </dt>
                   <dd className="font-mono-op text-[11px] break-all text-[var(--ember)]">
                     {donePhase.result.sender}
@@ -616,7 +618,7 @@ function ParticipationAccessEnabled({
                   <dd className="font-display text-[22px] tracking-[0.02em]">
                     {ownedKakera.kakera
                       ? `#${ownedKakera.kakera.submissionNo}`
-                      : "確認中…"}
+                      : "Checking..."}
                   </dd>
                 </div>
 
@@ -639,10 +641,10 @@ function ParticipationAccessEnabled({
 
               <div className="flex flex-wrap gap-3">
                 <Link className="op-btn-primary" href={`/units/${unitId}`}>
-                  完成状況を確認
+                  View completion status
                 </Link>
                 <Link className="op-btn-primary" href="/gallery">
-                  履歴ギャラリーを見る
+                  View history gallery
                 </Link>
               </div>
             </div>
@@ -654,7 +656,7 @@ function ParticipationAccessEnabled({
               onClick={() => disconnectWallet.mutate()}
               type="button"
             >
-              {connectedWalletLabel} を解除する
+              Disconnect {connectedWalletLabel}
             </button>
           </div>
         </>
@@ -663,8 +665,8 @@ function ParticipationAccessEnabled({
       ) : (
         <>
           <p className="text-sm text-[var(--ink-dim)]">
-            Google zkLogin または Sui wallet
-            を接続すると、この待機室から投稿できます。
+            Connect Google zkLogin or Sui wallet to submit from this waiting
+            room.
           </p>
           <div className="flex flex-wrap gap-3">
             <button
@@ -676,9 +678,9 @@ function ParticipationAccessEnabled({
               type="button"
             >
               {isConnecting
-                ? "Google zkLogin 接続中…"
+                ? "Connecting Google zkLogin..."
                 : connectError
-                  ? "Google zkLogin をやり直す"
+                  ? "Retry Google zkLogin"
                   : "Google zkLogin"}
             </button>
             <SuiWalletConnectModal
@@ -726,7 +728,7 @@ function ParticipationAccessEnabled({
             }}
             type="button"
           >
-            もう一度送信する
+            Submit again
           </button>
         </div>
       ) : null}
@@ -737,7 +739,7 @@ function ParticipationAccessEnabled({
 function FullUnitMessage(): React.ReactElement {
   return (
     <p className="text-sm text-[var(--ink-dim)]">
-      この Unit は満枠です。新しい投稿は受け付けていません。
+      This Unit is full. New submissions are closed.
     </p>
   );
 }
@@ -747,7 +749,7 @@ function toMessage(error: unknown): string {
     return error.message;
   }
 
-  return "処理に失敗しました。時間をおいて、もう一度お試しください。";
+  return "Processing failed. Please wait a moment and try again.";
 }
 
 /**
@@ -816,11 +818,11 @@ function describeKakeraStatus(
 ): string {
   switch (status) {
     case "found":
-      return "Kakera を受け取りました。";
+      return "Kakera received.";
     case "timeout":
-      return "Kakera を確認できませんでした（タイムアウト）。時間を置いてから再読み込みしてください。";
+      return "Could not confirm Kakera before the timeout. Please wait and reload.";
     case "searching":
-      return "Kakera を確認しています…";
+      return "Checking Kakera...";
     default:
       return "";
   }

--- a/apps/web/src/lib/admin/api.ts
+++ b/apps/web/src/lib/admin/api.ts
@@ -45,7 +45,7 @@ export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
     throw new AdminApiError(
       400,
       "invalid_args",
-      "`displayMaxSlots` は `maxSlots` 以上で送ってください。",
+      "`displayMaxSlots` must be greater than or equal to `maxSlots`.",
     );
   }
 
@@ -103,7 +103,7 @@ function asRecord(value: unknown): Record<string, unknown> {
   throw new AdminApiError(
     400,
     "invalid_args",
-    "送信内容の形式が正しくありません。",
+    "The submitted payload format is invalid.",
   );
 }
 
@@ -120,7 +120,7 @@ function assertExactKeys(
     throw new AdminApiError(
       400,
       "invalid_args",
-      `\`${expected.join("`, `")}\` だけを送ってください。`,
+      `\`${expected.join("`, `")}\` only.`,
     );
   }
 }
@@ -131,7 +131,7 @@ function parseBlobId(value: unknown): string {
     throw new AdminApiError(
       400,
       "invalid_args",
-      "`blobId` は空でない文字列で送ってください。",
+      "`blobId` must be a non-empty string.",
     );
   }
   return blobId;
@@ -143,7 +143,7 @@ function parseNonEmptyTrimmedString(value: unknown, fieldName: string): string {
     throw new AdminApiError(
       400,
       "invalid_args",
-      `\`${fieldName}\` は空でない文字列で送ってください。`,
+      `\`${fieldName}\` must be a non-empty string.`,
     );
   }
   return parsed;
@@ -161,7 +161,7 @@ function parseNonNegativeInteger(value: unknown, fieldName: string): number {
     throw new AdminApiError(
       400,
       "invalid_args",
-      `\`${fieldName}\` は 0 以上の整数で送ってください。`,
+      `\`${fieldName}\` must be an integer greater than or equal to 0.`,
     );
   }
 
@@ -175,7 +175,7 @@ function parsePositiveInteger(value: unknown, fieldName: string): number {
     throw new AdminApiError(
       400,
       "invalid_args",
-      `\`${fieldName}\` は 1 以上の整数で送ってください。`,
+      `\`${fieldName}\` must be an integer greater than or equal to 1.`,
     );
   }
 

--- a/apps/web/src/lib/enoki/client-submit.ts
+++ b/apps/web/src/lib/enoki/client-submit.ts
@@ -84,7 +84,7 @@ export async function submitPhotoWithEnoki(
     throw new EnokiSubmitClientError(
       401,
       "auth_expired",
-      "ログインが切れました。Google でもう一度ログインしてください。",
+      "Your login expired. Please sign in with Google again.",
     );
   }
 
@@ -232,7 +232,7 @@ function toClientError(
   return new EnokiSubmitClientError(
     status,
     "sponsor_failed",
-    "投稿の準備に失敗しました。時間をおいて、もう一度お試しください。",
+    "Could not prepare the submission. Please wait a moment and try again.",
   );
 }
 
@@ -275,7 +275,7 @@ function toExecuteSubmitError(
   return new EnokiSubmitClientError(
     502,
     "sponsor_failed",
-    "投稿結果を確認しています。時間をおいて、もう一度ご確認ください。",
+    "Checking the submission result. Please wait a moment and check again.",
     {
       submissionStatus: "recovering",
       recovery,

--- a/apps/web/src/lib/enoki/submit-photo.ts
+++ b/apps/web/src/lib/enoki/submit-photo.ts
@@ -70,7 +70,7 @@ type ExecuteDeps = {
 
 export function parseSubmitPhotoInput(input: unknown): SubmitPhotoInput {
   if (!isRecord(input)) {
-    throw invalidArgs("送信内容の形式が正しくありません。");
+    throw invalidArgs("The submitted payload format is invalid.");
   }
 
   const keys = Object.keys(input);
@@ -82,7 +82,7 @@ export function parseSubmitPhotoInput(input: unknown): SubmitPhotoInput {
     keys.some((key) => key !== "unitId" && key !== "blobId" && key !== "sender")
   ) {
     throw invalidArgs(
-      "`unitId` と `blobId`、必要なら `sender` だけを送ってください。",
+      "Send only `unitId`, `blobId`, and `sender` when needed.",
     );
   }
 
@@ -90,11 +90,11 @@ export function parseSubmitPhotoInput(input: unknown): SubmitPhotoInput {
   const blobId = typeof input.blobId === "string" ? input.blobId.trim() : "";
 
   if (!isValidSuiObjectId(unitId)) {
-    throw invalidArgs("`unitId` の形式が不正です。");
+    throw invalidArgs("`unitId` has an invalid format.");
   }
 
   if (!WALRUS_BLOB_ID_PATTERN.test(blobId)) {
-    throw invalidArgs("`blobId` の形式が不正です。");
+    throw invalidArgs("`blobId` has an invalid format.");
   }
 
   const sender =
@@ -118,7 +118,7 @@ export function parseExecuteSponsoredInput(
   input: unknown,
 ): ExecuteSponsoredInput {
   if (!isRecord(input)) {
-    throw invalidArgs("送信内容の形式が正しくありません。");
+    throw invalidArgs("The submitted payload format is invalid.");
   }
 
   const keys = Object.keys(input);
@@ -132,7 +132,7 @@ export function parseExecuteSponsoredInput(
     )
   ) {
     throw invalidArgs(
-      "`digest` と `signature`、必要なら `sender` だけを送ってください。",
+      "Send only `digest`, `signature`, and `sender` when needed.",
     );
   }
 
@@ -141,7 +141,7 @@ export function parseExecuteSponsoredInput(
     typeof input.signature === "string" ? input.signature.trim() : "";
 
   if (digest.length === 0 || signature.length === 0) {
-    throw invalidArgs("`digest` と `signature` は必須です。");
+    throw invalidArgs("`digest` and `signature` are required.");
   }
 
   const sender =
@@ -168,7 +168,7 @@ export function readZkLoginJwt(headers: Headers): string {
     throw new EnokiApiError(
       401,
       "auth_expired",
-      "ログインが切れました。Google でもう一度ログインしてください。",
+      "Your login expired. Please sign in with Google again.",
     );
   }
 
@@ -196,7 +196,7 @@ export function resolveRuntimeEnv(
       throw new EnokiApiError(
         503,
         "submit_unavailable",
-        "投稿用の設定がまだ揃っていません。",
+        "Submission configuration is not complete yet.",
       );
     }
 
@@ -222,7 +222,7 @@ export async function sponsorSubmitPhoto(
       throw new EnokiApiError(
         401,
         "auth_expired",
-        "ログイン情報を確認できません。もう一度お試しください。",
+        "Could not verify login information. Please try again.",
       );
     }
     const transactionKindBytes = await deps.buildTransactionKind({
@@ -321,7 +321,7 @@ function toEnokiNetwork(network: SuiNetwork): EnokiNetwork {
     throw new EnokiApiError(
       503,
       "submit_unavailable",
-      "Enoki は localnet をサポートしていません。",
+      "Enoki does not support localnet.",
     );
   }
 
@@ -338,14 +338,14 @@ function mapEnokiError(error: unknown): EnokiApiError {
       return new EnokiApiError(
         401,
         "auth_expired",
-        "ログインが切れました。Google でもう一度ログインしてください。",
+        "Your login expired. Please sign in with Google again.",
       );
     }
 
     return new EnokiApiError(
       502,
       "sponsor_failed",
-      "スポンサー処理に失敗しました。時間をおいて、もう一度お試しください。",
+      "Sponsorship failed. Please wait a moment and try again.",
     );
   }
 
@@ -356,7 +356,7 @@ function mapEnokiError(error: unknown): EnokiApiError {
   return new EnokiApiError(
     502,
     "sponsor_failed",
-    "スポンサー処理に失敗しました。時間をおいて、もう一度お試しください。",
+    "Sponsorship failed. Please wait a moment and try again.",
   );
 }
 

--- a/apps/web/src/lib/finalize/api.ts
+++ b/apps/web/src/lib/finalize/api.ts
@@ -25,17 +25,17 @@ export class FinalizeApiError extends Error {
 
 export function parseFinalizeInput(input: unknown): FinalizeRouteInput {
   if (!isRecord(input)) {
-    throw invalidArgs("送信内容の形式が正しくありません。");
+    throw invalidArgs("The submitted payload format is invalid.");
   }
 
   const keys = Object.keys(input);
   if (keys.length !== 1 || !keys.includes("unitId")) {
-    throw invalidArgs("`unitId` だけを送ってください。");
+    throw invalidArgs("`unitId` only.");
   }
 
   const unitId = typeof input.unitId === "string" ? input.unitId.trim() : "";
   if (!isValidSuiObjectId(unitId)) {
-    throw invalidArgs("`unitId` の形式が不正です。");
+    throw invalidArgs("`unitId` has an invalid format.");
   }
 
   return { unitId };

--- a/apps/web/src/lib/finalize/dispatch.ts
+++ b/apps/web/src/lib/finalize/dispatch.ts
@@ -88,7 +88,7 @@ export function createFinalizeDispatcher(
       throw new FinalizeApiError(
         503,
         "finalize_unavailable",
-        "外部 generator の共有 secret が未設定です。`OP_FINALIZE_DISPATCH_SECRET` を設定してください。",
+        "The external generator shared secret is not configured. Set `OP_FINALIZE_DISPATCH_SECRET`.",
       );
     }
 

--- a/apps/web/src/lib/generator-runtime.test.ts
+++ b/apps/web/src/lib/generator-runtime.test.ts
@@ -94,7 +94,7 @@ describe("resolveGeneratorRuntime", () => {
       }),
     ).toEqual({
       message:
-        "`OP_GENERATOR_BASE_URL` と `OP_FINALIZE_DISPATCH_URL` の値が一致していません。",
+        "`OP_GENERATOR_BASE_URL` and `OP_FINALIZE_DISPATCH_URL` must match.",
       source: "none",
       status: "misconfigured",
       url: null,

--- a/apps/web/src/lib/generator-runtime.ts
+++ b/apps/web/src/lib/generator-runtime.ts
@@ -292,7 +292,7 @@ function resolveLegacyRuntimeUrl(
   ) {
     return {
       message:
-        "`OP_GENERATOR_BASE_URL` と `OP_FINALIZE_DISPATCH_URL` の値が一致していません。",
+        "`OP_GENERATOR_BASE_URL` and `OP_FINALIZE_DISPATCH_URL` must match.",
       source: "none",
       status: "misconfigured",
       url: null,

--- a/apps/web/src/lib/image/preprocess.ts
+++ b/apps/web/src/lib/image/preprocess.ts
@@ -4,15 +4,15 @@
  * Client-side photo preprocessing for Walrus uploads.
  *
  * Spec (see `docs/tech.md` §5.3 / §6):
- * - 入力は 10MB 上限でサイズ検証
- * - 長辺 1024px へリサイズ（縮小のみ、拡大しない）
- * - JPEG 品質 0.85 で再エンコード（EXIF は再エンコードで除去される）
- * - 再エンコード後の Blob から SHA-256 を算出
- * - UI が貼れるプレビュー URL を返す
+ * - Validate the 10MB input size limit.
+ * - Resize the long edge to 1024px, only downscaling.
+ * - Re-encode as JPEG quality 0.85, stripping EXIF through re-encoding.
+ * - Compute SHA-256 from the re-encoded Blob.
+ * - Return a preview URL that the UI can render.
  *
- * ブラウザ API（`createImageBitmap` / `OffscreenCanvas` / `crypto.subtle` /
- * `URL.createObjectURL`）は DI で差し替え可能にして、テスト環境（happy-dom /
- * jsdom）でもロジックを検証できるようにしている。
+ * Browser APIs (`createImageBitmap` / `OffscreenCanvas` / `crypto.subtle` /
+ * `URL.createObjectURL`) are injectable so happy-dom / jsdom tests can verify
+ * the logic without real browser implementations.
  */
 
 const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
@@ -83,7 +83,7 @@ export type PreprocessDeps = {
 /**
  * Preprocess an uploaded photo for Walrus ingestion.
  *
- * Throws {@link ImagePreprocessError} with a UI-friendly Japanese message when
+ * Throws {@link ImagePreprocessError} with a UI-friendly message when
  * validation / decoding / encoding fails.
  */
 export async function preprocessPhoto(
@@ -93,7 +93,7 @@ export async function preprocessPhoto(
   if (file.size > MAX_PHOTO_BYTES) {
     throw new ImagePreprocessError(
       "file_too_large",
-      "写真のサイズが上限（10MB）を超えています。別の写真を選び直してください。",
+      "The photo exceeds the 10MB size limit. Please choose another photo.",
     );
   }
 
@@ -129,7 +129,7 @@ async function decode(file: File, deps: PreprocessDeps): Promise<BitmapLike> {
   if (!decoder) {
     throw new ImagePreprocessError(
       "canvas_unavailable",
-      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+      "This browser does not support photo preprocessing. Please try another environment.",
     );
   }
 
@@ -138,7 +138,7 @@ async function decode(file: File, deps: PreprocessDeps): Promise<BitmapLike> {
   } catch {
     throw new ImagePreprocessError(
       "decode_failed",
-      "写真を読み込めませんでした。別の写真で試してみてください。",
+      "Could not load the photo. Please try another photo.",
     );
   }
 }
@@ -154,7 +154,7 @@ async function reencode(
   if (!canvasFactory) {
     throw new ImagePreprocessError(
       "canvas_unavailable",
-      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+      "This browser does not support photo preprocessing. Please try another environment.",
     );
   }
 
@@ -164,7 +164,7 @@ async function reencode(
   if (!context) {
     throw new ImagePreprocessError(
       "canvas_unavailable",
-      "このブラウザでは写真の前処理がサポートされていません。別の環境でお試しください。",
+      "This browser does not support photo preprocessing. Please try another environment.",
     );
   }
 
@@ -178,7 +178,7 @@ async function reencode(
   } catch {
     throw new ImagePreprocessError(
       "encode_failed",
-      "写真の変換に失敗しました。もう一度お試しください。",
+      "Could not convert the photo. Please try again.",
     );
   }
 }
@@ -189,7 +189,7 @@ async function sha256Hex(blob: Blob, deps: PreprocessDeps): Promise<string> {
   if (!digestFn) {
     throw new ImagePreprocessError(
       "digest_unavailable",
-      "このブラウザでは写真のハッシュ計算がサポートされていません。別の環境でお試しください。",
+      "This browser does not support photo hashing. Please try another environment.",
     );
   }
 
@@ -204,7 +204,7 @@ function makePreviewUrl(blob: Blob, deps: PreprocessDeps): string {
   if (!create) {
     throw new ImagePreprocessError(
       "canvas_unavailable",
-      "このブラウザでは写真のプレビュー表示がサポートされていません。別の環境でお試しください。",
+      "This browser does not support photo previews. Please try another environment.",
     );
   }
 

--- a/apps/web/src/lib/sui/types.ts
+++ b/apps/web/src/lib/sui/types.ts
@@ -32,8 +32,9 @@ export type UnitStatus = "pending" | "filled" | "finalized";
  * View model returned to consumers (screens, route loaders, hooks).
  *
  * Field semantics:
- *   - `submittedCount`: UI に見せる進捗件数。demo unit では prefilled 分を含む。
- *   - `maxSlots`: UI に見せる総数。`display_max_slots` を優先する。
+ *   - `submittedCount`: Progress count shown in the UI, including prefilled
+ *     slots for demo units.
+ *   - `maxSlots`: Total count shown in the UI, preferring `display_max_slots`.
  *   - `masterId`: `null` until the unit reaches `finalized`.
  */
 export type AthleteProgressView = {

--- a/apps/web/src/lib/walrus/put-target.ts
+++ b/apps/web/src/lib/walrus/put-target.ts
@@ -23,7 +23,7 @@ export async function putTargetBlobToWalrus(
   if (!fetchFn) {
     throw new WalrusPutError(
       "config_missing",
-      "このブラウザでは Walrus へのアップロードがサポートされていません。",
+      "This browser does not support uploads to Walrus.",
     );
   }
 
@@ -56,7 +56,7 @@ export async function putTargetBlobToWalrus(
       if (!isTransientStatus(response.status)) {
         throw new WalrusPutError(
           "final",
-          "Walrus への画像の保存に失敗しました。もう一度お試しください。",
+          "Could not save the image to Walrus. Please try again.",
           { attempts: attempt, cause: lastError, status: response.status },
         );
       }
@@ -83,7 +83,7 @@ export async function putTargetBlobToWalrus(
 
   throw new WalrusPutError(
     "final",
-    "Walrus への画像の保存に失敗しました。通信状況を確認してから再試行してください。",
+    "Could not save the image to Walrus. Check your connection and try again.",
     {
       attempts: WALRUS_MAX_ATTEMPTS,
       cause: lastError,
@@ -102,7 +102,7 @@ function resolveEndpoints(env: WalrusEnv): {
   if (!publisher || !aggregator) {
     throw new WalrusPutError(
       "config_missing",
-      "Walrus のエンドポイントが設定されていません。NEXT_PUBLIC_WALRUS_PUBLISHER / NEXT_PUBLIC_WALRUS_AGGREGATOR を確認してください。",
+      "Walrus endpoints are not configured. Check NEXT_PUBLIC_WALRUS_PUBLISHER / NEXT_PUBLIC_WALRUS_AGGREGATOR.",
     );
   }
 
@@ -119,18 +119,16 @@ async function extractBlobId(response: Response): Promise<string> {
   } catch (error) {
     throw new WalrusPutError(
       "final",
-      "Walrus からの応答を解釈できませんでした。",
+      "Could not parse the response from Walrus.",
       { cause: error },
     );
   }
 
   const blobId = readBlobId(payload);
   if (!blobId) {
-    throw new WalrusPutError(
-      "final",
-      "Walrus から blob_id を取得できませんでした。",
-      { cause: payload },
-    );
+    throw new WalrusPutError("final", "Could not get blob_id from Walrus.", {
+      cause: payload,
+    });
   }
 
   return blobId;

--- a/apps/web/src/lib/walrus/put.ts
+++ b/apps/web/src/lib/walrus/put.ts
@@ -6,19 +6,19 @@ import type { PreprocessedPhoto } from "../image/preprocess";
  * Thin client for uploading a preprocessed photo to a Walrus Publisher.
  *
  * Spec (see `docs/tech.md` §5.3 / §6 / §10):
- * - ブラウザから Walrus Publisher へ直接 `PUT /v1/blobs?epochs=5` で送る。
- * - 一時的な失敗（ネットワーク / 5xx / タイムアウト）は指数バックオフで
- *   合計 3 回まで再試行。
- * - 最終的な失敗は UI が再試行ボタンを出せるよう分類済みのエラーで投げる。
- * - 成功時は `blob_id` と Aggregator 参照 URL を返す。
+ * - Send `PUT /v1/blobs?epochs=5` directly from the browser to Walrus Publisher.
+ * - Retry temporary failures (network / 5xx / timeout) up to 3 total attempts
+ *   with exponential backoff.
+ * - Throw classified errors for final failures so the UI can show retry.
+ * - Return `blob_id` and an Aggregator reference URL on success.
  *
- * 入力は {@link PreprocessedPhoto} に絞っており、10MB 検証・長辺 1024px・
- * JPEG 再エンコード・EXIF 除去を通過した Blob のみが PUT される。原画像が
- * そのまま Walrus に載らないよう型レベルで守る。
+ * Input is restricted to {@link PreprocessedPhoto}, so only Blobs that passed
+ * 10MB validation, 1024px long-edge resizing, JPEG re-encoding, and EXIF
+ * stripping can be PUT. The type boundary prevents raw originals from being
+ * uploaded to Walrus.
  *
- * `fetch` と `setTimeout` は DI で差し替え可能にしている。テストは実時計や実
- * ネットワークに依存せず、リトライ回数・URL 組み立て・エラー分類だけを検証
- * する。
+ * `fetch` and `setTimeout` are injectable, so tests can verify retry counts,
+ * URL construction, and error classification without real clocks or network.
  */
 
 const WALRUS_EPOCHS = 5;
@@ -98,7 +98,7 @@ export async function putBlobToWalrus(
   if (!fetchFn) {
     throw new WalrusPutError(
       "config_missing",
-      "このブラウザでは Walrus へのアップロードがサポートされていません。",
+      "This browser does not support uploads to Walrus.",
     );
   }
 
@@ -128,21 +128,21 @@ export async function putBlobToWalrus(
       lastStatus = response.status;
       lastError = new Error(`Walrus PUT failed with status ${response.status}`);
 
-      // 4xx は再試行しても結果が変わらない。即 final で抜ける。
+      // 4xx responses will not change with retries, so fail as final.
       if (!isTransientStatus(response.status)) {
         throw new WalrusPutError(
           "final",
-          "Walrus への写真の保存に失敗しました。もう一度お試しください。",
+          "Could not save the photo to Walrus. Please try again.",
           { attempts: attempt, status: response.status, cause: lastError },
         );
       }
     } catch (error) {
-      // 既に final 分類を付けて投げた場合はそのまま上げる。
+      // Preserve already-classified final errors.
       if (error instanceof WalrusPutError) {
         throw error;
       }
-      // AbortError（タイムアウトで自発的に中断）は一時失敗として扱う。
-      // fetch がハングしたまま永遠に待つのを防ぐ。
+      // Treat AbortError from our timeout as temporary so fetch cannot hang
+      // forever.
       lastError = error;
     }
 
@@ -163,7 +163,7 @@ export async function putBlobToWalrus(
 
   throw new WalrusPutError(
     "final",
-    "Walrus への写真の保存に失敗しました。通信状況を確認してから、再試行ボタンでもう一度お試しください。",
+    "Could not save the photo to Walrus. Check your connection, then use the retry button to try again.",
     {
       attempts: WALRUS_MAX_ATTEMPTS,
       status: lastStatus,
@@ -182,7 +182,7 @@ function resolveEndpoints(env: WalrusEnv): {
   if (!publisher || !aggregator) {
     throw new WalrusPutError(
       "config_missing",
-      "Walrus のエンドポイントが設定されていません。NEXT_PUBLIC_WALRUS_PUBLISHER / NEXT_PUBLIC_WALRUS_AGGREGATOR を確認してください。",
+      "Walrus endpoints are not configured. Check NEXT_PUBLIC_WALRUS_PUBLISHER / NEXT_PUBLIC_WALRUS_AGGREGATOR.",
     );
   }
 
@@ -203,18 +203,16 @@ async function extractBlobId(response: Response): Promise<string> {
   } catch (error) {
     throw new WalrusPutError(
       "final",
-      "Walrus からの応答を解釈できませんでした。",
+      "Could not parse the response from Walrus.",
       { cause: error },
     );
   }
 
   const blobId = readBlobId(payload);
   if (!blobId) {
-    throw new WalrusPutError(
-      "final",
-      "Walrus から blob_id を取得できませんでした。",
-      { cause: payload },
-    );
+    throw new WalrusPutError("final", "Could not get blob_id from Walrus.", {
+      cause: payload,
+    });
   }
   return blobId;
 }
@@ -250,7 +248,7 @@ function readBlobId(payload: unknown): string | null {
 }
 
 function isTransientStatus(status: number): boolean {
-  // 408 Request Timeout と 429 Too Many Requests は一時障害として扱う。
+  // Treat 408 Request Timeout and 429 Too Many Requests as temporary failures.
   if (status === 408 || status === 429) {
     return true;
   }
@@ -259,7 +257,7 @@ function isTransientStatus(status: number): boolean {
 
 function backoffDelayMs(attempt: number): number {
   // attempt = 1 → base * 2^0, attempt = 2 → base * 2^1, ...
-  // 指数的に増える。ハッカソンスコープなので jitter は省略する。
+  // Exponential backoff. Jitter is omitted for this hackathon scope.
   return WALRUS_BASE_BACKOFF_MS * 2 ** (attempt - 1);
 }
 

--- a/apps/web/tests/e2e/gallery-states.spec.ts
+++ b/apps/web/tests/e2e/gallery-states.spec.ts
@@ -9,7 +9,7 @@ test.describe("gallery states", () => {
 
     await page.goto("/gallery");
 
-    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(page.getByText("Empty", { exact: true })).toBeVisible();
     await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Check again" }),
@@ -109,7 +109,7 @@ test.describe("gallery states", () => {
 
     await page.getByRole("button", { name: "Check again" }).click();
 
-    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(page.getByText("Empty", { exact: true })).toBeVisible();
     await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/gallery-states.spec.ts
+++ b/apps/web/tests/e2e/gallery-states.spec.ts
@@ -10,11 +10,9 @@ test.describe("gallery states", () => {
     await page.goto("/gallery");
 
     await expect(page.getByText("Empty")).toBeVisible();
+    await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
     await expect(
-      page.getByText(/まだ Kakera が見つかりません。/),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "もう一度確認する" }),
+      page.getByRole("button", { name: "Check again" }),
     ).toBeVisible();
   });
 
@@ -63,7 +61,7 @@ test.describe("gallery states", () => {
     await page.goto("/gallery");
 
     const unitLink = page.getByRole("link", {
-      name: /unit ページで位置を見る/i,
+      name: /View position on Unit page/i,
     });
 
     await expect(unitLink).toHaveAttribute(
@@ -107,14 +105,12 @@ test.describe("gallery states", () => {
     await page.goto("/gallery");
 
     await expect(page.getByText("Unavailable")).toBeVisible();
-    await expect(page.getByText(/履歴を読み込めませんでした。/)).toBeVisible();
+    await expect(page.getByText(/Could not load history./)).toBeVisible();
 
-    await page.getByRole("button", { name: "もう一度確認する" }).click();
+    await page.getByRole("button", { name: "Check again" }).click();
 
     await expect(page.getByText("Empty")).toBeVisible();
-    await expect(
-      page.getByText(/まだ Kakera が見つかりません。/),
-    ).toBeVisible();
+    await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
   });
 
   test("shows the config-missing gallery shell from the request selector", async ({
@@ -125,9 +121,11 @@ test.describe("gallery states", () => {
     await page.goto("/gallery?op_e2e_gallery_state=config-missing");
 
     await expect(page.getByText("Unavailable")).toBeVisible();
-    await expect(page.getByText(/公開設定を確認できません。/)).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "もう一度確認する" }),
-    ).toHaveCount(0);
+      page.getByText(/Could not verify public configuration./),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Check again" })).toHaveCount(
+      0,
+    );
   });
 });

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -103,7 +103,7 @@ test.describe("home smoke", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        /Waiting|No active unit|on-chain progress is not available/i,
+        /Waiting \/ No active unit|on-chain progress is not available/i,
       ),
     ).toBeVisible();
 

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -54,7 +54,7 @@ test.describe("home smoke", () => {
 
     await expect(
       page.getByText(
-        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
+        /Connect Google zkLogin or Sui wallet to load your Kakera history./,
       ),
     ).toBeVisible();
     await expect(
@@ -103,7 +103,7 @@ test.describe("home smoke", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        /待機中|No active unit|on-chain progress is not available/i,
+        /Waiting|No active unit|on-chain progress is not available/i,
       ),
     ).toBeVisible();
 

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -152,7 +152,7 @@ test.describe("readiness regression", () => {
       `/?op_e2e_home_card_state=${DEMO_UNIT_ID}:waiting,${DEMO_SECOND_UNIT_ID}:unavailable`,
     );
 
-    await expect(page.getByText(/Waiting|No active unit/i)).toBeVisible();
+    await expect(page.getByText(/Waiting \/ No active unit/i)).toBeVisible();
     await expect(
       page
         .getByText(/Progress temporarily unavailable|temporarily unavailable/i)
@@ -182,7 +182,7 @@ test.describe("readiness regression", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        /Waiting|No active unit|on-chain progress is not available/i,
+        /Waiting \/ No active unit|on-chain progress is not available/i,
       ),
     ).toBeVisible();
 

--- a/apps/web/tests/e2e/readiness-regression.spec.ts
+++ b/apps/web/tests/e2e/readiness-regression.spec.ts
@@ -17,9 +17,7 @@ const CONSENT_LABEL =
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
-  await expect(
-    page.getByText(/zkLogin アドレスを確認できました/),
-  ).toBeVisible();
+  await expect(page.getByText(/zkLogin address confirmed/)).toBeVisible();
 
   await page
     .getByRole("checkbox", {
@@ -33,8 +31,8 @@ async function submitPhoto(page: Page): Promise<void> {
     buffer: TINY_JPEG_BUFFER,
   });
 
-  await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
-  await page.getByRole("button", { name: "投稿を確定" }).click();
+  await expect(page.getByAltText("Submission preview").first()).toBeVisible();
+  await page.getByRole("button", { name: "Confirm submission" }).click();
 }
 
 test.describe("readiness regression", () => {
@@ -77,7 +75,7 @@ test.describe("readiness regression", () => {
 
     await expect(
       page.getByText(
-        /Google zkLogin または Sui wallet を接続すると、あなたの Kakera 履歴を読み込めます。/,
+        /Connect Google zkLogin or Sui wallet to load your Kakera history./,
       ),
     ).toBeVisible();
     await expect(
@@ -122,17 +120,17 @@ test.describe("readiness regression", () => {
     await installDefaultMocks(page);
     await submitPhoto(page);
 
-    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+    await expect(page.getByText("Submission complete.")).toBeVisible({
       timeout: 15_000,
     });
 
     const galleryLink = page.getByRole("link", {
-      name: "履歴ギャラリーを見る",
+      name: "View history gallery",
     });
     await expect(galleryLink).toBeVisible({ timeout: 15_000 });
     await expect(
       page.getByText(
-        /この Unit ページで reveal と finalize\s*の状況を見ながら、履歴ギャラリーでも参加記録を確認できます。/,
+        /You can watch the reveal and finalize\s*status on this Unit page, and review your participation record in the history gallery./,
       ),
     ).toBeVisible();
 
@@ -154,10 +152,10 @@ test.describe("readiness regression", () => {
       `/?op_e2e_home_card_state=${DEMO_UNIT_ID}:waiting,${DEMO_SECOND_UNIT_ID}:unavailable`,
     );
 
-    await expect(page.getByText(/待機中|No active unit/i)).toBeVisible();
+    await expect(page.getByText(/Waiting|No active unit/i)).toBeVisible();
     await expect(
       page
-        .getByText(/進捗を一時取得できません|temporarily unavailable/i)
+        .getByText(/Progress temporarily unavailable|temporarily unavailable/i)
         .first(),
     ).toBeVisible();
 
@@ -184,7 +182,7 @@ test.describe("readiness regression", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        /待機中|No active unit|on-chain progress is not available/i,
+        /Waiting|No active unit|on-chain progress is not available/i,
       ),
     ).toBeVisible();
 

--- a/apps/web/tests/e2e/submit-happy.spec.ts
+++ b/apps/web/tests/e2e/submit-happy.spec.ts
@@ -17,9 +17,7 @@ const CONSENT_LABEL =
 async function submitPhoto(page: Page): Promise<void> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
-  await expect(
-    page.getByText(/zkLogin アドレスを確認できました/),
-  ).toBeVisible();
+  await expect(page.getByText(/zkLogin address confirmed/)).toBeVisible();
 
   await page
     .getByRole("checkbox", {
@@ -33,9 +31,9 @@ async function submitPhoto(page: Page): Promise<void> {
     buffer: TINY_JPEG_BUFFER,
   });
 
-  await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
+  await expect(page.getByAltText("Submission preview").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "投稿を確定" }).click();
+  await page.getByRole("button", { name: "Confirm submission" }).click();
 }
 
 async function submitPhotoWithExpectedWallet(
@@ -58,9 +56,9 @@ async function submitPhotoWithExpectedWallet(
     buffer: TINY_JPEG_BUFFER,
   });
 
-  await expect(page.getByAltText("投稿プレビュー").first()).toBeVisible();
+  await expect(page.getByAltText("Submission preview").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "投稿を確定" }).click();
+  await page.getByRole("button", { name: "Confirm submission" }).click();
 }
 
 test.describe("submit happy path", () => {
@@ -70,11 +68,11 @@ test.describe("submit happy path", () => {
     await installDefaultMocks(page);
     await submitPhoto(page);
 
-    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+    await expect(page.getByText("Submission complete.")).toBeVisible({
       timeout: 15_000,
     });
 
-    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+    await expect(page.getByText("Kakera received.")).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.getByText("#1")).toBeVisible();
@@ -93,10 +91,10 @@ test.describe("submit happy path", () => {
     await submitPhoto(page);
 
     const unitStatusLink = page.getByRole("link", {
-      name: "完成状況を確認",
+      name: "View completion status",
     });
     const galleryLink = page.getByRole("link", {
-      name: "履歴ギャラリーを見る",
+      name: "View history gallery",
     });
     await expect(unitStatusLink).toBeVisible({ timeout: 15_000 });
     await expect(unitStatusLink).toHaveAttribute(
@@ -106,7 +104,7 @@ test.describe("submit happy path", () => {
     await expect(galleryLink).toBeVisible({ timeout: 15_000 });
     await expect(
       page.getByText(
-        "この Unit ページで reveal と finalize の状況を見ながら、履歴ギャラリーでも参加記録を確認できます。",
+        "You can watch the reveal and finalize status on this Unit page, and review your participation record in the history gallery.",
       ),
     ).toBeVisible();
 
@@ -130,11 +128,11 @@ test.describe("submit happy path", () => {
     });
     await submitPhoto(page);
 
-    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+    await expect(page.getByText("Submission complete.")).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.getByText(STUB_DIGEST)).toBeVisible();
-    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+    await expect(page.getByText("Kakera received.")).toBeVisible({
       timeout: 15_000,
     });
   });
@@ -149,11 +147,11 @@ test.describe("submit happy path", () => {
     });
     await submitPhoto(page);
 
-    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+    await expect(page.getByText("Submission complete.")).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.getByText(STUB_DIGEST)).toBeVisible();
-    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+    await expect(page.getByText("Kakera received.")).toBeVisible({
       timeout: 15_000,
     });
   });
@@ -170,18 +168,18 @@ test.describe("submit happy path", () => {
     await submitPhoto(page);
 
     await expect(
-      page.getByText("投稿結果を確認しています。しばらくお待ちください。"),
+      page.getByText("Checking the submission result. Please wait."),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "もう一度送信する" }),
+      page.getByRole("button", { name: "Submit again" }),
     ).toBeHidden();
     await expect(
-      page.getByText("投稿を完了できませんでした。もう一度送信してください。"),
+      page.getByText("Could not complete the submission. Please submit again."),
     ).toBeVisible({
       timeout: 15_000,
     });
     await expect(
-      page.getByRole("button", { name: "もう一度送信する" }),
+      page.getByRole("button", { name: "Submit again" }),
     ).toBeVisible();
   });
 
@@ -189,15 +187,12 @@ test.describe("submit happy path", () => {
     page,
   }) => {
     await installDefaultMocks(page, { autoConnectWalletKind: "sui" });
-    await submitPhotoWithExpectedWallet(
-      page,
-      /Sui wallet アドレスを確認できました/,
-    );
+    await submitPhotoWithExpectedWallet(page, /Sui wallet address confirmed/);
 
-    await expect(page.getByText("投稿が完了しました。")).toBeVisible({
+    await expect(page.getByText("Submission complete.")).toBeVisible({
       timeout: 15_000,
     });
-    await expect(page.getByText("Kakera を受け取りました。")).toBeVisible({
+    await expect(page.getByText("Kakera received.")).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.getByText("#1")).toBeVisible();

--- a/apps/web/tests/e2e/waiting-room-submit.spec.ts
+++ b/apps/web/tests/e2e/waiting-room-submit.spec.ts
@@ -13,9 +13,7 @@ const CONSENT_LABEL =
 async function prepareSubmission(page: Page): Promise<string> {
   await page.goto(`/units/${STUB_UNIT_ID}`);
 
-  await expect(
-    page.getByText(/zkLogin アドレスを確認できました/),
-  ).toBeVisible();
+  await expect(page.getByText(/zkLogin address confirmed/)).toBeVisible();
 
   await page
     .getByRole("checkbox", {
@@ -31,7 +29,7 @@ async function prepareSubmission(page: Page): Promise<string> {
     buffer: TINY_JPEG_BUFFER,
   });
 
-  const preview = page.getByAltText("投稿プレビュー").first();
+  const preview = page.getByAltText("Submission preview").first();
   await expect(preview).toBeVisible();
 
   const previewSrc = await preview.getAttribute("src");
@@ -39,7 +37,7 @@ async function prepareSubmission(page: Page): Promise<string> {
     throw new Error("expected preview image src");
   }
 
-  await page.getByRole("button", { name: "投稿を確定" }).click();
+  await page.getByRole("button", { name: "Confirm submission" }).click();
   return previewSrc;
 }
 
@@ -49,9 +47,7 @@ test.describe("waiting room submit guards", () => {
 
     await page.goto(`/units/${STUB_UNIT_ID}`);
 
-    await expect(
-      page.getByText(/zkLogin アドレスを確認できました/),
-    ).toBeVisible();
+    await expect(page.getByText(/zkLogin address confirmed/)).toBeVisible();
 
     const consent = page.getByRole("checkbox", { name: CONSENT_LABEL });
     const fileInput = page.locator('input[type="file"]');
@@ -71,16 +67,14 @@ test.describe("waiting room submit guards", () => {
 
     await page.goto(`/units/${STUB_UNIT_ID}`);
 
-    await expect(
-      page.getByText(/zkLogin アドレスを確認できました/),
-    ).toBeVisible();
+    await expect(page.getByText(/zkLogin address confirmed/)).toBeVisible();
     await page.getByRole("checkbox", { name: CONSENT_LABEL }).check();
 
     await expect(page.locator('input[type="file"]')).toBeEnabled();
-    await expect(page.getByRole("button", { name: "投稿を確定" })).toHaveCount(
-      0,
-    );
-    await expect(page.getByAltText("投稿プレビュー")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Confirm submission" }),
+    ).toHaveCount(0);
+    await expect(page.getByAltText("Submission preview")).toHaveCount(0);
 
     expect(state.sponsorRequests).toBe(0);
     expect(state.executeRequests).toBe(0);
@@ -99,26 +93,25 @@ test.describe("waiting room submit guards", () => {
     const previewSrc = await prepareSubmission(page);
 
     await expect(
-      page.getByText("投稿結果を確認しています。しばらくお待ちください。"),
+      page.getByText("Checking the submission result. Please wait."),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "もう一度送信する" }),
+      page.getByRole("button", { name: "Submit again" }),
     ).toBeHidden();
     await expect(
-      page.getByText("投稿を完了できませんでした。もう一度送信してください。"),
+      page.getByText("Could not complete the submission. Please submit again."),
     ).toBeVisible({
       timeout: 15_000,
     });
 
-    const retryButton = page.getByRole("button", { name: "もう一度送信する" });
+    const retryButton = page.getByRole("button", { name: "Submit again" });
     await expect(retryButton).toBeVisible();
 
     await retryButton.click();
 
-    await expect(page.getByAltText("投稿プレビュー").first()).toHaveAttribute(
-      "src",
-      previewSrc,
-    );
+    await expect(
+      page.getByAltText("Submission preview").first(),
+    ).toHaveAttribute("src", previewSrc);
     await expect.poll(() => state.executeRequests).toBe(2);
   });
 });

--- a/apps/web/tests/e2e/wallet-connect-regression.spec.ts
+++ b/apps/web/tests/e2e/wallet-connect-regression.spec.ts
@@ -44,8 +44,6 @@ test.describe("wallet connect regression", () => {
       .click();
 
     await expect(page.getByText("Empty")).toBeVisible();
-    await expect(
-      page.getByText(/まだ Kakera が見つかりません。/),
-    ).toBeVisible();
+    await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
   });
 });

--- a/apps/web/tests/e2e/wallet-connect-regression.spec.ts
+++ b/apps/web/tests/e2e/wallet-connect-regression.spec.ts
@@ -43,7 +43,7 @@ test.describe("wallet connect regression", () => {
       .getByRole("button", { name: "ONE Portrait E2E Sui Stub" })
       .click();
 
-    await expect(page.getByText("Empty")).toBeVisible();
+    await expect(page.getByText("Empty", { exact: true })).toBeVisible();
     await expect(page.getByText(/No Kakera found yet./)).toBeVisible();
   });
 });

--- a/apps/web/tests/live/admin-zero-upload-demo.spec.ts
+++ b/apps/web/tests/live/admin-zero-upload-demo.spec.ts
@@ -55,7 +55,7 @@ test("creates and finalizes a zero-upload demo unit from the live admin page", a
   await page.getByRole("radio", { name: /Demo/ }).check();
   await page.getByLabel("Demo real upload count").fill("0");
   await expect(
-    page.getByText(/Immediately after creating 0 photos/),
+    page.getByText(/Treat as filled immediately after creating 0 photos/),
   ).toBeVisible();
   await page.getByRole("button", { name: "Create unit" }).click();
 

--- a/apps/web/tests/live/admin-zero-upload-demo.spec.ts
+++ b/apps/web/tests/live/admin-zero-upload-demo.spec.ts
@@ -29,12 +29,12 @@ test("creates and finalizes a zero-upload demo unit from the live admin page", a
 
   await page.goto("/admin");
   await expect(
-    page.getByRole("heading", { name: "デモ管理コンソール" }),
+    page.getByRole("heading", { name: "Demo admin console" }),
   ).toBeVisible();
   await expect
     .poll(
       async () => {
-        await page.getByRole("button", { name: "状態を更新" }).click();
+        await page.getByRole("button", { name: "Refresh status" }).click();
         return await page.getByText("worker_kv").count();
       },
       { timeout: 60_000 },
@@ -43,28 +43,30 @@ test("creates and finalizes a zero-upload demo unit from the live admin page", a
 
   await page.getByLabel("displayName").fill(displayName);
   await page.getByLabel("thumbnail URL").fill(thumbnailUrl);
-  await page.getByLabel("対象画像").setInputFiles({
+  await page.getByLabel("Target image").setInputFiles({
     name: "target.jpg",
     mimeType: "image/jpeg",
     buffer: targetJpeg,
   });
-  await expect(page.getByText("対象画像をアップロードしました")).toBeVisible({
+  await expect(page.getByText("Target image uploaded")).toBeVisible({
     timeout: 60_000,
   });
 
-  await page.getByRole("radio", { name: /デモ/ }).check();
-  await page.getByLabel("デモ実アップロード枚数").fill("0");
-  await expect(page.getByText(/0 枚作成直後/)).toBeVisible();
-  await page.getByRole("button", { name: "ユニットを作成" }).click();
+  await page.getByRole("radio", { name: /Demo/ }).check();
+  await page.getByLabel("Demo real upload count").fill("0");
+  await expect(
+    page.getByText(/Immediately after creating 0 photos/),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Create unit" }).click();
 
-  const action = page.getByText(/ユニットID: 0x[0-9a-fA-F]+/);
+  const action = page.getByText(/Unit ID: 0x[0-9a-fA-F]+/);
   await expect(action).toBeVisible({ timeout: 120_000 });
   const unitId = extractUnitId((await action.textContent()) ?? "");
 
   await expect
     .poll(
       async () => {
-        await page.getByRole("button", { name: "状態を更新" }).click();
+        await page.getByRole("button", { name: "Refresh status" }).click();
         const unitCard = page.locator("article").filter({ hasText: unitId });
         return (await unitCard.count()) > 0
           ? await unitCard.first().textContent()
@@ -77,11 +79,11 @@ test("creates and finalizes a zero-upload demo unit from the live admin page", a
   const unitCard = page.locator("article").filter({ hasText: unitId }).first();
   await expect(unitCard).toContainText("2000 / 2000");
   await expect(unitCard).toContainText("0 / 0");
-  await unitCard.getByRole("button", { name: /finalize を再試行/ }).click();
-  await expect(page.getByText("finalize を再試行しました")).toBeVisible({
+  await unitCard.getByRole("button", { name: /Retry finalize/ }).click();
+  await expect(page.getByText("Finalize retried")).toBeVisible({
     timeout: 180_000,
   });
-  await expect(page.getByText(/ステータス: finalized/)).toBeVisible();
+  await expect(page.getByText(/Status: finalized/)).toBeVisible();
 
   await page.goto(
     `/units/${unitId}?athleteName=${encodeURIComponent(displayName)}`,


### PR DESCRIPTION
## 概要
web アプリ配下の UI コピー、ユーザー向けエラー、テスト期待値、スクリプトメッセージ、コメントを英語化しました。

## 変更内容
- `apps/web/src`
  - 参加導線、ギャラリー、ホーム、管理画面、Enoki/Walrus/finalize/generator 関連メッセージを英語化
- `apps/web/tests`
  - Vitest / Playwright / live E2E の期待値を英語文言に更新
- `apps/web/scripts`
  - generator runtime の設定エラー文言を英語化

## 関連する Issue やチケット
なし

## 動作確認
- `rg -n "[ぁ-んァ-ン一-龥ー]" apps/web/src apps/web/tests apps/web/scripts`
- `corepack pnpm --filter web exec vitest run src/app/units/[unitId]/participation-access.test.tsx src/app/gallery/gallery-client.test.tsx src/app/admin/admin-client.test.tsx src/app/page.test.tsx src/app/units/[unitId]/page.test.tsx`
- `corepack pnpm --filter web run typecheck`
- `corepack pnpm --filter web run lint`
- `corepack pnpm --filter web test`