### PR TITLE
feat: リビール画面で原画像と赤枠ハイライトを見やすくする

### DIFF
--- a/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { unitTileGrid } from "@one-portrait/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RevealPanel } from "./reveal-panel";
+
+describe("RevealPanel", () => {
+  it("shows the original photo and the red tile frame by default", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl="https://example.com/original.png"
+        placement={{ x: 12, y: 34, submitter: "0xviewer", submissionNo: 42 }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: /Demo Athlete One completed mosaic/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("img", { name: /Demo Athlete One original submission/i }),
+    ).toBeTruthy();
+    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
+      `left: ${(12 / unitTileGrid.cols) * 100}%`,
+    );
+    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
+      `top: ${(34 / unitTileGrid.rows) * 100}%`,
+    );
+    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
+      `width: ${100 / unitTileGrid.cols}%`,
+    );
+    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
+      `height: ${100 / unitTileGrid.rows}%`,
+    );
+  });
+
+  it("toggles the highlight visibility", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl="https://example.com/original.png"
+        placement={{ x: 12, y: 34, submitter: "0xviewer", submissionNo: 42 }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /hide highlight/i }));
+    expect(screen.queryByTestId("placement-highlight")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /show highlight/i }));
+    expect(screen.getByTestId("placement-highlight")).toBeTruthy();
+  });
+
+  it("keeps the fallback copy when the original photo is unavailable", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl={null}
+        placement={{ x: 12, y: 34, submitter: "0xviewer", submissionNo: 42 }}
+      />,
+    );
+
+    expect(screen.getByText(/Original photo unavailable/i)).toBeTruthy();
+    expect(
+      screen.getByText(/Your Kakera is highlighted at \(12, 34\) as #42\./i),
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
@@ -21,20 +21,22 @@ describe("RevealPanel", () => {
       screen.getByRole("img", { name: /Demo Athlete One completed mosaic/i }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("img", { name: /Demo Athlete One original submission/i }),
+      screen.getByRole("img", {
+        name: /Demo Athlete One original submission/i,
+      }),
     ).toBeTruthy();
-    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
-      `left: ${(12 / unitTileGrid.cols) * 100}%`,
-    );
-    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
-      `top: ${(34 / unitTileGrid.rows) * 100}%`,
-    );
-    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
-      `width: ${100 / unitTileGrid.cols}%`,
-    );
-    expect(screen.getByTestId("placement-highlight").getAttribute("style")).toContain(
-      `height: ${100 / unitTileGrid.rows}%`,
-    );
+    expect(
+      screen.getByTestId("placement-highlight").getAttribute("style"),
+    ).toContain(`left: ${(12 / unitTileGrid.cols) * 100}%`);
+    expect(
+      screen.getByTestId("placement-highlight").getAttribute("style"),
+    ).toContain(`top: ${(34 / unitTileGrid.rows) * 100}%`);
+    expect(
+      screen.getByTestId("placement-highlight").getAttribute("style"),
+    ).toContain(`width: ${100 / unitTileGrid.cols}%`);
+    expect(
+      screen.getByTestId("placement-highlight").getAttribute("style"),
+    ).toContain(`height: ${100 / unitTileGrid.rows}%`);
   });
 
   it("toggles the highlight visibility", () => {

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -6,12 +6,14 @@ import type { MasterPlacementView } from "../../../lib/sui";
 type RevealPanelProps = {
   readonly displayName: string;
   readonly mosaicUrl: string;
+  readonly originalPhotoUrl?: string | null;
   readonly placement: MasterPlacementView | null;
 };
 
 export function RevealPanel({
   displayName,
   mosaicUrl,
+  originalPhotoUrl: _originalPhotoUrl,
   placement,
 }: RevealPanelProps): React.ReactElement {
   return (

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { unitTileGrid } from "@one-portrait/shared";
+import { useState } from "react";
 import type { MasterPlacementView } from "../../../lib/sui";
 
 type RevealPanelProps = {
@@ -13,9 +14,13 @@ type RevealPanelProps = {
 export function RevealPanel({
   displayName,
   mosaicUrl,
-  originalPhotoUrl: _originalPhotoUrl,
+  originalPhotoUrl,
   placement,
 }: RevealPanelProps): React.ReactElement {
+  const [highlightVisible, setHighlightVisible] = useState(true);
+  const hasPlacement = placement !== null;
+  const highlightLabel = highlightVisible ? "Hide highlight" : "Show highlight";
+
   return (
     <section
       className="mt-8 grid gap-5 border border-[var(--rule-strong)] bg-[rgba(10,6,4,0.85)] p-5 text-left"
@@ -36,42 +41,91 @@ export function RevealPanel({
         </div>
       </div>
 
-      <div
-        className="op-reveal-surface relative"
-        style={{
-          aspectRatio: `${unitTileGrid.cols} / ${unitTileGrid.rows}`,
-        }}
-      >
-        {/* biome-ignore lint: remote Walrus aggregator image, next/image not configured for it yet. */}
-        <img
-          alt={`${displayName} completed mosaic`}
-          className="block h-full w-full object-cover"
-          data-testid="reveal-image"
-          src={mosaicUrl}
-        />
-
-        {placement ? (
-          <div
-            className="pointer-events-none absolute h-6 w-6 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-[var(--fire-1)] bg-[rgba(255,209,102,0.25)] shadow-[0_0_0_9999px_rgba(2,6,23,0.12)]"
-            data-testid="placement-highlight"
-            style={{
-              left: `${((placement.x + 0.5) / unitTileGrid.cols) * 100}%`,
-              top: `${((placement.y + 0.5) / unitTileGrid.rows) * 100}%`,
-            }}
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.85fr)] lg:items-start">
+        <div
+          className="op-reveal-surface relative overflow-hidden border border-[var(--rule)] bg-[rgba(0,0,0,0.12)]"
+          style={{
+            aspectRatio: `${unitTileGrid.cols} / ${unitTileGrid.rows}`,
+          }}
+        >
+          {/* biome-ignore lint: remote Walrus aggregator image, next/image not configured for it yet. */}
+          <img
+            alt={`${displayName} completed mosaic`}
+            className="block h-full w-full object-cover"
+            data-testid="reveal-image"
+            src={mosaicUrl}
           />
-        ) : null}
-      </div>
 
-      {placement ? (
-        <p className="font-serif-display italic text-[15px] text-[var(--ink)]">
-          Your Kakera is highlighted at ({placement.x}, {placement.y}) as #
-          {placement.submissionNo}.
-        </p>
-      ) : (
-        <p className="font-serif-display italic text-[15px] text-[var(--ink-dim)]">
-          The completed mosaic is ready.
-        </p>
-      )}
+          {placement && highlightVisible ? (
+            <div
+              className="pointer-events-none absolute box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
+              data-testid="placement-highlight"
+              style={{
+                left: `${(placement.x / unitTileGrid.cols) * 100}%`,
+                top: `${(placement.y / unitTileGrid.rows) * 100}%`,
+                width: `${100 / unitTileGrid.cols}%`,
+                height: `${100 / unitTileGrid.rows}%`,
+              }}
+            />
+          ) : null}
+        </div>
+
+        <aside className="grid gap-4">
+          <section className="grid gap-2 border border-[var(--rule)] bg-[rgba(245,239,227,0.04)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
+                Your photo
+              </p>
+              {hasPlacement ? (
+                <button
+                  className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ember)] hover:text-[var(--ink)]"
+                  aria-pressed={highlightVisible}
+                  onClick={() => setHighlightVisible((current) => !current)}
+                  type="button"
+                >
+                  {highlightLabel}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="overflow-hidden border border-[var(--rule-strong)] bg-[rgba(0,0,0,0.2)]">
+              {originalPhotoUrl ? (
+                // biome-ignore lint: remote Walrus aggregator image, next/image not configured for it yet.
+                <img
+                  alt={`${displayName} original submission`}
+                  className="block aspect-[4/3] w-full object-cover"
+                  src={originalPhotoUrl}
+                />
+              ) : (
+                <div className="flex aspect-[4/3] items-center justify-center p-6 text-center font-serif-display italic text-[15px] text-[var(--ink-dim)]">
+                  Original photo unavailable
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="grid gap-2 border border-[var(--rule)] bg-[rgba(245,239,227,0.03)] p-4">
+            <p className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
+              Placement
+            </p>
+            {placement ? (
+              <p className="font-serif-display italic text-[15px] text-[var(--ink)]">
+                Your Kakera is highlighted at ({placement.x}, {placement.y})
+                as #{placement.submissionNo}.
+              </p>
+            ) : (
+              <p className="font-serif-display italic text-[15px] text-[var(--ink-dim)]">
+                The completed mosaic is ready.
+              </p>
+            )}
+            {hasPlacement ? (
+              <p className="font-mono-op text-[11px] uppercase tracking-[0.12em] text-[var(--ink-dim)]">
+                Toggle the red frame when you want only the full mosaic.
+              </p>
+            ) : null}
+          </section>
+        </aside>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -110,8 +110,8 @@ export function RevealPanel({
             </p>
             {placement ? (
               <p className="font-serif-display italic text-[15px] text-[var(--ink)]">
-                Your Kakera is highlighted at ({placement.x}, {placement.y})
-                as #{placement.submissionNo}.
+                Your Kakera is highlighted at ({placement.x}, {placement.y}) as
+                #{placement.submissionNo}.
               </p>
             ) : (
               <p className="font-serif-display italic text-[15px] text-[var(--ink-dim)]">

--- a/apps/web/src/app/units/[unitId]/unit-reveal-client.original-photo.test.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-reveal-client.original-photo.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+
+import { unitTileCount } from "@one-portrait/shared";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GalleryEntryView, OwnedKakera } from "../../../lib/sui";
+
+const {
+  useEnokiConfigStateMock,
+  useCurrentAccountMock,
+  findOwnedKakeraForUnitMock,
+  getGalleryEntryMock,
+  getMasterPlacementMock,
+  getSuiClientMock,
+  revealPanelMock,
+} = vi.hoisted(() => ({
+  useEnokiConfigStateMock: vi.fn(),
+  useCurrentAccountMock: vi.fn(),
+  findOwnedKakeraForUnitMock: vi.fn(),
+  getGalleryEntryMock: vi.fn(),
+  getMasterPlacementMock: vi.fn(),
+  getSuiClientMock: vi.fn(),
+  revealPanelMock: vi.fn(),
+}));
+
+vi.mock("../../../lib/enoki/provider", () => ({
+  useEnokiConfigState: () => useEnokiConfigStateMock(),
+}));
+
+vi.mock("@mysten/dapp-kit", () => ({
+  useCurrentAccount: () => useCurrentAccountMock(),
+}));
+
+vi.mock("../../../lib/sui", () => ({
+  findOwnedKakeraForUnit: findOwnedKakeraForUnitMock,
+  getGalleryEntry: getGalleryEntryMock,
+  getMasterPlacement: getMasterPlacementMock,
+  getSuiClient: getSuiClientMock,
+}));
+
+vi.mock("./reveal-panel", () => ({
+  RevealPanel: ({
+    displayName,
+    mosaicUrl,
+    originalPhotoUrl,
+  }: {
+    readonly displayName: string;
+    readonly mosaicUrl: string;
+    readonly originalPhotoUrl?: string | null;
+  }) => {
+    revealPanelMock({ displayName, mosaicUrl, originalPhotoUrl });
+    return <div data-testid="reveal-panel" />;
+  },
+}));
+
+vi.mock("./live-progress", () => ({
+  LiveProgress: () => <div data-testid="live-progress" />,
+}));
+
+import { UnitRevealClient } from "./unit-reveal-client";
+
+const AGGREGATOR_BASE = "https://aggregator.example.com";
+
+function completedEntry(
+  overrides: Partial<
+    Extract<GalleryEntryView, { status: { kind: "completed" } }>
+  > = {},
+): Extract<GalleryEntryView, { status: { kind: "completed" } }> {
+  return {
+    unitId: "0xunit-1",
+    displayName: "Demo Athlete One",
+    walrusBlobId: "walrus-blob-1",
+    kakeraObjectId: "0xkakera-1",
+    submissionNo: 42,
+    mintedAtMs: 1700000000000,
+    masterId: "0xmaster-1",
+    mosaicWalrusBlobId: "mosaic-blob-1",
+    placement: null,
+    status: { kind: "completed" },
+    ...overrides,
+  };
+}
+
+function ownedKakera(overrides: Partial<OwnedKakera> = {}): OwnedKakera {
+  return {
+    objectId: "0xkakera-1",
+    unitId: "0xunit-1",
+    walrusBlobId: "walrus-original-1",
+    submissionNo: 42,
+    mintedAtMs: 1700000000000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useEnokiConfigStateMock.mockReturnValue({
+    submitEnabled: true,
+    walletProviderAvailable: true,
+    config: {
+      suiNetwork: "testnet",
+      packageId: "0xpkg",
+      enokiApiKey: "public-key",
+      googleClientId: "google-client-id",
+    },
+  });
+  useCurrentAccountMock.mockReturnValue({ address: "0xviewer" });
+  getSuiClientMock.mockReturnValue({ network: "testnet" });
+  findOwnedKakeraForUnitMock.mockResolvedValue(ownedKakera());
+  getGalleryEntryMock.mockResolvedValue(completedEntry());
+  getMasterPlacementMock.mockResolvedValue({
+    masterId: "0xmaster-1",
+    mosaicWalrusBlobId: "mosaic-master-blob",
+    placement: null,
+  });
+});
+
+afterEach(() => {
+  revealPanelMock.mockReset();
+  useCurrentAccountMock.mockReset();
+  findOwnedKakeraForUnitMock.mockReset();
+  getGalleryEntryMock.mockReset();
+  getMasterPlacementMock.mockReset();
+  getSuiClientMock.mockReset();
+  useEnokiConfigStateMock.mockReset();
+});
+
+describe("UnitRevealClient original photo wiring", () => {
+  it("passes the viewer original photo URL into RevealPanel", async () => {
+    render(
+      <UnitRevealClient
+        displayName="Demo Athlete One"
+        aggregatorBase={AGGREGATOR_BASE}
+        initialMasterId="0xmaster-1"
+        initialSubmittedCount={unitTileCount}
+        maxSlots={unitTileCount}
+        packageId="0xpkg"
+        unitId="0xunit-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(revealPanelMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originalPhotoUrl: `${AGGREGATOR_BASE}/v1/blobs/walrus-original-1`,
+        }),
+      );
+    });
+  });
+
+  it("keeps the original photo URL null when no owned Kakera is found", async () => {
+    findOwnedKakeraForUnitMock.mockResolvedValue(null);
+
+    render(
+      <UnitRevealClient
+        displayName="Demo Athlete One"
+        aggregatorBase={AGGREGATOR_BASE}
+        initialMasterId="0xmaster-1"
+        initialSubmittedCount={unitTileCount}
+        maxSlots={unitTileCount}
+        packageId="0xpkg"
+        unitId="0xunit-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(revealPanelMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originalPhotoUrl: null,
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/src/app/units/[unitId]/unit-reveal-client.tsx
+++ b/apps/web/src/app/units/[unitId]/unit-reveal-client.tsx
@@ -29,6 +29,7 @@ type UnitRevealClientProps = {
 type RevealState = {
   readonly masterId: string;
   readonly mosaicWalrusBlobId: string | null;
+  readonly ownedWalrusBlobId: string | null;
   readonly placement: MasterPlacementView | null;
 };
 
@@ -84,12 +85,14 @@ function UnitRevealClientCore(
       ? {
           masterId: initialMasterId,
           mosaicWalrusBlobId: null,
+          ownedWalrusBlobId: null,
           placement: null,
         }
       : null,
   );
   const revealMasterId = reveal?.masterId ?? null;
   const revealBlobId = reveal?.mosaicWalrusBlobId ?? null;
+  const revealOwnedBlobId = reveal?.ownedWalrusBlobId ?? null;
   const revealPlacement = reveal?.placement ?? null;
 
   useEffect(() => {
@@ -102,8 +105,8 @@ function UnitRevealClientCore(
     const loadReveal = async (): Promise<void> => {
       const suiClient = getSuiClient();
       let mosaicWalrusBlobId = revealBlobId;
+      let ownedWalrusBlobId = revealOwnedBlobId;
       let placement = revealPlacement;
-      let ownedWalrusBlobId: string | null = null;
 
       if (currentAccountAddress && packageId) {
         try {
@@ -166,6 +169,7 @@ function UnitRevealClientCore(
 
         if (
           current.mosaicWalrusBlobId === mosaicWalrusBlobId &&
+          current.ownedWalrusBlobId === ownedWalrusBlobId &&
           samePlacement(current.placement, placement)
         ) {
           return current;
@@ -174,6 +178,7 @@ function UnitRevealClientCore(
         return {
           masterId: current.masterId,
           mosaicWalrusBlobId,
+          ownedWalrusBlobId,
           placement,
         };
       });
@@ -189,6 +194,7 @@ function UnitRevealClientCore(
     packageId,
     revealBlobId,
     revealMasterId,
+    revealOwnedBlobId,
     revealPlacement,
     startupEnabled,
     unitId,
@@ -210,6 +216,7 @@ function UnitRevealClientCore(
           setReveal({
             masterId: event.masterId,
             mosaicWalrusBlobId: decodeByteString(event.mosaicWalrusBlobId),
+            ownedWalrusBlobId: null,
             placement: null,
           });
         }}
@@ -221,6 +228,10 @@ function UnitRevealClientCore(
         <RevealPanel
           displayName={displayName}
           mosaicUrl={mosaicUrl}
+          originalPhotoUrl={buildWalrusAggregatorUrl(
+            reveal.ownedWalrusBlobId,
+            aggregatorBase,
+          )}
           placement={reveal.placement}
         />
       ) : null}


### PR DESCRIPTION
## 概要
`/units/[unitId]` のリビール画面で、
原画像とモザイクの対応が見やすくなるようにしました。

## 変更内容
- `apps/web/src/app/units/[unitId]/unit-reveal-client.tsx`
  - owned Kakera の `walrusBlobId` を保持し、原画像 URL を渡すようにしました。
- `apps/web/src/app/units/[unitId]/reveal-panel.tsx`
  - モザイクと原画像を並べるレイアウトにしました。
  - 位置ハイライトを赤い四角枠に変更しました。
  - ハイライトの表示・非表示を切り替えられるようにしました。
- `apps/web/src/app/units/[unitId]/unit-reveal-client.original-photo.test.tsx`
  - 原画像 URL の受け渡しを確認するテストを追加しました。
- `apps/web/src/app/units/[unitId]/reveal-panel.test.tsx`
  - 初期表示、切替、fallback を確認するテストを追加しました。

## 関連する Issue やチケット
Closes #114

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/units/[unitId]/unit-reveal-client.original-photo.test.tsx src/app/units/[unitId]/unit-reveal-client.test.tsx src/app/units/[unitId]/reveal-panel.test.tsx`
- `corepack pnpm --filter web run typecheck`
- `corepack pnpm --filter web run check`
