### PR TITLE
fix: Kakera Display の固定画像URLを設定する

### DIFF
--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -43,6 +43,7 @@ fun kakera_display_fields(): vector<String> {
         string::utf8(b"name"),
         string::utf8(b"description"),
         string::utf8(b"image_url"),
+        string::utf8(b"thumbnail_url"),
         string::utf8(b"project_url"),
     ]
 }
@@ -51,7 +52,8 @@ fun kakera_display_values(): vector<String> {
     vector[
         string::utf8(b"ONE Portrait Kakera #{submission_no}"),
         string::utf8(b"Soulbound proof of participation in ONE Portrait."),
-        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/demo/demo_mozaiku.png"),
+        string::utf8(b"https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true"),
+        string::utf8(b"https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true"),
         string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/"),
     ]
 }

--- a/contracts/tests/registry_admin_tests.move
+++ b/contracts/tests/registry_admin_tests.move
@@ -28,7 +28,7 @@ fun init_creates_admin_cap_kakera_display_and_shared_registry() {
 
     assert_eq!(registry::unit_count_for_testing(&registry), 0);
     assert_eq!(display::version(&kakera_display), 1);
-    assert_eq!(vec_map::length(display::fields(&kakera_display)), 4);
+    assert_eq!(vec_map::length(display::fields(&kakera_display)), 5);
     assert_eq!(
         *vec_map::get(display::fields(&kakera_display), &string::utf8(b"name")),
         string::utf8(b"ONE Portrait Kakera #{submission_no}")
@@ -39,7 +39,11 @@ fun init_creates_admin_cap_kakera_display_and_shared_registry() {
     );
     assert_eq!(
         *vec_map::get(display::fields(&kakera_display), &string::utf8(b"image_url")),
-        string::utf8(b"https://one-portrait-web.bububutasan00.workers.dev/demo/demo_mozaiku.png")
+        string::utf8(b"https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true")
+    );
+    assert_eq!(
+        *vec_map::get(display::fields(&kakera_display), &string::utf8(b"thumbnail_url")),
+        string::utf8(b"https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true")
     );
     assert_eq!(
         *vec_map::get(display::fields(&kakera_display), &string::utf8(b"project_url")),

--- a/docs/kakera-display-runbook.md
+++ b/docs/kakera-display-runbook.md
@@ -1,0 +1,57 @@
+# Kakera Display 運用手順
+
+この手順は現在の Move package で新規 mint される `Kakera` の Display だけを対象にする。旧 package `0x8568...ffbf` で mint 済みの object は対象外。
+
+## 前提
+
+- `image_url` と `thumbnail_url` は固定で `https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true` を使う。
+- `name`、`description`、`project_url` は package の `registry.move` で定義した値を維持する。
+- Display 更新には Display object の owner 権限を持つ運用アドレスを使う。
+
+## Display object の確認
+
+1. 現在 package ID を `ops/deployments/testnet.json` などのデプロイ正本で確認する。
+2. Sui Explorer で package の objects を開き、型が `0x2::display::Display<PACKAGE_ID::kakera::Kakera>` の object を探す。
+3. CLI で確認する場合は Display object ID を指定して取得する。
+
+```bash
+sui client object <DISPLAY_OBJECT_ID> --json
+```
+
+`fields` に `name`、`description`、`image_url`、`thumbnail_url`、`project_url` があり、`version` が更新済みであることを確認する。
+
+## Kakera 表示の検証
+
+mint 済みの現在 package の Kakera object ID に対して、JSON-RPC の `sui_getObject` で `showDisplay: true` を指定する。
+
+```bash
+curl -s -X POST "$SUI_RPC_URL" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_getObject",
+    "params": [
+      "<KAKERA_OBJECT_ID>",
+      {
+        "showType": true,
+        "showContent": true,
+        "showDisplay": true
+      }
+    ]
+  }'
+```
+
+レスポンスの `data.display.data.image_url` と `data.display.data.thumbnail_url` が固定 URL になっていることを確認する。Explorer でも同じ Kakera object を開き、画像が表示されることを確認する。
+
+## 公開済み current-package Display の更新
+
+すでに公開済みの現在 package の Display object を更新する場合は、運用アドレスで Programmable Transaction Block を作る。同じ Display object に対して、既存 field は `sui::display::edit` で更新し、足りない field は `sui::display::add` で追加する。最後に `sui::display::update_version` を呼ぶ。
+
+更新する field:
+
+- `image_url` は `sui::display::edit` で更新する。
+- `thumbnail_url` は存在しなければ `sui::display::add` で追加する。
+- どちらの値も `https://github.com/UnagiLabs/one_portrait/blob/main/apps/web/src/app/icon.jpg?raw=true` にする。
+
+`name`、`description`、`project_url` は変更しない。PTB 実行後、Display object の `version` が増えていることを確認し、上記の `sui_getObject` + `showDisplay: true` で current-package Kakera の表示を再検証する。


### PR DESCRIPTION
## 概要
Kakera NFT の Display 画像を固定URLにします。

新しく mint される Kakera が、Explorer で画像付きに見えるようにします。

## 変更内容
- `contracts/sources/registry.move`
  - `Kakera` Display に `thumbnail_url` を追加
  - `image_url` と `thumbnail_url` を固定画像URLに変更
- `contracts/tests/registry_admin_tests.move`
  - Display field 数と固定画像URLの期待値を更新
- `docs/kakera-display-runbook.md`
  - Display object の確認手順を追加
  - `showDisplay: true` での検証手順を追加
  - 公開済み current-package Display の更新手順を追加

## 関連する Issue やチケット
Close #99

## 動作確認
- `sui move test --path contracts --test`
  - 17 passed, 0 failed
- `corepack pnpm run check`
  - deployment drift check, lint, typecheck, unit tests が通過
- PR 前レビュー
  - `verification_reviewer` で blocking findings なし
