### PR TITLE
fix: 位置確認ガイドを緑の強調表示にする

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1068,9 +1068,19 @@ a {
 }
 
 .op-placement-guide-line {
-  filter: drop-shadow(0 0 8px rgba(212, 50, 14, 0.72));
+  filter: drop-shadow(0 0 10px rgba(20, 184, 138, 0.78));
   clip-path: inset(0 0 0 100%);
   animation: op-placement-guide-reveal 680ms ease-out forwards;
+}
+
+.op-placement-highlight-frame {
+  border: 2px solid rgba(160, 238, 211, 0.96);
+  background: rgba(20, 184, 138, 0.18);
+  box-shadow:
+    inset 0 0 0 1px rgba(245, 239, 227, 0.14),
+    0 0 0 1px rgba(160, 238, 211, 0.32),
+    0 0 24px rgba(20, 184, 138, 0.72),
+    0 0 90px -42px rgba(20, 184, 138, 0.82);
 }
 
 .op-placement-highlight-pulse {
@@ -1098,15 +1108,18 @@ a {
   0% {
     box-shadow:
       inset 0 0 0 1px rgba(255, 255, 255, 0.16),
-      0 0 0 0 rgba(212, 50, 14, 0.7),
-      0 0 22px rgba(212, 50, 14, 0.48);
+      0 0 0 0 rgba(160, 238, 211, 0.7),
+      0 0 32px rgba(20, 184, 138, 0.88),
+      0 0 90px -42px rgba(20, 184, 138, 0.82);
   }
 
   100% {
     box-shadow:
-      inset 0 0 0 1px rgba(255, 255, 255, 0.12),
-      0 0 0 6px rgba(212, 50, 14, 0),
-      0 0 0 1px rgba(212, 50, 14, 0.4);
+      inset 0 0 0 1px rgba(245, 239, 227, 0.14),
+      0 0 0 7px rgba(160, 238, 211, 0),
+      0 0 0 1px rgba(160, 238, 211, 0.32),
+      0 0 24px rgba(20, 184, 138, 0.72),
+      0 0 90px -42px rgba(20, 184, 138, 0.82);
   }
 }
 

--- a/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { RevealPanel } from "./reveal-panel";
 
 describe("RevealPanel", () => {
-  it("shows the original photo, red tile frame, and guide line by default", () => {
+  it("shows the original photo, tile highlight, and guide line by default", () => {
     render(
       <RevealPanel
         displayName="Demo Athlete One"
@@ -37,6 +37,17 @@ describe("RevealPanel", () => {
     expect(
       screen.getByTestId("placement-highlight").getAttribute("style"),
     ).toContain(`height: ${100 / unitTileGrid.rows}%`);
+    expect(
+      screen
+        .getByTestId("placement-highlight")
+        .classList.contains("op-placement-highlight-frame"),
+    ).toBe(true);
+    expect(
+      screen.getByTestId("placement-guide-line").getAttribute("stroke"),
+    ).toBe("var(--ok)");
+    expect(
+      screen.getByTestId("placement-guide-line").getAttribute("stroke-width"),
+    ).toBe("1.35");
     expect(screen.getByTestId("placement-guide-line")).toBeTruthy();
   });
 

--- a/apps/web/src/app/units/[unitId]/reveal-panel.tsx
+++ b/apps/web/src/app/units/[unitId]/reveal-panel.tsx
@@ -68,7 +68,7 @@ export function RevealPanel({
 
           {placement && highlightVisible ? (
             <div
-              className="op-placement-highlight-pulse pointer-events-none absolute z-10 box-border border-[2px] border-[var(--ember)] bg-[rgba(212,50,14,0.12)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12),0_0_0_1px_rgba(212,50,14,0.4)]"
+              className="op-placement-highlight-frame op-placement-highlight-pulse pointer-events-none absolute z-10 box-border"
               data-replay-id={highlightReplayId}
               data-testid="placement-highlight"
               style={{
@@ -96,10 +96,10 @@ export function RevealPanel({
               data-testid="placement-guide-line"
               fill="none"
               pathLength={1}
-              stroke="var(--ember)"
+              stroke="var(--ok)"
               strokeDasharray="0.04 0.035"
               strokeLinecap="round"
-              strokeWidth="0.7"
+              strokeWidth="1.35"
               vectorEffect="non-scaling-stroke"
             />
           </svg>


### PR DESCRIPTION
## 概要
位置確認ビューの強調表示を見やすくしました。

オレンジの赤枠を、demo の選手強調に近い緑の glow に変更します。
点線も緑にそろえ、線幅を太くしました。

## 変更内容
- `apps/web/src/app/units/[unitId]/reveal-panel.tsx`
  - 赤枠の強調表示を緑の glow class に切り替えました。
  - 点線ガイドの色を緑にしました。
  - 点線ガイドの線幅を太くしました。
- `apps/web/src/app/globals.css`
  - 緑の glow と box-shadow を追加しました。
  - pulse 演出も緑系に変更しました。
- `apps/web/src/app/units/[unitId]/reveal-panel.test.tsx`
  - 強調 class と点線の色、太さを確認します。

## 関連する Issue やチケット
Follow-up #117

## 動作確認
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web test -- reveal-panel.test.tsx`
- `pnpm --filter web test:e2e -- tests/e2e/gallery-states.spec.ts`
- desktop visual check で緑 glow と太い点線を確認しました。
