### PR TITLE
feat: ホームのポートレートレールに矢印操作を追加

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -489,8 +489,17 @@ a {
   line-height: 1.56;
 }
 
+.op-home-portrait-rail-shell {
+  position: relative;
+}
+
 .op-home-portrait-rail {
   overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   mask-image: linear-gradient(
     90deg,
     transparent,
@@ -500,12 +509,61 @@ a {
   );
 }
 
+.op-home-portrait-rail::-webkit-scrollbar {
+  display: none;
+}
+
 .op-home-portrait-track {
   display: flex;
   gap: 16px;
   width: max-content;
   padding: 6px 24px 20px;
-  animation: op-home-portrait-flow 48s linear infinite;
+}
+
+.op-home-portrait-nav {
+  position: absolute;
+  top: calc(50% - 7px);
+  z-index: 8;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 46px;
+  padding: 0;
+  border: 1px solid rgba(245, 239, 227, 0.2);
+  border-radius: 999px;
+  background: rgba(10, 6, 4, 0.72);
+  color: var(--ink);
+  box-shadow:
+    0 0 0 1px rgba(255, 122, 26, 0.08) inset,
+    0 14px 40px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+  transform: translateY(-50%);
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.op-home-portrait-nav:hover {
+  border-color: rgba(255, 122, 26, 0.7);
+  background: rgba(24, 12, 6, 0.9);
+  color: var(--fire-1);
+  transform: translateY(-50%) scale(1.04);
+}
+
+.op-home-portrait-nav:focus-visible {
+  outline: 2px solid var(--ember);
+  outline-offset: 3px;
+}
+
+.op-home-portrait-nav.is-prev {
+  left: 14px;
+}
+
+.op-home-portrait-nav.is-next {
+  right: 14px;
 }
 
 .op-home-portrait-card {
@@ -1860,6 +1918,20 @@ a {
     height: 250px;
   }
 
+  .op-home-portrait-nav {
+    top: calc(50% - 6px);
+    width: 30px;
+    height: 40px;
+  }
+
+  .op-home-portrait-nav.is-prev {
+    left: 8px;
+  }
+
+  .op-home-portrait-nav.is-next {
+    right: 8px;
+  }
+
   .op-home-submit {
     grid-template-columns: 1fr;
     padding: 24px;
@@ -1978,7 +2050,6 @@ a {
   .op-hero-title .accent,
   .op-hero-title .line,
   .op-corners,
-  .op-home-portrait-track,
   .op-home-scroll-flip,
   .op-home-scroll-reveal,
   .op-home-teaser-image,

--- a/apps/web/src/app/home-portrait-rail.tsx
+++ b/apps/web/src/app/home-portrait-rail.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { type ReactNode, useCallback, useEffect, useRef } from "react";
+
+const fallbackCardStepPx = 266;
+const manualPauseMs = 3200;
+const loopDurationMs = 48000;
+
+export function HomePortraitRail({
+  children,
+}: {
+  readonly children: ReactNode;
+}): React.ReactElement {
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const pauseUntilRef = useRef(0);
+
+  const getLoopWidth = useCallback((): number => {
+    const track = trackRef.current;
+    if (!track) {
+      return 0;
+    }
+
+    return track.scrollWidth / 2;
+  }, []);
+
+  const getCardStep = useCallback((): number => {
+    const track = trackRef.current;
+    const firstCard = track?.querySelector<HTMLElement>(
+      ".op-home-portrait-card, .op-home-portrait-card-link",
+    );
+    if (!track || !firstCard) {
+      return fallbackCardStepPx;
+    }
+
+    const cardWidth = firstCard.getBoundingClientRect().width;
+    const gap = Number.parseFloat(window.getComputedStyle(track).columnGap);
+    const step = cardWidth + (Number.isFinite(gap) ? gap : 0);
+    return step > 0 ? Math.round(step) : fallbackCardStepPx;
+  }, []);
+
+  const normalizeLoopPosition = useCallback((): void => {
+    const rail = railRef.current;
+    const loopWidth = getLoopWidth();
+    if (!rail || loopWidth <= 0) {
+      return;
+    }
+
+    if (rail.scrollLeft >= loopWidth) {
+      rail.scrollLeft -= loopWidth;
+    }
+  }, [getLoopWidth]);
+
+  const moveRail = useCallback(
+    (direction: -1 | 1): void => {
+      const rail = railRef.current;
+      if (!rail) {
+        return;
+      }
+
+      const step = getCardStep();
+      const loopWidth = getLoopWidth();
+      pauseUntilRef.current = Date.now() + manualPauseMs;
+
+      if (direction < 0 && loopWidth > 0 && rail.scrollLeft <= 1) {
+        rail.scrollLeft += loopWidth;
+      }
+
+      if (
+        direction > 0 &&
+        loopWidth > 0 &&
+        rail.scrollLeft >= loopWidth - step
+      ) {
+        rail.scrollLeft -= loopWidth;
+      }
+
+      rail.scrollBy({
+        behavior: "smooth",
+        left: direction * step,
+      });
+    },
+    [getCardStep, getLoopWidth],
+  );
+
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) {
+      return;
+    }
+
+    const prefersReducedMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    let frameId = 0;
+    let lastFrameTime = 0;
+
+    const animate = (time: number): void => {
+      frameId = window.requestAnimationFrame(animate);
+      if (lastFrameTime === 0) {
+        lastFrameTime = time;
+        return;
+      }
+
+      const elapsed = time - lastFrameTime;
+      lastFrameTime = time;
+      if (Date.now() < pauseUntilRef.current) {
+        return;
+      }
+
+      const loopWidth = getLoopWidth();
+      if (loopWidth <= 0) {
+        return;
+      }
+
+      rail.scrollLeft += (elapsed * loopWidth) / loopDurationMs;
+      normalizeLoopPosition();
+    };
+
+    frameId = window.requestAnimationFrame(animate);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [getLoopWidth, normalizeLoopPosition]);
+
+  return (
+    <div className="op-home-portrait-rail-shell">
+      <button
+        aria-label="Previous portraits"
+        className="op-home-portrait-nav is-prev"
+        onClick={() => moveRail(-1)}
+        type="button"
+      >
+        <RailArrow direction="prev" />
+      </button>
+      <div className="op-home-portrait-rail" ref={railRef}>
+        <div className="op-home-portrait-track" ref={trackRef}>
+          {children}
+        </div>
+      </div>
+      <button
+        aria-label="Next portraits"
+        className="op-home-portrait-nav is-next"
+        onClick={() => moveRail(1)}
+        type="button"
+      >
+        <RailArrow direction="next" />
+      </button>
+    </div>
+  );
+}
+
+function RailArrow({
+  direction,
+}: {
+  readonly direction: "next" | "prev";
+}): React.ReactElement {
+  const path =
+    direction === "next" ? "M7 4 L13 10 L7 16" : "M13 4 L7 10 L13 16";
+
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="20"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d={path}
+        stroke="currentColor"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { unitTileCount } from "@one-portrait/shared";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { demoUnitId } from "../lib/demo";
@@ -102,6 +102,40 @@ describe("HomePage", () => {
       name: /participation history/i,
     });
     expect(link.getAttribute("href")).toBe("/gallery");
+  });
+
+  it("lets users move the portrait rail one card at a time", async () => {
+    getActiveHomeUnitsMock.mockResolvedValue([]);
+    const originalScrollBy = HTMLElement.prototype.scrollBy;
+    const scrollByMock = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollBy", {
+      configurable: true,
+      value: scrollByMock,
+    });
+
+    try {
+      const ui = await HomePage();
+      render(ui);
+
+      fireEvent.click(screen.getByRole("button", { name: "Next portraits" }));
+      expect(scrollByMock).toHaveBeenLastCalledWith({
+        behavior: "smooth",
+        left: 266,
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Previous portraits" }),
+      );
+      expect(scrollByMock).toHaveBeenLastCalledWith({
+        behavior: "smooth",
+        left: -266,
+      });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollBy", {
+        configurable: true,
+        value: originalScrollBy,
+      });
+    }
   });
 
   it("links live portrait menu cards to the upload page", async () => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   HomeScrollMotion,
   HomeSubmitSection,
 } from "./home-experience";
