### PR TITLE
feat: モザイク位置確認に点線ガイドを追加する

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1067,6 +1067,49 @@ a {
     0 0 2px rgba(255, 122, 26, 0.6);
 }
 
+.op-placement-guide-line {
+  filter: drop-shadow(0 0 8px rgba(212, 50, 14, 0.72));
+  clip-path: inset(0 0 0 100%);
+  animation: op-placement-guide-reveal 680ms ease-out forwards;
+}
+
+.op-placement-highlight-pulse {
+  animation: op-placement-highlight-pulse 520ms ease-out 680ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .op-placement-guide-line,
+  .op-placement-highlight-pulse {
+    animation: none;
+  }
+
+  .op-placement-guide-line {
+    clip-path: inset(0);
+  }
+}
+
+@keyframes op-placement-guide-reveal {
+  to {
+    clip-path: inset(0);
+  }
+}
+
+@keyframes op-placement-highlight-pulse {
+  0% {
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+      0 0 0 0 rgba(212, 50, 14, 0.7),
+      0 0 22px rgba(212, 50, 14, 0.48);
+  }
+
+  100% {
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.12),
+      0 0 0 6px rgba(212, 50, 14, 0),
+      0 0 0 1px rgba(212, 50, 14, 0.4);
+  }
+}
+
 /* Home hero teaser */
 .op-home-teaser-panel {
   animation: op-home-teaser-float 6.4s ease-in-out infinite;

--- a/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
@@ -40,6 +40,22 @@ describe("RevealPanel", () => {
     expect(screen.getByTestId("placement-guide-line")).toBeTruthy();
   });
 
+  it("starts the placement guide replay identifier at its initial value", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl="https://example.com/original.png"
+        placement={{ x: 12, y: 34, submitter: "0xviewer", submissionNo: 42 }}
+      />,
+    );
+
+    expect(screen.getByTestId("placement-guide").dataset.replayId).toBe("0");
+    expect(screen.getByTestId("placement-highlight").dataset.replayId).toBe(
+      "0",
+    );
+  });
+
   it("toggles the highlight and guide visibility", () => {
     render(
       <RevealPanel
@@ -57,6 +73,31 @@ describe("RevealPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /show highlight/i }));
     expect(screen.getByTestId("placement-highlight")).toBeTruthy();
     expect(screen.getByTestId("placement-guide-line")).toBeTruthy();
+    expect(screen.getByTestId("placement-guide").dataset.replayId).toBe("1");
+    expect(screen.getByTestId("placement-highlight").dataset.replayId).toBe(
+      "1",
+    );
+  });
+
+  it("uses breakpoint classes to hide the guide below the two-column layout", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl="https://example.com/original.png"
+        placement={{ x: 12, y: 34, submitter: "0xviewer", submissionNo: 42 }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("placement-guide").classList.contains("hidden"),
+    ).toBe(true);
+    expect(
+      screen.getByTestId("placement-guide").classList.contains("lg:block"),
+    ).toBe(true);
+    expect(
+      screen.getByTestId("placement-guide").getAttribute("preserveAspectRatio"),
+    ).toBe("none");
   });
 
   it("does not render the highlight or guide when placement is unavailable", () => {

--- a/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { RevealPanel } from "./reveal-panel";
 
 describe("RevealPanel", () => {
-  it("shows the original photo and the red tile frame by default", () => {
+  it("shows the original photo, red tile frame, and guide line by default", () => {
     render(
       <RevealPanel
         displayName="Demo Athlete One"
@@ -37,9 +37,10 @@ describe("RevealPanel", () => {
     expect(
       screen.getByTestId("placement-highlight").getAttribute("style"),
     ).toContain(`height: ${100 / unitTileGrid.rows}%`);
+    expect(screen.getByTestId("placement-guide-line")).toBeTruthy();
   });
 
-  it("toggles the highlight visibility", () => {
+  it("toggles the highlight and guide visibility", () => {
     render(
       <RevealPanel
         displayName="Demo Athlete One"
@@ -51,9 +52,26 @@ describe("RevealPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /hide highlight/i }));
     expect(screen.queryByTestId("placement-highlight")).toBeNull();
+    expect(screen.queryByTestId("placement-guide-line")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /show highlight/i }));
     expect(screen.getByTestId("placement-highlight")).toBeTruthy();
+    expect(screen.getByTestId("placement-guide-line")).toBeTruthy();
+  });
+
+  it("does not render the highlight or guide when placement is unavailable", () => {
+    render(
+      <RevealPanel
+        displayName="Demo Athlete One"
+        mosaicUrl="https://example.com/mosaic.png"
+        originalPhotoUrl={null}
+        placement={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("placement-highlight")).toBeNull();
+    expect(screen.queryByTestId("placement-guide-line")).toBeNull();
+    expect(screen.getByText(/Original photo unavailable/i)).toBeTruthy();
   });
 
   it("keeps the fallback copy when the original photo is unavailable", () => {

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -57,16 +57,32 @@ export function RevealPanel({
           />
 
           {placement && highlightVisible ? (
-            <div
-              className="pointer-events-none absolute box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
-              data-testid="placement-highlight"
-              style={{
-                left: `${(placement.x / unitTileGrid.cols) * 100}%`,
-                top: `${(placement.y / unitTileGrid.rows) * 100}%`,
-                width: `${100 / unitTileGrid.cols}%`,
-                height: `${100 / unitTileGrid.rows}%`,
-              }}
-            />
+            <>
+              <svg
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 h-full w-full"
+                data-testid="placement-guide-line"
+                viewBox="0 0 100 100"
+              >
+                <path
+                  d="M 8 92 L 92 8"
+                  fill="none"
+                  stroke="var(--ember)"
+                  strokeDasharray="4 4"
+                  strokeWidth="1.5"
+                />
+              </svg>
+              <div
+                className="pointer-events-none absolute box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
+                data-testid="placement-highlight"
+                style={{
+                  left: `${(placement.x / unitTileGrid.cols) * 100}%`,
+                  top: `${(placement.y / unitTileGrid.rows) * 100}%`,
+                  width: `${100 / unitTileGrid.cols}%`,
+                  height: `${100 / unitTileGrid.rows}%`,
+                }}
+              />
+            </>
           ) : null}
         </div>
 

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -18,8 +18,18 @@ export function RevealPanel({
   placement,
 }: RevealPanelProps): React.ReactElement {
   const [highlightVisible, setHighlightVisible] = useState(true);
+  const [highlightReplayId, setHighlightReplayId] = useState(0);
   const hasPlacement = placement !== null;
   const highlightLabel = highlightVisible ? "Hide highlight" : "Show highlight";
+  const mosaicWidth = 58;
+  const guideStartX = 82;
+  const guideStartY = 38;
+  const guideEndX = placement
+    ? ((placement.x + 0.5) / unitTileGrid.cols) * mosaicWidth
+    : 0;
+  const guideEndY = placement
+    ? ((placement.y + 0.5) / unitTileGrid.rows) * 100
+    : 0;
 
   return (
     <section
@@ -41,7 +51,7 @@ export function RevealPanel({
         </div>
       </div>
 
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.85fr)] lg:items-start">
+      <div className="relative grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.85fr)] lg:items-start">
         <div
           className="op-reveal-surface relative overflow-hidden border border-[var(--rule)] bg-[rgba(0,0,0,0.12)]"
           style={{
@@ -57,36 +67,45 @@ export function RevealPanel({
           />
 
           {placement && highlightVisible ? (
-            <>
-              <svg
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0 h-full w-full"
-                data-testid="placement-guide-line"
-                viewBox="0 0 100 100"
-              >
-                <path
-                  d="M 8 92 L 92 8"
-                  fill="none"
-                  stroke="var(--ember)"
-                  strokeDasharray="4 4"
-                  strokeWidth="1.5"
-                />
-              </svg>
-              <div
-                className="pointer-events-none absolute box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
-                data-testid="placement-highlight"
-                style={{
-                  left: `${(placement.x / unitTileGrid.cols) * 100}%`,
-                  top: `${(placement.y / unitTileGrid.rows) * 100}%`,
-                  width: `${100 / unitTileGrid.cols}%`,
-                  height: `${100 / unitTileGrid.rows}%`,
-                }}
-              />
-            </>
+            <div
+              className="op-placement-highlight-pulse pointer-events-none absolute z-10 box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
+              data-replay-id={highlightReplayId}
+              data-testid="placement-highlight"
+              style={{
+                left: `${(placement.x / unitTileGrid.cols) * 100}%`,
+                top: `${(placement.y / unitTileGrid.rows) * 100}%`,
+                width: `${100 / unitTileGrid.cols}%`,
+                height: `${100 / unitTileGrid.rows}%`,
+              }}
+            />
           ) : null}
         </div>
 
-        <aside className="grid gap-4">
+        {placement && highlightVisible ? (
+          <svg
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 z-[1] hidden h-full w-full lg:block"
+            data-replay-id={highlightReplayId}
+            data-testid="placement-guide"
+            preserveAspectRatio="none"
+            viewBox="0 0 100 100"
+          >
+            <path
+              className="op-placement-guide-line"
+              d={`M ${guideStartX} ${guideStartY} L ${guideEndX} ${guideEndY}`}
+              data-testid="placement-guide-line"
+              fill="none"
+              pathLength={1}
+              stroke="var(--ember)"
+              strokeDasharray="0.04 0.035"
+              strokeLinecap="round"
+              strokeWidth="0.7"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        ) : null}
+
+        <aside className="relative grid gap-4">
           <section className="grid gap-2 border border-[var(--rule)] bg-[rgba(245,239,227,0.04)] p-4">
             <div className="flex items-center justify-between gap-3">
               <p className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
@@ -96,7 +115,14 @@ export function RevealPanel({
                 <button
                   className="font-mono-op text-[10px] uppercase tracking-[0.14em] text-[var(--ember)] hover:text-[var(--ink)]"
                   aria-pressed={highlightVisible}
-                  onClick={() => setHighlightVisible((current) => !current)}
+                  onClick={() => {
+                    setHighlightVisible((current) => {
+                      if (!current) {
+                        setHighlightReplayId((replayId) => replayId + 1);
+                      }
+                      return !current;
+                    });
+                  }}
                   type="button"
                 >
                   {highlightLabel}


### PR DESCRIPTION
## 概要
完成モザイクの位置確認ビューで、元写真と赤枠の関係を見やすくしました。

元写真側から赤枠へ向かう点線を追加します。
`Show highlight` で再表示した時も、線と赤枠の演出を再生します。

## 変更内容
- `apps/web/src/app/units/[unitId]/reveal-panel.tsx`
  - 元写真側から赤枠へ向かう SVG の点線を追加しました。
  - `placement.x/y` から赤枠中心を計算します。
  - `Hide highlight` では点線も非表示にします。
  - `Show highlight` では演出を再実行します。
  - `lg` 未満では点線を隠し、縦積み表示を守ります。
- `apps/web/src/app/globals.css`
  - 点線が写真側から出るアニメーションを追加しました。
  - 点線の後に赤枠を短く強調します。
  - reduced motion では動きを止め、静的に表示します。
- `apps/web/src/app/units/[unitId]/reveal-panel.test.tsx`
  - 点線の表示、非表示、再表示をテストしました。
  - placement なしと元写真 fallback の回帰を確認しました。

## 関連する Issue やチケット
Close #117

## 動作確認
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web test -- reveal-panel.test.tsx`
- `pnpm --filter web test:e2e -- tests/e2e/gallery-states.spec.ts`
- desktop 表示で、点線が赤枠まで届くことを確認しました。
- mobile 表示で、点線が隠れて本文を覆わないことを確認しました。
- reduced motion で、点線と赤枠が静的に表示されることを確認しました。
