### PR TITLE
fix: admin作成Unitを正しいportrait railカードへ反映する

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -306,6 +306,47 @@ describe("HomePage", () => {
     expect(screen.queryByText("1998 / 2000")).toBeNull();
   });
 
+  it("shows matched active entries that reached max slots as Complete in the UI guard after getActiveHomeUnits filters filled units", async () => {
+    const firstAthlete = CATALOG[0];
+    getActiveHomeUnitsMock.mockResolvedValue([
+      {
+        displayName: firstAthlete.displayName,
+        maxSlots: unitTileCount,
+        submittedCount: unitTileCount,
+        thumbnailUrl: firstAthlete.thumbnailUrl,
+        unitId: "0xunit-complete",
+      },
+    ]);
+
+    const ui = await HomePage();
+    render(ui);
+
+    const firstAthleteCards = screen
+      .getAllByRole("heading", {
+        level: 3,
+        name: firstAthlete.displayName,
+      })
+      .map((heading) => heading.closest(".op-home-portrait-card"));
+    expect(firstAthleteCards).toHaveLength(2);
+
+    for (const card of firstAthleteCards) {
+      expect(card).toBeTruthy();
+      const cardElement = card as HTMLElement;
+      expect(cardElement.getAttribute("data-complete")).toBe("true");
+      expect(cardElement.getAttribute("data-live")).toBeNull();
+      expect(cardElement.closest("a")).toBeNull();
+      expect(within(cardElement).getAllByText("Complete").length).toBe(2);
+      expect(within(cardElement).queryByText("Live")).toBeNull();
+      expect(within(cardElement).getByText("2000 / 2000")).toBeTruthy();
+    }
+
+    expect(
+      screen.queryByRole("link", {
+        name: /Demo Athlete One portrait upload page/i,
+      }),
+    ).toBeNull();
+  });
+
   it("keeps E2E degraded home card states distinct in the portrait rail", async () => {
     process.env.NEXT_PUBLIC_E2E_STUB_WALLET = "1";
 

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -228,12 +228,13 @@ describe("HomePage", () => {
   });
 
   it("links live portrait menu cards to the upload page", async () => {
+    const firstAthlete = CATALOG[0];
     getActiveHomeUnitsMock.mockResolvedValue([
       {
-        displayName: "chain-only-name",
+        displayName: firstAthlete.displayName,
         maxSlots: unitTileCount,
         submittedCount: 1999,
-        thumbnailUrl: "https://placehold.co/512x512/png?text=chain",
+        thumbnailUrl: firstAthlete.thumbnailUrl,
         unitId: "0xunit-1",
       },
     ]);
@@ -247,7 +248,6 @@ describe("HomePage", () => {
     expect(link?.getAttribute("href")).toBe(
       "/units/0xunit-1?athleteName=Demo+Athlete+One",
     );
-    expect(screen.queryByText("chain-only-name")).toBeNull();
     expect(screen.getAllByText("Live").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1999 / 2000").length).toBeGreaterThan(0);
   });
@@ -283,7 +283,7 @@ describe("HomePage", () => {
       expect(link.getAttribute("href")).toBe(
         `/units/${secondAthlete.unitId}?athleteName=Demo+Athlete+Two`,
       );
-      expect(within(link).getByText("Live")).toBeTruthy();
+      expect(within(link).getAllByText("Live").length).toBeGreaterThan(0);
       expect(within(link).getByText("37 / 2000")).toBeTruthy();
     }
 

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { unitTileCount } from "@one-portrait/shared";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { demoUnitId } from "../lib/demo";
@@ -250,6 +250,60 @@ describe("HomePage", () => {
     expect(screen.queryByText("chain-only-name")).toBeNull();
     expect(screen.getAllByText("Live").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1999 / 2000").length).toBeGreaterThan(0);
+  });
+
+  it("matches live home cards to catalog athletes without relying on chain order", async () => {
+    const secondAthlete = CATALOG[1];
+    getActiveHomeUnitsMock.mockResolvedValue([
+      {
+        displayName: secondAthlete.displayName,
+        maxSlots: unitTileCount,
+        submittedCount: 37,
+        thumbnailUrl: secondAthlete.thumbnailUrl,
+        unitId: secondAthlete.unitId,
+      },
+      {
+        displayName: "Unlisted Chain Athlete",
+        maxSlots: unitTileCount,
+        submittedCount: 1998,
+        thumbnailUrl: "https://placehold.co/512x512/png?text=unlisted",
+        unitId:
+          "0x0000000000000000000000000000000000000000000000000000000000000bad",
+      },
+    ]);
+
+    const ui = await HomePage();
+    render(ui);
+
+    const secondAthleteLinks = screen.getAllByRole("link", {
+      name: /Demo Athlete Two portrait upload page/i,
+    });
+    expect(secondAthleteLinks).toHaveLength(2);
+    for (const link of secondAthleteLinks) {
+      expect(link.getAttribute("href")).toBe(
+        `/units/${secondAthlete.unitId}?athleteName=Demo+Athlete+Two`,
+      );
+      expect(within(link).getByText("Live")).toBeTruthy();
+      expect(within(link).getByText("37 / 2000")).toBeTruthy();
+    }
+
+    const firstAthleteHeadings = screen.getAllByRole("heading", {
+      level: 3,
+      name: "Demo Athlete One",
+    });
+    expect(firstAthleteHeadings).toHaveLength(2);
+    for (const heading of firstAthleteHeadings) {
+      const card = heading.closest(".op-home-portrait-card");
+      expect(card).toBeTruthy();
+      expect(card?.getAttribute("data-live")).toBeNull();
+      expect(card?.closest("a")).toBeNull();
+      expect(within(card as HTMLElement).queryByText("Live")).toBeNull();
+      expect(within(card as HTMLElement).queryByText("37 / 2000")).toBeNull();
+      expect(within(card as HTMLElement).queryByText("1998 / 2000")).toBeNull();
+    }
+
+    expect(screen.queryByText("Unlisted Chain Athlete")).toBeNull();
+    expect(screen.queryByText("1998 / 2000")).toBeNull();
   });
 
   it("keeps E2E degraded home card states distinct in the portrait rail", async () => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -59,9 +59,13 @@ function buildPortraitWorkRail(
   catalog: readonly AthleteCatalogEntry[],
   entries: readonly HomeEntry[],
 ) {
-  const works = catalog.map((catalogEntry, index): PortraitWork => {
+  const entriesByCatalogKey = new Map(
+    entries.map((entry) => [buildPortraitCatalogKey(entry), entry]),
+  );
+
+  const works = catalog.map((catalogEntry): PortraitWork => {
     const work = toPortraitWork(catalogEntry);
-    const entry = entries[index];
+    const entry = entriesByCatalogKey.get(buildPortraitCatalogKey(work));
     if (!entry) {
       return work;
     }
@@ -97,6 +101,13 @@ function buildPortraitWorkRail(
     ...works.map((work) => ({ ...work, railId: `first-${work.slug}` })),
     ...works.map((work) => ({ ...work, railId: `second-${work.slug}` })),
   ];
+}
+
+function buildPortraitCatalogKey({
+  displayName,
+  thumbnailUrl,
+}: Pick<AthleteCatalogEntry, "displayName" | "thumbnailUrl">): string {
+  return JSON.stringify([displayName, thumbnailUrl]);
 }
 
 function toPortraitWork(entry: AthleteCatalogEntry): PortraitWork {

--- a/apps/web/src/lib/catalog/athlete-catalog.test.ts
+++ b/apps/web/src/lib/catalog/athlete-catalog.test.ts
@@ -32,6 +32,23 @@ describe("getAthleteCatalog", () => {
 
     expect(slugs.size).toBe(catalog.length);
   });
+
+  it("has unique home rail matching keys across entries", async () => {
+    const catalog = await getAthleteCatalog();
+    const seenKeys = new Set<string>();
+    const duplicateKeys: string[] = [];
+
+    for (const entry of catalog) {
+      const key = `${entry.displayName}\n${entry.thumbnailUrl}`;
+
+      if (seenKeys.has(key)) {
+        duplicateKeys.push(`${entry.displayName} (${entry.thumbnailUrl})`);
+      }
+      seenKeys.add(key);
+    }
+
+    expect(duplicateKeys).toEqual([]);
+  });
 });
 
 describe("getAthleteBySlug", () => {


### PR DESCRIPTION
## 概要
admin で作った Unit を、同じ選手カードへ出します。

これまでは catalog と Unit を順番で合わせていました。
そのため registry の順番が違うと、別の選手カードが Live になりました。

この PR では、表示名と画像 URL の組で Unit を探します。
admin 作成時に Unit へ渡す catalog 情報と同じ値を使います。

## 変更内容
- `apps/web/src/app/page.tsx`
  - portrait rail の照合を index から stable key に変更しました。
  - `displayName` と `thumbnailUrl` の組で Unit を探します。
  - catalog に一致しない Unit は rail に出しません。
  - catalog の表示順はそのまま保ちます。

- `apps/web/src/app/page.test.tsx`
  - registry の順番が catalog と違うケースを追加しました。
  - rail が 2 周分あるため、両方のカードを確認します。
  - 未一致 Unit が表示に混ざらないことを確認します。
  - 完了済み扱いの active entry がリンクなしになることを確認します。

- `apps/web/src/lib/catalog/athlete-catalog.test.ts`
  - 表示名と画像 URL の組が重複しないことを確認します。

## 関連する Issue やチケット
Close #110

## 動作確認
- `corepack pnpm --filter web test -- page.test.tsx`
  - web の Vitest 54 files / 421 tests が通過
  - node deployment tests 16 tests が通過
- `corepack pnpm --filter web exec vitest run src/lib/catalog/athlete-catalog.test.ts`
  - 1 file / 12 tests が通過
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web lint`
  - 168 files checked

## レビュー結果
- verification reviewer: blocking findings なし