+import { HomePortraitRail } from "./home-portrait-rail";
 
 const mosaicAspectRatio = `${unitTileGrid.cols} / ${unitTileGrid.rows}`;
 
@@ -195,13 +196,11 @@ export default async function HomePage(
             one photo, and become part of the final reveal.
           </p>
         </div>
-        <div className="op-home-portrait-rail">
-          <div className="op-home-portrait-track">
-            {portraitWorkRail.map((work) => (
-              <PortraitWorkCard key={work.railId} work={work} />
-            ))}
-          </div>
-        </div>
+        <HomePortraitRail>
+          {portraitWorkRail.map((work) => (
+            <PortraitWorkCard key={work.railId} work={work} />
+          ))}
+        </HomePortraitRail>
       </section>
 
       <HomeSubmitSection />


### PR DESCRIPTION
## 概要
ホームのポートレートレールに左右の小さな矢印ボタンを追加し、ユーザーが任意にカード1枚ぶん前後へ移動できるようにします。既存の横流れ演出は維持し、ユーザー操作後は短時間だけ自動スクロールを一時停止します。

## 変更内容
- `apps/web/src/app/home-portrait-rail.tsx`
  - 自動スクロールと左右矢印操作を担うクライアントコンポーネントを追加
  - reduced motion では自動移動を停止し、矢印操作だけ有効化
- `apps/web/src/app/page.tsx`
  - 既存のポートレートカード列を新しいレールコンポーネントでラップ
- `apps/web/src/app/globals.css`
  - 小さい矢印ボタン、スクロール可能なレール、モバイル表示を追加調整
- `apps/web/src/app/page.test.tsx`
  - 矢印クリックでカード1枚ぶん前後へスクロールすることを検証

## 関連する Issue やチケット
なし

## 動作確認
- `pnpm --filter web exec vitest run src/app/page.test.tsx`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm --filter web test`
- `curl -I http://localhost:3000` -> `200 OK`
