### PR TITLE
fix: 完了済みホームカードから完成画像へ遷移できるようにする

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -335,17 +335,20 @@ describe("HomePage", () => {
       const cardElement = card as HTMLElement;
       expect(cardElement.getAttribute("data-complete")).toBe("true");
       expect(cardElement.getAttribute("data-live")).toBeNull();
-      expect(cardElement.closest("a")).toBeNull();
+      const link = cardElement.closest("a");
+      expect(link?.getAttribute("href")).toBe(
+        "/units/0xunit-complete?athleteName=Demo+Athlete+One",
+      );
       expect(within(cardElement).getAllByText("Complete").length).toBe(2);
       expect(within(cardElement).queryByText("Live")).toBeNull();
       expect(within(cardElement).getByText("347 / 2000")).toBeTruthy();
     }
 
     expect(
-      screen.queryByRole("link", {
-        name: /Demo Athlete One portrait upload page/i,
+      screen.getAllByRole("link", {
+        name: /Demo Athlete One portrait page/i,
       }),
-    ).toBeNull();
+    ).toHaveLength(2);
   });
 
   it("keeps E2E degraded home card states distinct in the portrait rail", async () => {

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -243,7 +243,7 @@ describe("HomePage", () => {
     render(ui);
 
     const link = screen.getAllByRole("link", {
-      name: /Demo Athlete One portrait upload page/i,
+      name: /Demo Athlete One portrait page/i,
     })[0];
     expect(link?.getAttribute("href")).toBe(
       "/units/0xunit-1?athleteName=Demo+Athlete+One",
@@ -276,7 +276,7 @@ describe("HomePage", () => {
     render(ui);
 
     const secondAthleteLinks = screen.getAllByRole("link", {
-      name: /Demo Athlete Two portrait upload page/i,
+      name: /Demo Athlete Two portrait page/i,
     });
     expect(secondAthleteLinks).toHaveLength(2);
     for (const link of secondAthleteLinks) {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -83,7 +83,7 @@ function buildPortraitWorkRail(
     return {
       ...work,
       href:
-        !isComplete && entry.progress.unitId !== null
+        entry.progress.kind === "active" && entry.progress.unitId !== null
           ? buildWaitingRoomHref(entry.progress.unitId, work.displayName)
           : undefined,
       progressLabel,
@@ -282,7 +282,7 @@ function PortraitWorkCard({
 
   return (
     <Link
-      aria-label={`${work.displayName} portrait upload page`}
+      aria-label={`${work.displayName} portrait page`}
       className="op-home-portrait-card-link"
       href={work.href}
     >


### PR DESCRIPTION
## 概要
完了済みとして緑ハイライトされるホームのポートレートカードもクリック可能にし、既存の Unit ページから完成モザイクを見られるようにします。

## 変更内容
- `apps/web/src/app/page.tsx`
  - 完了済みカードも `/units/[unitId]` へのリンクを持つように変更
  - live / complete 共通で使えるよう aria-label を `portrait page` に変更
- `apps/web/src/app/page.test.tsx`
  - 完了済みカードが Unit ページへのリンクを持つことを検証
  - 既存の live カードリンクテストを新しい aria-label に追従

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/page.test.tsx src/app/units/[unitId]/page.test.tsx src/app/units/[unitId]/unit-reveal-client.test.tsx src/lib/sui/registry.test.ts`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run check`