### PR TITLE
feat: adminのunit作成を選手選択式にする

### DIFF
--- a/apps/web/src/app/admin/admin-client.test.tsx
+++ b/apps/web/src/app/admin/admin-client.test.tsx
@@ -21,6 +21,16 @@ vi.mock("../../lib/walrus/put-target", () => ({
 
 import { AdminClient } from "./admin-client";
 
+const CATALOG = Array.from({ length: 11 }, (_, index) => {
+  const athleteNumber = index + 1;
+
+  return {
+    displayName: `Catalog Athlete ${athleteNumber}`,
+    slug: `catalog-athlete-${athleteNumber}`,
+    thumbnailUrl: `https://example.com/catalog-${athleteNumber}.png`,
+  };
+});
+
 const HEALTH_OK = {
   currentUrl: "https://generator.example.com",
   dispatchAuthorization: { httpStatus: 200, status: "ok" } as const,
@@ -46,6 +56,7 @@ describe("AdminClient", () => {
   it("renders initial unit cards and health", () => {
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[
           {
             currentUnit: {
@@ -86,6 +97,7 @@ describe("AdminClient", () => {
   it("renders admin health warning details", () => {
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[]}
         initialHealth={{
           ...HEALTH_OK,
@@ -153,6 +165,7 @@ describe("AdminClient", () => {
 
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[
           {
             currentUnit: {
@@ -202,7 +215,13 @@ describe("AdminClient", () => {
       blobId: "target-blob-9",
     });
 
-    render(<AdminClient initialAthletes={[]} initialHealth={HEALTH_OK} />);
+    render(
+      <AdminClient
+        initialAthletes={[]}
+        initialCatalog={CATALOG}
+        initialHealth={HEALTH_OK}
+      />,
+    );
 
     const input = screen.getByLabelText(/Target image/) as HTMLInputElement;
     const file = new File(["target"], "target.jpg", { type: "image/jpeg" });
@@ -266,6 +285,7 @@ describe("AdminClient", () => {
 
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[
           {
             currentUnit: null,
@@ -282,6 +302,8 @@ describe("AdminClient", () => {
     );
 
     expect(screen.queryByLabelText(/unit ID/)).toBeNull();
+    expect(screen.queryByLabelText("displayName")).toBeNull();
+    expect(screen.queryByLabelText("thumbnail URL")).toBeNull();
     fireEvent.change(screen.getByLabelText(/Target blob ID/), {
       target: { value: "target-blob-7" },
     });
@@ -294,11 +316,10 @@ describe("AdminClient", () => {
     expect(screen.getByText(/Status: created/)).toBeTruthy();
     expect(screen.queryByText(/unit ID: 7/)).toBeNull();
     expect(createPayload).toEqual({
+      athleteSlug: "catalog-athlete-1",
       blobId: "target-blob-7",
       displayMaxSlots: unitTileCount,
-      displayName: "Demo Athlete Seven",
       maxSlots: unitTileCount,
-      thumbnailUrl: "https://example.com/7.png",
     });
   });
 
@@ -349,6 +370,7 @@ describe("AdminClient", () => {
 
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[
           {
             currentUnit: null,
@@ -377,11 +399,10 @@ describe("AdminClient", () => {
       expect(screen.getByText("Unit created")).toBeTruthy();
     });
     expect(createPayload).toEqual({
+      athleteSlug: "catalog-athlete-1",
       blobId: "target-blob-demo",
       displayMaxSlots: unitTileCount,
-      displayName: "Demo Athlete Twelve",
       maxSlots: 5,
-      thumbnailUrl: "https://example.com/12.png",
     });
   });
 
@@ -432,6 +453,7 @@ describe("AdminClient", () => {
 
     render(
       <AdminClient
+        initialCatalog={CATALOG}
         initialAthletes={[
           {
             currentUnit: null,
@@ -463,11 +485,102 @@ describe("AdminClient", () => {
       screen.getByText(/Treat as filled immediately after creating 0 photos/),
     ).toBeTruthy();
     expect(createPayload).toEqual({
+      athleteSlug: "catalog-athlete-1",
       blobId: "target-blob-demo-zero",
       displayMaxSlots: unitTileCount,
-      displayName: "Demo Athlete Zero",
       maxSlots: 0,
-      thumbnailUrl: "https://example.com/0.png",
     });
+  });
+
+  it("renders all fixed catalog athletes as create choices and previews the selected athlete", () => {
+    render(
+      <AdminClient
+        initialAthletes={[]}
+        initialCatalog={CATALOG}
+        initialHealth={HEALTH_OK}
+      />,
+    );
+
+    const select = screen.getByLabelText("Athlete");
+
+    expect(screen.queryByLabelText("displayName")).toBeNull();
+    expect(screen.queryByLabelText("thumbnail URL")).toBeNull();
+    expect(select.querySelectorAll("option")).toHaveLength(11);
+
+    for (const athlete of CATALOG) {
+      expect(
+        screen.getByRole("option", { name: athlete.displayName }),
+      ).toBeTruthy();
+    }
+
+    fireEvent.change(select, { target: { value: "catalog-athlete-7" } });
+
+    expect(screen.getAllByText("Catalog Athlete 7")).toHaveLength(2);
+    expect(
+      screen.getByAltText("Catalog Athlete 7 preview").getAttribute("src"),
+    ).toBe("https://example.com/catalog-7.png");
+  });
+
+  it("keeps the fixed create choices after refresh updates current status", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/admin/status")) {
+        return new Response(
+          JSON.stringify({
+            athletes: [
+              {
+                currentUnit: null,
+                displayName: "Only Status Athlete",
+                entryId: "status-only",
+                lookupState: "ready",
+                metadataState: "ready",
+                slug: "status-only",
+                thumbnailUrl: "https://example.com/status-only.png",
+              },
+            ],
+          }),
+          {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          },
+        );
+      }
+
+      return new Response(JSON.stringify(HEALTH_OK), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    });
+
+    render(
+      <AdminClient
+        initialAthletes={[]}
+        initialCatalog={CATALOG}
+        initialHealth={HEALTH_OK}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh status/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Only Status Athlete" }));
+    });
+
+    const select = screen.getByLabelText("Athlete");
+    expect(select.querySelectorAll("option")).toHaveLength(11);
+    expect(
+      screen.getByRole("option", { name: "Catalog Athlete 11" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("option", { name: "Only Status Athlete" }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/app/admin/admin-client.tsx
+++ b/apps/web/src/app/admin/admin-client.tsx
@@ -5,6 +5,7 @@ import { type ChangeEvent, type FormEvent, useState } from "react";
 
 import type { AdminAthleteEntry } from "../../lib/admin/athletes";
 import type { AdminHealthSummary } from "../../lib/admin/health";
+import type { AthleteCatalogEntry } from "../../lib/catalog";
 import { preprocessPhoto } from "../../lib/image/preprocess";
 import { putTargetBlobToWalrus } from "../../lib/walrus/put-target";
 
@@ -15,6 +16,7 @@ type ActionResult = {
 
 type AdminClientProps = {
   readonly initialAthletes: readonly AdminAthleteEntry[];
+  readonly initialCatalog: readonly AthleteCatalogEntry[];
   readonly initialHealth: AdminHealthSummary;
 };
 
@@ -24,15 +26,13 @@ const DEFAULT_DEMO_REAL_UPLOAD_COUNT = "5";
 
 export function AdminClient({
   initialAthletes,
+  initialCatalog,
   initialHealth,
 }: AdminClientProps): React.ReactElement {
   const [athletes, setAthletes] = useState(initialAthletes);
   const [health, setHealth] = useState(initialHealth);
-  const [createDisplayName, setCreateDisplayName] = useState(
-    initialAthletes[0]?.displayName ?? "",
-  );
-  const [createThumbnailUrl, setCreateThumbnailUrl] = useState(
-    initialAthletes[0]?.thumbnailUrl ?? "",
+  const [selectedAthleteSlug, setSelectedAthleteSlug] = useState(
+    initialCatalog[0]?.slug ?? "",
   );
   const [createMode, setCreateMode] = useState<CreateUnitMode>("normal");
   const [createRealUploadCount, setCreateRealUploadCount] = useState(
@@ -56,6 +56,9 @@ export function AdminClient({
     createMode === "demo"
       ? (parsedDemoRealUploadCount ?? 0)
       : effectiveDisplayMaxSlots;
+  const selectedAthlete =
+    initialCatalog.find((athlete) => athlete.slug === selectedAthleteSlug) ??
+    null;
 
   async function refreshAll(): Promise<void> {
     setIsRefreshing(true);
@@ -86,30 +89,6 @@ export function AdminClient({
     } finally {
       setIsRefreshing(false);
     }
-  }
-
-  function loadCreateDraft(entryKey: string): void {
-    const athlete = athletes.find(
-      (entry) => (entry.entryId ?? entry.currentUnit?.unitId) === entryKey,
-    );
-    if (!athlete) {
-      return;
-    }
-
-    setCreateDisplayName(athlete.displayName);
-    setCreateThumbnailUrl(athlete.thumbnailUrl);
-
-    if (
-      athlete.currentUnit &&
-      athlete.currentUnit.displayMaxSlots > athlete.currentUnit.maxSlots
-    ) {
-      setCreateMode("demo");
-      setCreateRealUploadCount(String(athlete.currentUnit.maxSlots));
-      return;
-    }
-
-    setCreateMode("normal");
-    setCreateRealUploadCount(DEFAULT_DEMO_REAL_UPLOAD_COUNT);
   }
 
   async function handleTargetUpload(
@@ -157,11 +136,10 @@ export function AdminClient({
 
     try {
       const payload = await postJson("/api/admin/create-unit", {
+        athleteSlug: selectedAthleteSlug,
         blobId: targetBlobId,
         displayMaxSlots: effectiveDisplayMaxSlots,
-        displayName: createDisplayName,
         maxSlots: effectiveMaxSlots,
-        thumbnailUrl: createThumbnailUrl,
       });
 
       setLastAction({
@@ -278,52 +256,43 @@ export function AdminClient({
           </p>
         </div>
 
-        {athletes.length > 0 ? (
+        <form
+          className="grid gap-5"
+          onSubmit={(event) => void handleCreateUnit(event)}
+        >
           <label className="grid gap-2 text-sm text-stone-200">
-            Copy inputs from existing unit
+            Athlete
             <select
               className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
-              onChange={(event) => loadCreateDraft(event.target.value)}
-              value=""
+              onChange={(event) => setSelectedAthleteSlug(event.target.value)}
+              value={selectedAthleteSlug}
             >
-              <option value="">Select one</option>
-              {athletes.map((athlete) => (
-                <option
-                  key={athlete.entryId ?? athlete.currentUnit?.unitId}
-                  value={athlete.entryId ?? athlete.currentUnit?.unitId}
-                >
+              {initialCatalog.map((athlete) => (
+                <option key={athlete.slug} value={athlete.slug}>
                   {athlete.displayName}
                 </option>
               ))}
             </select>
           </label>
-        ) : null}
 
-        <form
-          className="grid gap-5"
-          onSubmit={(event) => void handleCreateUnit(event)}
-        >
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="grid gap-2 text-sm text-stone-200">
-              displayName
-              <input
-                className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3"
-                onChange={(event) => setCreateDisplayName(event.target.value)}
-                placeholder="Demo Athlete Seven"
-                value={createDisplayName}
+          {selectedAthlete ? (
+            <div className="flex items-center gap-3 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+              {/* biome-ignore lint/performance/noImgElement: operator preview */}
+              <img
+                alt={`${selectedAthlete.displayName} preview`}
+                className="h-14 w-14 rounded-2xl border border-white/10 object-cover"
+                src={selectedAthlete.thumbnailUrl}
               />
-            </label>
-          </div>
-
-          <label className="grid gap-2 text-sm text-stone-200">
-            thumbnail URL
-            <input
-              className="rounded-2xl border border-white/10 bg-stone-900 px-4 py-3 font-mono text-xs"
-              onChange={(event) => setCreateThumbnailUrl(event.target.value)}
-              placeholder="https://example.com/7.png"
-              value={createThumbnailUrl}
-            />
-          </label>
+              <div className="grid gap-1">
+                <p className="text-sm font-medium text-white">
+                  {selectedAthlete.displayName}
+                </p>
+                <p className="font-mono text-xs text-stone-400">
+                  {selectedAthlete.slug}
+                </p>
+              </div>
+            </div>
+          ) : null}
 
           <fieldset className="grid gap-3 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
             <legend className="px-2 text-sm font-medium text-stone-100">
@@ -427,8 +396,7 @@ export function AdminClient({
             disabled={
               isUploading ||
               pendingAction === "create" ||
-              createDisplayName.trim().length === 0 ||
-              createThumbnailUrl.trim().length === 0 ||
+              !selectedAthlete ||
               targetBlobId.trim().length === 0 ||
               (createMode === "demo" && !isDemoRealUploadCountValid)
             }

--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -3,9 +3,15 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-const { getAdminHealthMock, loadAdminAthletesMock } = vi.hoisted(() => ({
-  getAdminHealthMock: vi.fn(),
-  loadAdminAthletesMock: vi.fn(),
+const { getAdminHealthMock, getAthleteCatalogMock, loadAdminAthletesMock } =
+  vi.hoisted(() => ({
+    getAdminHealthMock: vi.fn(),
+    getAthleteCatalogMock: vi.fn(),
+    loadAdminAthletesMock: vi.fn(),
+  }));
+
+vi.mock("../../lib/catalog", () => ({
+  getAthleteCatalog: getAthleteCatalogMock,
 }));
 
 vi.mock("../../lib/admin/athletes", () => ({
@@ -55,6 +61,13 @@ describe("AdminPage", () => {
         thumbnailUrl: "https://example.com/1.png",
       },
     ]);
+    getAthleteCatalogMock.mockResolvedValue([
+      {
+        displayName: "Catalog Create Athlete",
+        slug: "catalog-create-athlete",
+        thumbnailUrl: "https://example.com/catalog-create-athlete.png",
+      },
+    ]);
     getAdminHealthMock.mockResolvedValue(HEALTH_OK);
 
     const ui = await AdminPage();
@@ -67,5 +80,8 @@ describe("AdminPage", () => {
     expect(screen.getByText(/target-blob-1/)).toBeTruthy();
     expect(screen.getAllByText("ok")).toHaveLength(3);
     expect(screen.getByText("https://generator.example.com")).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: "Catalog Create Athlete" }),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { loadAdminAthletes } from "../../lib/admin/athletes";
 import { getAdminHealth } from "../../lib/admin/health";
+import { getAthleteCatalog } from "../../lib/catalog";
 
 import { AdminClient } from "./admin-client";
 
@@ -12,6 +13,7 @@ export default async function AdminPage(): Promise<React.ReactElement> {
     loadInitialAthletes(),
     getAdminHealth(),
   ]);
+  const catalog = await getAthleteCatalog();
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#2e2210,_#13100b_55%,_#060504)] px-6 py-16 text-stone-100">
@@ -39,7 +41,11 @@ export default async function AdminPage(): Promise<React.ReactElement> {
           </p>
         </header>
 
-        <AdminClient initialAthletes={athletes} initialHealth={health} />
+        <AdminClient
+          initialAthletes={athletes}
+          initialCatalog={catalog}
+          initialHealth={health}
+        />
       </div>
     </main>
   );

--- a/apps/web/src/app/api/admin/create-unit/route.test.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.test.ts
@@ -9,8 +9,16 @@ const { getRequestCloudflareEnvMock } = vi.hoisted(() => ({
   getRequestCloudflareEnvMock: vi.fn(),
 }));
 
+const { getAthleteBySlugMock } = vi.hoisted(() => ({
+  getAthleteBySlugMock: vi.fn(),
+}));
+
 vi.mock("../../../../lib/admin/env", () => ({
   loadAdminRelayEnv: loadAdminRelayEnvMock,
+}));
+
+vi.mock("../../../../lib/catalog", () => ({
+  getAthleteBySlug: getAthleteBySlugMock,
 }));
 
 vi.mock("../../../../lib/env", () => ({
@@ -34,6 +42,7 @@ describe("POST /api/admin/create-unit", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    getAthleteBySlugMock.mockReset();
     getRequestCloudflareEnvMock.mockReset();
     loadAdminRelayEnvMock.mockReset();
     loadPublicEnvMock.mockReset();
@@ -60,11 +69,10 @@ describe("POST /api/admin/create-unit", () => {
     const response = await POST(
       new Request("http://localhost/api/admin/create-unit", {
         body: JSON.stringify({
+          athleteSlug: "yuya-wakamatsu",
           blobId: "target-blob-12",
           displayMaxSlots: 2000,
-          displayName: "Demo Athlete Twelve",
           maxSlots: 2000,
-          thumbnailUrl: "https://example.com/12.png",
         }),
         method: "POST",
       }),
@@ -76,8 +84,39 @@ describe("POST /api/admin/create-unit", () => {
     });
   });
 
-  it("relays the validated create-unit request to the generator", async () => {
+  it("returns 400 for an unknown athleteSlug", async () => {
+    getAthleteBySlugMock.mockResolvedValue(undefined);
+
+    const response = await POST(
+      new Request("http://localhost/api/admin/create-unit", {
+        body: JSON.stringify({
+          athleteSlug: "unknown-athlete",
+          blobId: "target-blob-12",
+          displayMaxSlots: 2000,
+          maxSlots: 2000,
+        }),
+        headers: {
+          "x-one-portrait-admin-request": "same-origin",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "invalid_args",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("relays the catalog-resolved create-unit request to the generator", async () => {
     getRequestCloudflareEnvMock.mockReturnValue(null);
+    getAthleteBySlugMock.mockResolvedValue({
+      displayName: "Yuya Wakamatsu",
+      slug: "yuya-wakamatsu",
+      thumbnailUrl:
+        "/demo/one-athletes/Yuya_Wakamatsu-avatar-champ-500x345-1.png",
+    });
     loadPublicEnvMock.mockReturnValue({
       packageId: "0xpkg",
       registryObjectId: VALID_REGISTRY_ID,
@@ -105,11 +144,10 @@ describe("POST /api/admin/create-unit", () => {
     const response = await POST(
       new Request("http://localhost/api/admin/create-unit", {
         body: JSON.stringify({
+          athleteSlug: "yuya-wakamatsu",
           blobId: "target-blob-12",
           displayMaxSlots: 2000,
-          displayName: "Demo Athlete Twelve",
           maxSlots: 2000,
-          thumbnailUrl: "https://example.com/12.png",
         }),
         headers: {
           "x-one-portrait-admin-request": "same-origin",
@@ -119,20 +157,24 @@ describe("POST /api/admin/create-unit", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(getAthleteBySlugMock).toHaveBeenCalledWith("yuya-wakamatsu");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const request = fetchMock.mock.calls[0]?.[0] as Request;
     expect(request.url).toBe("https://generator.example.com/admin/create-unit");
     expect(request.headers.get("x-op-finalize-dispatch-secret")).toBe(
       "shared-secret",
     );
-    await expect(request.json()).resolves.toEqual({
+    const relayBody = await request.json();
+    expect(relayBody).toEqual({
       blobId: "target-blob-12",
       displayMaxSlots: 2000,
-      displayName: "Demo Athlete Twelve",
+      displayName: "Yuya Wakamatsu",
       maxSlots: 2000,
       registryObjectId: VALID_REGISTRY_ID,
-      thumbnailUrl: "https://example.com/12.png",
+      thumbnailUrl:
+        "/demo/one-athletes/Yuya_Wakamatsu-avatar-champ-500x345-1.png",
     });
+    expect(relayBody).not.toHaveProperty("athleteSlug");
     await expect(response.json()).resolves.toEqual({
       digest: "0xdigest",
       status: "created",

--- a/apps/web/src/app/api/admin/create-unit/route.ts
+++ b/apps/web/src/app/api/admin/create-unit/route.ts
@@ -6,6 +6,7 @@ import {
   parseCreateUnitInput,
 } from "../../../../lib/admin/api";
 import { relayAdminPost } from "../../../../lib/admin/dispatch";
+import { getAthleteBySlug } from "../../../../lib/catalog";
 import { getRequestCloudflareEnv } from "../../../../lib/cloudflare-context";
 import { loadPublicEnv } from "../../../../lib/env";
 
@@ -14,17 +15,25 @@ export async function POST(request: Request): Promise<Response> {
     assertAdminMutationRequest(request);
     const cloudflareEnv = getRequestCloudflareEnv() ?? undefined;
     const input = parseCreateUnitInput(await request.json());
+    const athlete = await getAthleteBySlug(input.athleteSlug);
+    if (!athlete) {
+      throw new AdminApiError(
+        400,
+        "invalid_args",
+        "`athleteSlug` does not match a catalog athlete.",
+      );
+    }
     const { registryObjectId } = loadPublicEnv(process.env);
 
     return await relayAdminPost(
       "/admin/create-unit",
       {
         displayMaxSlots: input.displayMaxSlots,
-        displayName: input.displayName,
+        displayName: athlete.displayName,
         blobId: input.blobId,
         maxSlots: input.maxSlots,
         registryObjectId,
-        thumbnailUrl: input.thumbnailUrl,
+        thumbnailUrl: athlete.thumbnailUrl,
       },
       {
         env: cloudflareEnv,

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -2,7 +2,7 @@
 
 import { unitTileCount } from "@one-portrait/shared";
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { demoUnitId } from "../lib/demo";
 
@@ -38,6 +38,8 @@ const CATALOG = [
     slug: "demo-athlete-one",
     displayName: "Demo Athlete One",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
+    region: "Demo Region One",
+    status: "Active portrait",
   },
   {
     unitId:
@@ -45,8 +47,14 @@ const CATALOG = [
     slug: "demo-athlete-two",
     displayName: "Demo Athlete Two",
     thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+2",
+    region: "Demo Region Two",
+    status: "Opening soon",
   },
 ] as const;
+
+beforeEach(() => {
+  getAthleteCatalogMock.mockResolvedValue(CATALOG);
+});
 
 afterEach(() => {
   delete process.env.NEXT_PUBLIC_DEMO_MODE;
@@ -56,6 +64,25 @@ afterEach(() => {
 });
 
 describe("HomePage", () => {
+  it("renders the horizontal portrait rail from catalog names and image paths", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    getAthleteCatalogMock.mockResolvedValue(CATALOG);
+
+    const ui = await HomePage();
+    render(ui);
+
+    for (const athlete of CATALOG) {
+      expect(screen.getAllByText(athlete.displayName).length).toBeGreaterThan(
+        0,
+      );
+      expect(
+        screen
+          .getAllByAltText(athlete.displayName)
+          .some((image) => image.getAttribute("src") === athlete.thumbnailUrl),
+      ).toBe(true);
+    }
+  });
+
   it("renders chain-driven cards with on-chain metadata", async () => {
     getActiveHomeUnitsMock.mockResolvedValue([
       {
@@ -75,8 +102,8 @@ describe("HomePage", () => {
     const ui = await HomePage();
     render(ui);
 
-    expect(screen.getByText("Demo Athlete One")).toBeTruthy();
-    expect(screen.getByText("Demo Athlete Two")).toBeTruthy();
+    expect(screen.getAllByText("Demo Athlete One").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Demo Athlete Two").length).toBeGreaterThan(0);
   });
 
   it("shows the current unit progress when an active unit exists", async () => {
@@ -205,8 +232,8 @@ describe("HomePage", () => {
     });
     render(ui);
 
-    expect(screen.getByText("Demo Athlete One")).toBeTruthy();
-    expect(screen.getByText("Demo Athlete Two")).toBeTruthy();
+    expect(screen.getAllByText("Demo Athlete One").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Demo Athlete Two").length).toBeGreaterThan(0);
     expect(screen.getByText(/Waiting \/ No active unit/i)).toBeTruthy();
     expect(
       screen.getByText(

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
 import Link from "next/link";
 
-import { getAthleteCatalog } from "../lib/catalog";
+import { type AthleteCatalogEntry, getAthleteCatalog } from "../lib/catalog";
 import { getDemoUnitProgress, isDemoModeEnabled } from "../lib/demo";
 import { getActiveHomeUnits, RegistrySchemaError } from "../lib/sui";
 import {
@@ -23,7 +23,7 @@ type HomePageProps = {
 };
 
 type HomeEntry = {
-  readonly unitId: string;
+  readonly unitId: string | null;
   readonly displayName: string;
   readonly thumbnailUrl: string;
   readonly progress:
@@ -43,98 +43,23 @@ type HomeEntry = {
       };
 };
 
-type PortraitWork = {
-  readonly id: string;
-  readonly name: string;
+type PortraitWork = Pick<
+  AthleteCatalogEntry,
+  "displayName" | "slug" | "thumbnailUrl"
+> & {
   readonly region: string;
   readonly status: string;
-  readonly src: string;
 };
 
-const portraitWorks: readonly PortraitWork[] = [
-  {
-    id: "yuya-wakamatsu",
-    name: "Yuya Wakamatsu",
-    region: "Japan",
-    status: "Active portrait",
-    src: "/demo/one-athletes/Yuya_Wakamatsu-avatar-champ-500x345-1.png",
-  },
-  {
-    id: "takeru",
-    name: "Takeru",
-    region: "Japan",
-    status: "Opening soon",
-    src: "/demo/one-athletes/Takeru-500x345-1.png",
-  },
-  {
-    id: "rodtang-jitmuangnon",
-    name: "Rodtang Jitmuangnon",
-    region: "Thailand",
-    status: "Active portrait",
-    src: "/demo/one-athletes/Rodtang_Jitmuangnon-Avatar-500x345-1.png",
-  },
-  {
-    id: "ayaka-miura",
-    name: "Ayaka Miura",
-    region: "Japan",
-    status: "Waiting room",
-    src: "/demo/one-athletes/Ayaka_Miura-avatar-500x345-1.png",
-  },
-  {
-    id: "itsuki-hirata",
-    name: "Itsuki Hirata",
-    region: "Japan",
-    status: "Opening soon",
-    src: "/demo/one-athletes/Itsuki_Hirata-avatar-500x345-4.png",
-  },
-  {
-    id: "jonathan-haggerty",
-    name: "Jonathan Haggerty",
-    region: "United Kingdom",
-    status: "Active portrait",
-    src: "/demo/one-athletes/Jonathan_Haggerty-avatar-500x345-4.png",
-  },
-  {
-    id: "ritu-phogat",
-    name: "Ritu Phogat",
-    region: "India",
-    status: "Waiting room",
-    src: "/demo/one-athletes/Ritu_Phogat-avatar-500x345-1.png",
-  },
-  {
-    id: "toma-kuroda",
-    name: "Toma Kuroda",
-    region: "Japan",
-    status: "Opening soon",
-    src: "/demo/one-athletes/Toma_Kuroda-avatar-500x345-1.png",
-  },
-  {
-    id: "yuki-yoza",
-    name: "Yuki Yoza",
-    region: "Japan",
-    status: "Waiting room",
-    src: "/demo/one-athletes/Yuki_Yoza-avatar-500x345-1.png",
-  },
-  {
-    id: "chihiro-sawada",
-    name: "Chihiro Sawada",
-    region: "Japan",
-    status: "Opening soon",
-    src: "/demo/one-athletes/Chihiro_Sawada-avatar-500x345-3.png",
-  },
-  {
-    id: "avazbek-kholmirzaev",
-    name: "Avazbek Kholmirzaev",
-    region: "Uzbekistan",
-    status: "Waiting room",
-    src: "/demo/one-athletes/Avazbek_Kholmirzaev-Avatar-500x345-1.png",
-  },
-];
-
-const portraitWorkRail = [
-  ...portraitWorks.map((work) => ({ ...work, railId: `first-${work.id}` })),
-  ...portraitWorks.map((work) => ({ ...work, railId: `second-${work.id}` })),
-] as const;
+function toPortraitWork(entry: AthleteCatalogEntry): PortraitWork {
+  return {
+    displayName: entry.displayName,
+    region: entry.region ?? "",
+    slug: entry.slug,
+    status: entry.status ?? "",
+    thumbnailUrl: entry.thumbnailUrl,
+  };
+}
 
 export default async function HomePage(
   props: HomePageProps = {},
@@ -146,6 +71,17 @@ export default async function HomePage(
   const entries = useDemoEntries
     ? await loadDemoEntries(searchParams.op_e2e_home_card_state)
     : await loadChainEntries();
+  const portraitWorks = (await getAthleteCatalog()).map(toPortraitWork);
+  const portraitWorkRail = [
+    ...portraitWorks.map((work) => ({
+      ...work,
+      railId: `first-${work.slug}`,
+    })),
+    ...portraitWorks.map((work) => ({
+      ...work,
+      railId: `second-${work.slug}`,
+    })),
+  ];
 
   const firstActive = entries.find(
     (
@@ -295,13 +231,13 @@ function PortraitWorkCard({
   return (
     <article className="op-home-portrait-card">
       {/* biome-ignore lint/performance/noImgElement: temporary public portrait artwork */}
-      <img alt={work.name} src={work.src} />
+      <img alt={work.displayName} src={work.thumbnailUrl} />
       <div className="op-home-portrait-card-body">
         <div className="flex items-center justify-between gap-4">
           <span>{work.region}</span>
           <span className="is-live">{work.status}</span>
         </div>
-        <h3>{work.name}</h3>
+        <h3>{work.displayName}</h3>
         <div className="op-home-portrait-card-meter">
           <i />
         </div>
@@ -533,7 +469,7 @@ async function loadDemoEntries(
   const entries: HomeEntry[] = [];
 
   for (const athlete of catalog) {
-    const unitId = athlete.unitId;
+    const unitId = athlete.unitId ?? null;
     const override = resolveE2ECardOverride(
       athlete.unitId,
       rawOverride,
@@ -542,6 +478,7 @@ async function loadDemoEntries(
     if (override) {
       entries.push({
         ...athlete,
+        unitId,
         progress: override,
       });
       continue;
@@ -558,6 +495,7 @@ async function loadDemoEntries(
 
     entries.push({
       ...athlete,
+      unitId,
       progress: {
         kind: "active",
         maxSlots: progress.maxSlots,
@@ -576,7 +514,7 @@ function buildWaitingRoomHref(unitId: string, athleteName: string): string {
 }
 
 function resolveE2ECardOverride(
-  entryUnitId: string,
+  entryUnitId: string | undefined,
   rawOverride: string | undefined,
   unitId: string | null,
 ):

--- a/apps/web/src/data/athlete-catalog.ts
+++ b/apps/web/src/data/athlete-catalog.ts
@@ -4,8 +4,6 @@
  * Replace this module with a CMS/JSON fetch later without touching callers —
  * the public helpers in `@/lib/catalog` already expose an async-friendly API.
  *
- * All data here is placeholder. We intentionally do not hardcode real ONE
- * Championship athletes until legal/brand review is complete.
  */
 
 import type { AthleteCatalogEntry } from "../lib/catalog/types";
@@ -14,22 +12,85 @@ import { demoUnitId } from "../lib/demo";
 export const athleteCatalogEntries: readonly AthleteCatalogEntry[] = [
   {
     unitId: demoUnitId,
-    slug: "demo-athlete-one",
-    displayName: "Demo Athlete One",
-    thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+1",
+    slug: "yuya-wakamatsu",
+    displayName: "Yuya Wakamatsu",
+    thumbnailUrl:
+      "/demo/one-athletes/Yuya_Wakamatsu-avatar-champ-500x345-1.png",
+    region: "Japan",
+    status: "Active portrait",
   },
   {
     unitId:
       "0x00000000000000000000000000000000000000000000000000000000000000d4",
-    slug: "demo-athlete-two",
-    displayName: "Demo Athlete Two",
-    thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+2",
+    slug: "takeru",
+    displayName: "Takeru",
+    thumbnailUrl: "/demo/one-athletes/Takeru-500x345-1.png",
+    region: "Japan",
+    status: "Opening soon",
   },
   {
     unitId:
       "0x00000000000000000000000000000000000000000000000000000000000000d5",
-    slug: "demo-athlete-three",
-    displayName: "Demo Athlete Three",
-    thumbnailUrl: "https://placehold.co/512x512/png?text=Athlete+3",
+    slug: "rodtang-jitmuangnon",
+    displayName: "Rodtang Jitmuangnon",
+    thumbnailUrl: "/demo/one-athletes/Rodtang_Jitmuangnon-Avatar-500x345-1.png",
+    region: "Thailand",
+    status: "Active portrait",
+  },
+  {
+    slug: "ayaka-miura",
+    displayName: "Ayaka Miura",
+    thumbnailUrl: "/demo/one-athletes/Ayaka_Miura-avatar-500x345-1.png",
+    region: "Japan",
+    status: "Waiting room",
+  },
+  {
+    slug: "itsuki-hirata",
+    displayName: "Itsuki Hirata",
+    thumbnailUrl: "/demo/one-athletes/Itsuki_Hirata-avatar-500x345-4.png",
+    region: "Japan",
+    status: "Opening soon",
+  },
+  {
+    slug: "jonathan-haggerty",
+    displayName: "Jonathan Haggerty",
+    thumbnailUrl: "/demo/one-athletes/Jonathan_Haggerty-avatar-500x345-4.png",
+    region: "United Kingdom",
+    status: "Active portrait",
+  },
+  {
+    slug: "ritu-phogat",
+    displayName: "Ritu Phogat",
+    thumbnailUrl: "/demo/one-athletes/Ritu_Phogat-avatar-500x345-1.png",
+    region: "India",
+    status: "Waiting room",
+  },
+  {
+    slug: "toma-kuroda",
+    displayName: "Toma Kuroda",
+    thumbnailUrl: "/demo/one-athletes/Toma_Kuroda-avatar-500x345-1.png",
+    region: "Japan",
+    status: "Opening soon",
+  },
+  {
+    slug: "yuki-yoza",
+    displayName: "Yuki Yoza",
+    thumbnailUrl: "/demo/one-athletes/Yuki_Yoza-avatar-500x345-1.png",
+    region: "Japan",
+    status: "Waiting room",
+  },
+  {
+    slug: "chihiro-sawada",
+    displayName: "Chihiro Sawada",
+    thumbnailUrl: "/demo/one-athletes/Chihiro_Sawada-avatar-500x345-3.png",
+    region: "Japan",
+    status: "Opening soon",
+  },
+  {
+    slug: "avazbek-kholmirzaev",
+    displayName: "Avazbek Kholmirzaev",
+    thumbnailUrl: "/demo/one-athletes/Avazbek_Kholmirzaev-Avatar-500x345-1.png",
+    region: "Uzbekistan",
+    status: "Waiting room",
   },
 ] as const;

--- a/apps/web/src/lib/admin/api.test.ts
+++ b/apps/web/src/lib/admin/api.test.ts
@@ -9,50 +9,45 @@ import {
 } from "./api";
 
 describe("parseCreateUnitInput", () => {
-  it("accepts create-unit input without athleteId", () => {
+  it("accepts create-unit input with athleteSlug", () => {
     expect(
       parseCreateUnitInput({
+        athleteSlug: "demo-athlete-twelve",
         blobId: "target-blob-12",
         displayMaxSlots: 2000,
-        displayName: "Demo Athlete Twelve",
         maxSlots: 2000,
-        thumbnailUrl: "https://example.com/12.png",
       }),
     ).toEqual({
+      athleteSlug: "demo-athlete-twelve",
       blobId: "target-blob-12",
       displayMaxSlots: 2000,
-      displayName: "Demo Athlete Twelve",
       maxSlots: 2000,
-      thumbnailUrl: "https://example.com/12.png",
     });
   });
 
   it("accepts zero real upload slots for a demo unit", () => {
     expect(
       parseCreateUnitInput({
+        athleteSlug: "demo-athlete-twelve",
         blobId: "target-blob-12",
         displayMaxSlots: 2000,
-        displayName: "Demo Athlete Twelve",
         maxSlots: 0,
-        thumbnailUrl: "https://example.com/12.png",
       }),
     ).toEqual({
+      athleteSlug: "demo-athlete-twelve",
       blobId: "target-blob-12",
       displayMaxSlots: 2000,
-      displayName: "Demo Athlete Twelve",
       maxSlots: 0,
-      thumbnailUrl: "https://example.com/12.png",
     });
   });
 
   it("rejects a zero display slot unit", () => {
     expect(() =>
       parseCreateUnitInput({
+        athleteSlug: "demo-athlete-twelve",
         blobId: "target-blob-12",
         displayMaxSlots: 0,
-        displayName: "Demo Athlete Twelve",
         maxSlots: 0,
-        thumbnailUrl: "https://example.com/12.png",
       }),
     ).toThrowError(AdminApiError);
   });
@@ -61,9 +56,32 @@ describe("parseCreateUnitInput", () => {
     expect(() =>
       parseCreateUnitInput({
         athleteId: 12,
+        athleteSlug: "demo-athlete-twelve",
+        blobId: "target-blob-12",
+        displayMaxSlots: 2000,
+        maxSlots: 2000,
+      }),
+    ).toThrowError(AdminApiError);
+  });
+
+  it("rejects client-provided displayName", () => {
+    expect(() =>
+      parseCreateUnitInput({
+        athleteSlug: "demo-athlete-twelve",
         blobId: "target-blob-12",
         displayMaxSlots: 2000,
         displayName: "Demo Athlete Twelve",
+        maxSlots: 2000,
+      }),
+    ).toThrowError(AdminApiError);
+  });
+
+  it("rejects client-provided thumbnailUrl", () => {
+    expect(() =>
+      parseCreateUnitInput({
+        athleteSlug: "demo-athlete-twelve",
+        blobId: "target-blob-12",
+        displayMaxSlots: 2000,
         maxSlots: 2000,
         thumbnailUrl: "https://example.com/12.png",
       }),

--- a/apps/web/src/lib/admin/api.ts
+++ b/apps/web/src/lib/admin/api.ts
@@ -19,21 +19,19 @@ export class AdminApiError extends Error {
 }
 
 export type CreateUnitRouteInput = {
+  readonly athleteSlug: string;
   readonly displayMaxSlots: number;
-  readonly displayName: string;
   readonly blobId: string;
   readonly maxSlots: number;
-  readonly thumbnailUrl: string;
 };
 
 export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
   const record = asRecord(input);
   assertExactKeys(record, [
+    "athleteSlug",
     "blobId",
     "displayMaxSlots",
-    "displayName",
     "maxSlots",
-    "thumbnailUrl",
   ]);
 
   const maxSlots = parseNonNegativeInteger(record.maxSlots, "maxSlots");
@@ -50,14 +48,13 @@ export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
   }
 
   return {
+    athleteSlug: parseNonEmptyTrimmedString(
+      record.athleteSlug,
+      "athleteSlug",
+    ),
     displayMaxSlots,
-    displayName: parseNonEmptyTrimmedString(record.displayName, "displayName"),
     blobId: parseBlobId(record.blobId),
     maxSlots,
-    thumbnailUrl: parseNonEmptyTrimmedString(
-      record.thumbnailUrl,
-      "thumbnailUrl",
-    ),
   };
 }
 

--- a/apps/web/src/lib/admin/api.ts
+++ b/apps/web/src/lib/admin/api.ts
@@ -48,10 +48,7 @@ export function parseCreateUnitInput(input: unknown): CreateUnitRouteInput {
   }
 
   return {
-    athleteSlug: parseNonEmptyTrimmedString(
-      record.athleteSlug,
-      "athleteSlug",
-    ),
+    athleteSlug: parseNonEmptyTrimmedString(record.athleteSlug, "athleteSlug"),
     displayMaxSlots,
     blobId: parseBlobId(record.blobId),
     maxSlots,

--- a/apps/web/src/lib/catalog/athlete-catalog.test.ts
+++ b/apps/web/src/lib/catalog/athlete-catalog.test.ts
@@ -7,30 +7,29 @@ import {
 } from "./index";
 
 describe("getAthleteCatalog", () => {
-  it("returns at least two athlete entries for MVP demo", async () => {
+  it("returns the 11 home rail athlete entries", async () => {
     const catalog = await getAthleteCatalog();
 
     expect(Array.isArray(catalog)).toBe(true);
-    expect(catalog.length).toBeGreaterThanOrEqual(2);
+    expect(catalog).toHaveLength(11);
   });
 
-  it("gives every entry the required unit display fields", async () => {
+  it("gives every entry the required home rail display fields", async () => {
     const catalog = await getAthleteCatalog();
 
     for (const entry of catalog) {
-      expect(entry.unitId).toMatch(/^0x[0-9a-f]+$/i);
       expect(entry.displayName.length).toBeGreaterThan(0);
       expect(entry.slug.length).toBeGreaterThan(0);
       expect(entry.thumbnailUrl.length).toBeGreaterThan(0);
+      expect(entry.region?.length).toBeGreaterThan(0);
+      expect(entry.status?.length).toBeGreaterThan(0);
     }
   });
 
-  it("has unique unitId and slug across entries", async () => {
+  it("has unique slugs across entries", async () => {
     const catalog = await getAthleteCatalog();
-    const ids = new Set(catalog.map((entry) => entry.unitId));
     const slugs = new Set(catalog.map((entry) => entry.slug));
 
-    expect(ids.size).toBe(catalog.length);
     expect(slugs.size).toBe(catalog.length);
   });
 });
@@ -60,6 +59,10 @@ describe("getAthleteByUnitId", () => {
     const first = catalog[0];
     if (!first) {
       expect.unreachable("catalog should not be empty");
+      return;
+    }
+    if (!first.unitId) {
+      expect.unreachable("first catalog entry should have a unitId");
       return;
     }
 
@@ -108,17 +111,15 @@ describe("AthleteChainRef", () => {
 });
 
 describe("AthleteCatalogEntry", () => {
-  it("is structurally independent from AthleteChainRef", () => {
+  it("keeps unitId optional for catalog-only home rail entries", () => {
     const entry: AthleteCatalogEntry = {
-      unitId: "0x42",
       slug: "example",
       displayName: "Example Athlete",
       thumbnailUrl: "https://example.invalid/thumb.jpg",
-    };
-    const ref: AthleteChainRef = {
-      unitId: "0x42",
+      region: "Example Region",
+      status: "Opening soon",
     };
 
-    expect(entry.unitId).toBe(ref.unitId);
+    expect(entry.unitId).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/catalog/types.ts
+++ b/apps/web/src/lib/catalog/types.ts
@@ -1,9 +1,8 @@
 /**
  * Catalog type boundary for ONE Portrait.
  *
- * The catalog layer owns demo/display metadata for known Units.
- * Live chain data now carries its own display name and thumbnail on Unit,
- * so `unitId` is the only catalog key.
+ * The catalog layer owns demo/display metadata for known athletes.
+ * A catalog entry may be used before a Unit exists, so `unitId` is optional.
  */
 
 /**
@@ -14,14 +13,18 @@
  * {@link AthleteChainRef}.
  */
 export type AthleteCatalogEntry = {
-  /** Object ID of the current demo/display Unit. */
-  readonly unitId: string;
+  /** Object ID of the current demo/display Unit, when one exists. */
+  readonly unitId?: string;
   /** URL-safe identifier used in routes like `/athletes/[slug]`. */
   readonly slug: string;
   /** Human-readable name shown in UI. */
   readonly displayName: string;
   /** Absolute URL for the athlete thumbnail (served from Walrus or CDN). */
   readonly thumbnailUrl: string;
+  /** Region label shown in catalog-driven UI. */
+  readonly region?: string;
+  /** Short availability label shown in catalog-driven UI. */
+  readonly status?: string;
 };
 
 /**


### PR DESCRIPTION
## 概要

`/admin` の unit 作成を、選手名とサムネイル URL の手入力から選択式へ変えます。

トップページの横流れ選手リストを catalog の正本にします。
admin も同じ catalog を使うため、名前と画像のズレを防げます。

## 変更内容

- `apps/web/src/data/athlete-catalog.ts`
  - トップページの 11 人を catalog に移動
  - `region` と `status` も catalog で管理

- `apps/web/src/app/page.tsx`
  - 横流れ選手カードを catalog から生成
  - 固定配列の重複を削除

- `apps/web/src/lib/admin/api.ts`
  - create-unit 入力を `athleteSlug` に変更
  - `displayName` と `thumbnailUrl` の直接入力を拒否

- `apps/web/src/app/api/admin/create-unit/route.ts`
  - slug から catalog の選手を解決
  - 不正 slug を 400 で拒否
  - generator へは catalog 由来の名前と画像を中継

- `apps/web/src/app/admin/admin-client.tsx`
  - unit 作成フォームを選手選択式に変更
  - thumbnail URL 入力を削除
  - 選択中の選手プレビューを表示
  - 作成候補と Current status の state を分離

- tests
  - catalog、トップページ、admin API、admin UI の回帰テストを追加・更新

## 関連する Issue やチケット

Close #102

## 動作確認

- `pnpm --filter web exec vitest run src/lib/catalog/athlete-catalog.test.ts src/app/page.test.tsx src/lib/admin/api.test.ts src/app/api/admin/create-unit/route.test.ts src/app/admin/admin-client.test.tsx src/app/admin/page.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web test`

PR 前レビューでは blocking 指摘なしです。
