### PR TITLE
fix: ホームポートレートレールのスクロール操作を安定化する

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -502,7 +502,6 @@ a {
   overflow: hidden;
   overflow-x: auto;
   overflow-y: hidden;
-  scroll-behavior: smooth;
   scrollbar-width: none;
   -ms-overflow-style: none;
   mask-image: linear-gradient(

--- a/apps/web/src/app/home-portrait-rail.tsx
+++ b/apps/web/src/app/home-portrait-rail.tsx
@@ -71,10 +71,7 @@ export function HomePortraitRail({
         rail.scrollLeft -= loopWidth;
       }
 
-      rail.scrollBy({
-        behavior: "smooth",
-        left: direction * step,
-      });
+      rail.scrollLeft += direction * step;
     },
     [getCardStep, getLoopWidth],
   );

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -107,34 +107,55 @@ describe("HomePage", () => {
   it("lets users move the portrait rail one card at a time", async () => {
     getActiveHomeUnitsMock.mockResolvedValue([]);
     const originalScrollBy = HTMLElement.prototype.scrollBy;
-    const scrollByMock = vi.fn();
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
     Object.defineProperty(HTMLElement.prototype, "scrollBy", {
       configurable: true,
-      value: scrollByMock,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      get() {
+        return this.classList.contains("op-home-portrait-track") ? 1000 : 0;
+      },
     });
 
     try {
       const ui = await HomePage();
       render(ui);
 
+      const rail = document.querySelector<HTMLElement>(
+        ".op-home-portrait-rail",
+      );
+      expect(rail).toBeTruthy();
+      if (!rail) {
+        throw new Error("Portrait rail was not rendered");
+      }
+
+      rail.scrollLeft = 10;
       fireEvent.click(screen.getByRole("button", { name: "Next portraits" }));
-      expect(scrollByMock).toHaveBeenLastCalledWith({
-        behavior: "smooth",
-        left: 266,
-      });
+      expect(rail.scrollLeft).toBe(276);
 
       fireEvent.click(
         screen.getByRole("button", { name: "Previous portraits" }),
       );
-      expect(scrollByMock).toHaveBeenLastCalledWith({
-        behavior: "smooth",
-        left: -266,
-      });
+      expect(rail.scrollLeft).toBe(10);
     } finally {
       Object.defineProperty(HTMLElement.prototype, "scrollBy", {
         configurable: true,
         value: originalScrollBy,
       });
+      if (originalScrollWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollWidth",
+          originalScrollWidth,
+        );
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollWidth");
+      }
     }
   });
 

--- a/apps/web/tests/e2e/home-smoke.spec.ts
+++ b/apps/web/tests/e2e/home-smoke.spec.ts
@@ -88,6 +88,47 @@ test.describe("home smoke", () => {
     expect(hasNoHorizontalOverflow).toBe(true);
   });
 
+  test("keeps the portrait rail autoplay and arrow controls responsive", async ({
+    page,
+  }) => {
+    await installDefaultMocks(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    await page.goto("/");
+    await page.locator("#portrait-works").scrollIntoViewIfNeeded();
+
+    const rail = page.locator(".op-home-portrait-rail");
+    await expect(rail).toBeVisible();
+
+    const autoplayBefore = await rail.evaluate((element) => element.scrollLeft);
+    await page.waitForTimeout(450);
+    const autoplayAfter = await rail.evaluate((element) => element.scrollLeft);
+    expect(autoplayAfter - autoplayBefore).toBeGreaterThan(10);
+
+    const step = await page
+      .locator(".op-home-portrait-track")
+      .evaluate((track) => {
+        const card = track.querySelector<HTMLElement>(
+          ".op-home-portrait-card, .op-home-portrait-card-link",
+        );
+        const cardWidth = card?.getBoundingClientRect().width ?? 250;
+        const gap = Number.parseFloat(getComputedStyle(track).columnGap);
+        return Math.round(cardWidth + (Number.isFinite(gap) ? gap : 0));
+      });
+
+    const beforeNext = await rail.evaluate((element) => element.scrollLeft);
+    await page.getByRole("button", { name: "Next portraits" }).click();
+    const afterNext = await rail.evaluate((element) => element.scrollLeft);
+    expect(afterNext - beforeNext).toBeGreaterThanOrEqual(step - 2);
+    expect(afterNext - beforeNext).toBeLessThanOrEqual(step + 80);
+
+    const beforePrev = await rail.evaluate((element) => element.scrollLeft);
+    await page.getByRole("button", { name: "Previous portraits" }).click();
+    const afterPrev = await rail.evaluate((element) => element.scrollLeft);
+    expect(beforePrev - afterPrev).toBeGreaterThanOrEqual(step - 80);
+    expect(beforePrev - afterPrev).toBeLessThanOrEqual(step + 2);
+  });
+
   test("keeps the waiting room readable on a mobile viewport", async ({
     page,
   }) => {


### PR DESCRIPTION
## 概要
ホームのポートレートレールで、自動移動がカクつき、左右矢印クリックがカード1枚分の移動として効いていない問題を修正します。

本番 URL を Playwright で確認したところ、`.op-home-portrait-rail` の `scroll-behavior: smooth` と `requestAnimationFrame` による `scrollLeft` 更新が干渉し、自動移動にゼロ移動フレームが多発していました。また、矢印クリック時の `scrollBy({ behavior: "smooth" })` も実質的にキャンセルされ、カード1枚分の移動になっていませんでした。

## 変更内容
- `apps/web/src/app/home-portrait-rail.tsx`
  - 矢印クリック時に native smooth scroll を使わず、`scrollLeft` をカード1枚分だけ直接更新
  - 自動移動の RAF は止めず、reduced motion 時のみ自動移動を無効化する既存挙動を維持
- `apps/web/src/app/globals.css`
  - レールの `scroll-behavior: smooth` を削除し、RAF 更新との干渉を解消
- `apps/web/src/app/page.test.tsx`
  - 矢印クリックで `scrollLeft` がカード1枚分変わることを検証
- `apps/web/tests/e2e/home-smoke.spec.ts`
  - 実ブラウザで自動移動と左右矢印操作が機能することを検証

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/page.test.tsx`
- `corepack pnpm --filter web test:e2e -- tests/e2e/home-smoke.spec.ts`
- `corepack pnpm --filter web lint`
- `corepack pnpm --filter web typecheck`
- Playwright headless でローカル画面を再計測
  - `scroll-behavior`: `auto`
  - 自動移動: 1.2秒で `105 -> 177`、ゼロ移動フレーム `0`
  - Next / Previous: どちらも `266px` 移動
