### PR TITLE
fix: ホームポートレートレールの自動移動を維持する

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -491,9 +491,14 @@ a {
 
 .op-home-portrait-rail-shell {
   position: relative;
+  width: 100%;
+  max-width: 100vw;
+  min-width: 0;
 }
 
 .op-home-portrait-rail {
+  width: 100%;
+  min-width: 0;
   overflow: hidden;
   overflow-x: auto;
   overflow-y: hidden;

--- a/apps/web/src/app/home-portrait-rail.tsx
+++ b/apps/web/src/app/home-portrait-rail.tsx
@@ -3,7 +3,6 @@
 import { type ReactNode, useCallback, useEffect, useRef } from "react";
 
 const fallbackCardStepPx = 266;
-const manualPauseMs = 3200;
 const loopDurationMs = 48000;
 
 export function HomePortraitRail({
@@ -13,7 +12,6 @@ export function HomePortraitRail({
 }): React.ReactElement {
   const railRef = useRef<HTMLDivElement | null>(null);
   const trackRef = useRef<HTMLDivElement | null>(null);
-  const pauseUntilRef = useRef(0);
 
   const getLoopWidth = useCallback((): number => {
     const track = trackRef.current;
@@ -60,7 +58,6 @@ export function HomePortraitRail({
 
       const step = getCardStep();
       const loopWidth = getLoopWidth();
-      pauseUntilRef.current = Date.now() + manualPauseMs;
 
       if (direction < 0 && loopWidth > 0 && rail.scrollLeft <= 1) {
         rail.scrollLeft += loopWidth;
@@ -107,9 +104,6 @@ export function HomePortraitRail({
 
       const elapsed = time - lastFrameTime;
       lastFrameTime = time;
-      if (Date.now() < pauseUntilRef.current) {
-        return;
-      }
 
       const loopWidth = getLoopWidth();
       if (loopWidth <= 0) {

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -138,6 +138,74 @@ describe("HomePage", () => {
     }
   });
 
+  it("keeps autoplay active immediately after arrow navigation", async () => {
+    getActiveHomeUnitsMock.mockResolvedValue([]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-24T00:00:00.000Z"));
+
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const originalScrollBy = HTMLElement.prototype.scrollBy;
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
+    const frameCallbacks: FrameRequestCallback[] = [];
+
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    window.cancelAnimationFrame = vi.fn();
+
+    Object.defineProperty(HTMLElement.prototype, "scrollBy", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      get() {
+        return this.classList.contains("op-home-portrait-track") ? 1000 : 0;
+      },
+    });
+
+    try {
+      const ui = await HomePage();
+      render(ui);
+
+      const rail = document.querySelector<HTMLElement>(
+        ".op-home-portrait-rail",
+      );
+      expect(rail).toBeTruthy();
+      if (!rail) {
+        throw new Error("Portrait rail was not rendered");
+      }
+
+      frameCallbacks.shift()?.(1);
+      fireEvent.click(screen.getByRole("button", { name: "Next portraits" }));
+      frameCallbacks.shift()?.(17);
+
+      expect(rail.scrollLeft).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+      Object.defineProperty(HTMLElement.prototype, "scrollBy", {
+        configurable: true,
+        value: originalScrollBy,
+      });
+      if (originalScrollWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollWidth",
+          originalScrollWidth,
+        );
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollWidth");
+      }
+    }
+  });
+
   it("links live portrait menu cards to the upload page", async () => {
     getActiveHomeUnitsMock.mockResolvedValue([
       {


### PR DESCRIPTION
## 概要
ホームのポートレートレールで、矢印クリック後も自動移動が止まらないようにします。あわせて、レール幅が中身に引っ張られて右矢印が画面外へ逃げないようにします。

## 変更内容
- `apps/web/src/app/home-portrait-rail.tsx`
  - 矢印クリック後に自動スクロールを一時停止する pause 制御を削除
  - `prefers-reduced-motion` 以外では `requestAnimationFrame` による自動移動を継続
- `apps/web/src/app/globals.css`
  - レールシェルとレールを viewport 幅内に収め、左右矢印が表示されるよう調整
- `apps/web/src/app/page.test.tsx`
  - 矢印クリック直後も自動移動が継続する回帰テストを追加

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/page.test.tsx`
- `corepack pnpm --filter web lint`
- `corepack pnpm --filter web typecheck`
- Playwright headless で `http://localhost:3000` を確認
  - 自動スクロールが進むこと
  - 左右矢印が viewport 内に表示されること
  - 矢印クリック後も自動スクロールが継続すること
