### PR TITLE
fix: 完了済みポートレートをホームで強調表示する

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -306,13 +306,14 @@ describe("HomePage", () => {
     expect(screen.queryByText("1998 / 2000")).toBeNull();
   });
 
-  it("shows matched active entries that reached max slots as Complete in the UI guard after getActiveHomeUnits filters filled units", async () => {
+  it("shows matched completed entries as Complete when chain lifecycle is complete", async () => {
     const firstAthlete = CATALOG[0];
     getActiveHomeUnitsMock.mockResolvedValue([
       {
         displayName: firstAthlete.displayName,
+        lifecycleState: "complete",
         maxSlots: unitTileCount,
-        submittedCount: unitTileCount,
+        submittedCount: 347,
         thumbnailUrl: firstAthlete.thumbnailUrl,
         unitId: "0xunit-complete",
       },
@@ -337,7 +338,7 @@ describe("HomePage", () => {
       expect(cardElement.closest("a")).toBeNull();
       expect(within(cardElement).getAllByText("Complete").length).toBe(2);
       expect(within(cardElement).queryByText("Live")).toBeNull();
-      expect(within(cardElement).getByText("2000 / 2000")).toBeTruthy();
+      expect(within(cardElement).getByText("347 / 2000")).toBeTruthy();
     }
 
     expect(

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -30,6 +30,7 @@ type HomeEntry = {
   readonly progress:
     | {
         readonly kind: "active";
+        readonly lifecycleState: "complete" | "live";
         readonly maxSlots: number;
         readonly submittedCount: number;
         readonly unitId: string;
@@ -72,7 +73,8 @@ function buildPortraitWorkRail(
 
     const isComplete =
       entry.progress.kind === "active" &&
-      entry.progress.submittedCount >= entry.progress.maxSlots;
+      (entry.progress.lifecycleState === "complete" ||
+        entry.progress.submittedCount >= entry.progress.maxSlots);
     const progressLabel =
       entry.progress.kind === "active"
         ? `${formatProgressCount(entry.progress.submittedCount)} / ${formatProgressCount(entry.progress.maxSlots)}`
@@ -375,6 +377,7 @@ async function loadChainEntries(): Promise<readonly HomeEntry[]> {
       thumbnailUrl: unit.thumbnailUrl,
       progress: {
         kind: "active" as const,
+        lifecycleState: unit.lifecycleState,
         maxSlots: unit.maxSlots,
         submittedCount: unit.submittedCount,
         unitId: unit.unitId,
@@ -430,6 +433,10 @@ async function loadDemoEntries(
       unitId,
       progress: {
         kind: "active",
+        lifecycleState:
+          progress.status === "pending" && progress.masterId === null
+            ? "live"
+            : "complete",
         maxSlots: progress.maxSlots,
         submittedCount: progress.submittedCount,
         unitId,

--- a/apps/web/src/lib/sui/registry.test.ts
+++ b/apps/web/src/lib/sui/registry.test.ts
@@ -143,6 +143,7 @@ describe("getActiveHomeUnits", () => {
     ).resolves.toEqual([
       {
         displayName: "Latest Deployment Athlete",
+        lifecycleState: "live",
         maxSlots: 2000,
         submittedCount: 0,
         thumbnailUrl: "https://example.com/1.png",
@@ -152,7 +153,7 @@ describe("getActiveHomeUnits", () => {
     expect(calls).toEqual([REGISTRY_ID, UNIT_ONE]);
   });
 
-  it("returns only pending units from the registry index", async () => {
+  it("returns live and completed units from the registry index", async () => {
     const client = makeClient({
       getObject: vi.fn(async ({ id }) => {
         if (id === REGISTRY_ID) {
@@ -188,6 +189,14 @@ describe("getActiveHomeUnits", () => {
         submittedCount: 1997,
         thumbnailUrl: "https://example.com/1.png",
         unitId: UNIT_ONE,
+      },
+      {
+        displayName: "Demo Athlete Two",
+        lifecycleState: "complete",
+        maxSlots: 2000,
+        submittedCount: 0,
+        thumbnailUrl: "https://example.com/2.png",
+        unitId: UNIT_TWO,
       },
     ]);
   });

--- a/apps/web/src/lib/sui/registry.test.ts
+++ b/apps/web/src/lib/sui/registry.test.ts
@@ -183,8 +183,42 @@ describe("getActiveHomeUnits", () => {
     ).resolves.toEqual([
       {
         displayName: "Demo Athlete One",
+        lifecycleState: "live",
         maxSlots: 2000,
         submittedCount: 1997,
+        thumbnailUrl: "https://example.com/1.png",
+        unitId: UNIT_ONE,
+      },
+    ]);
+  });
+
+  it("returns finalized units as completed home entries", async () => {
+    const client = makeClient({
+      getObject: vi.fn(async ({ id }) => {
+        if (id === REGISTRY_ID) {
+          return { data: registryObject({ unit_ids: [UNIT_ONE] }) };
+        }
+        if (id === UNIT_ONE) {
+          return {
+            data: unitObject(UNIT_ONE, 1, "Demo Athlete One", {
+              status: 2,
+              master_id: { fields: { vec: ["0xmaster"] } },
+              submissions: submissionList(347),
+            }),
+          };
+        }
+        throw new Error(`unexpected id ${id}`);
+      }) as unknown as SuiReadClient["getObject"],
+    });
+
+    await expect(
+      getActiveHomeUnits({ client, registryObjectId: REGISTRY_ID }),
+    ).resolves.toEqual([
+      {
+        displayName: "Demo Athlete One",
+        lifecycleState: "complete",
+        maxSlots: 2000,
+        submittedCount: 347,
         thumbnailUrl: "https://example.com/1.png",
         unitId: UNIT_ONE,
       },

--- a/apps/web/src/lib/sui/registry.ts
+++ b/apps/web/src/lib/sui/registry.ts
@@ -96,12 +96,14 @@ export async function getActiveHomeUnits(
     registry.unitIds.map(async (unitId) => {
       try {
         const unit = await getUnitProgress(unitId, { client });
-        if (unit.status !== "pending" || unit.masterId !== null) {
-          return null;
-        }
+        const lifecycleState =
+          unit.status === "pending" && unit.masterId === null
+            ? "live"
+            : "complete";
 
         return {
           displayName: unit.displayName,
+          lifecycleState,
           maxSlots: unit.maxSlots,
           submittedCount: unit.submittedCount,
           thumbnailUrl: unit.thumbnailUrl,

--- a/apps/web/src/lib/sui/types.ts
+++ b/apps/web/src/lib/sui/types.ts
@@ -16,6 +16,7 @@ export type RegistryAthleteView = {
 
 export type ActiveHomeUnitView = {
   readonly displayName: string;
+  readonly lifecycleState: "complete" | "live";
   readonly maxSlots: number;
   readonly submittedCount: number;
   readonly thumbnailUrl: string;


### PR DESCRIPTION
## 概要
ホームの横流れポートレートカードで、オンチェーン上で完了済みの unit も既存の緑色系 `Complete` ハイライトで表示されるようにしました。
加えて、完了済みカードもクリック可能にして、既存の Unit ページから完成モザイクを見られる導線へつなぎました。

## 変更内容
- `apps/web/src/lib/sui`
  - ホーム用 unit view に `lifecycleState` を追加
  - `pending` は `live`、`filled` / `finalized` / `masterId` ありは `complete` として返すように変更
- `apps/web/src/app/page.tsx`
  - `lifecycleState: "complete"` を既存の `is-complete` 表示へ接続
  - 完了カードも `/units/[unitId]` へリンクし、Unit ページの完成モザイク表示へ遷移できるように変更
  - リンクの aria-label を live / complete 共通の `portrait page` に変更
- `apps/web/src/app/page.test.tsx`, `apps/web/src/lib/sui/registry.test.ts`
  - 完了済み unit がホームに残り、緑ハイライト用状態として扱われることを検証
  - 完了カードも Unit ページへのリンクを持つことを検証

## 動作確認
- `corepack pnpm --filter web exec vitest run src/lib/sui/registry.test.ts src/app/page.test.tsx`
- `corepack pnpm --filter web exec vitest run src/app/page.test.tsx src/app/units/[unitId]/page.test.tsx src/app/units/[unitId]/unit-reveal-client.test.tsx src/lib/sui/registry.test.ts`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run check`
- `corepack pnpm run test:e2e:readiness`