### PR TITLE
[feat] finalize 経路のコンソール出力と「生成中」UI の体裁改善

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -419,6 +419,45 @@ a {
   transition: width 0.4s;
 }
 
+@keyframes op-finalize-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.op-finalize-spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 148, 54, 0.25);
+  border-top-color: var(--ember);
+  animation: op-finalize-spin 0.9s linear infinite;
+  flex: none;
+}
+
+@keyframes op-indeterminate-bar {
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+.op-indeterminate-bar {
+  position: relative;
+  height: 2px;
+  background: var(--rule);
+  overflow: hidden;
+}
+.op-indeterminate-bar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, var(--ember), transparent);
+  animation: op-indeterminate-bar 1.6s ease-in-out infinite;
+}
+
 /* Athlete card */
 .op-athlete-card {
   background: var(--bg-2);
@@ -2261,7 +2300,9 @@ a {
   .op-home-teaser-scan,
   .op-demo-hero-athlete.primary,
   .op-demo-grid-glow,
-  .op-demo-athlete-track {
+  .op-demo-athlete-track,
+  .op-finalize-spinner,
+  .op-indeterminate-bar::after {
     animation: none;
   }
 

--- a/apps/web/src/app/units/[unitId]/live-progress.test.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.test.tsx
@@ -371,6 +371,47 @@ describe("LiveProgress", () => {
     expect(triggerFinalize).toHaveBeenLastCalledWith("0xunit-1");
   });
 
+  it("renders the spinner and elapsed counter while finalize is running", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const triggerFinalize = vi.fn(
+        () =>
+          new Promise<{
+            readonly status: "queued";
+            readonly unitId: string;
+          }>(() => {
+            // never resolve so the running state stays mounted
+          }),
+      );
+      useUnitEventsMock.mockImplementation(() => undefined);
+
+      const { container } = render(
+        <LiveProgress
+          initialMasterId={null}
+          initialSubmittedCount={unitTileCount}
+          maxSlots={unitTileCount}
+          packageId="0xpkg"
+          triggerFinalize={triggerFinalize}
+          unitId="0xunit-1"
+        />,
+      );
+
+      expect(screen.getByText(/Finalizing your mosaic/i)).toBeTruthy();
+      expect(container.querySelector(".op-finalize-spinner")).toBeTruthy();
+      expect(container.querySelector(".op-indeterminate-bar")).toBeTruthy();
+      expect(screen.getByText(/Elapsed 00:00/)).toBeTruthy();
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText(/Elapsed 00:05/)).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps completed revisit progress from auto-finalizing", () => {
     const triggerFinalize = vi.fn(async () => ({
       status: "queued" as const,

--- a/apps/web/src/app/units/[unitId]/live-progress.tsx
+++ b/apps/web/src/app/units/[unitId]/live-progress.tsx
@@ -34,6 +34,14 @@ function formatProgressCount(value: number): string {
   return String(value);
 }
 
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const padded = (n: number) => String(n).padStart(2, "0");
+  return `${padded(minutes)}:${padded(seconds)}`;
+}
+
 export type LiveProgressProps = {
   readonly eventSubscriptionEnabled?: boolean;
   readonly packageId: string;
@@ -88,6 +96,10 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
   const [finalizeState, setFinalizeState] = useState<FinalizeState>(
     needsInitialFinalize ? { status: "running" } : { status: "idle" },
   );
+  const [startedAtMs, setStartedAtMs] = useState<number | null>(
+    needsInitialFinalize ? Date.now() : null,
+  );
+  const [elapsedMs, setElapsedMs] = useState(0);
   const finalizeTriggeredRef = useRef(false);
   const { markFullIfAtCap } = useUnitFullState();
 
@@ -97,6 +109,8 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
     }
 
     finalizeTriggeredRef.current = true;
+    setStartedAtMs(Date.now());
+    setElapsedMs(0);
     setFinalizeState({ status: "running" });
     void triggerFinalize(unitId)
       .then((result) => {
@@ -131,6 +145,27 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
   useEffect(() => {
     markFullIfAtCap(initialSubmittedCount, maxSlots);
   }, [initialSubmittedCount, markFullIfAtCap, maxSlots]);
+
+  useEffect(() => {
+    if (finalizeState.status !== "running") {
+      setStartedAtMs(null);
+      setElapsedMs(0);
+      return;
+    }
+
+    if (startedAtMs === null) {
+      return;
+    }
+
+    setElapsedMs(Date.now() - startedAtMs);
+    const interval = window.setInterval(() => {
+      setElapsedMs(Date.now() - startedAtMs);
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [finalizeState.status, startedAtMs]);
 
   useUnitEvents({
     packageId: eventSubscriptionEnabled ? packageId : "",
@@ -213,12 +248,32 @@ export function LiveProgress(props: LiveProgressProps): React.ReactElement {
               </button>
             </>
           ) : (
-            <p
-              aria-live="polite"
-              className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]"
-            >
-              finalize is running
-            </p>
+            <div className="grid gap-3">
+              <span aria-live="polite" className="sr-only">
+                finalize is running
+              </span>
+              <div className="flex items-center gap-3">
+                <span aria-hidden="true" className="op-finalize-spinner" />
+                <p className="font-mono-op text-[13px] uppercase tracking-[0.18em] text-[var(--ember)]">
+                  Finalizing your mosaic
+                </p>
+              </div>
+              <p className="text-sm text-[var(--ink-dim)]">
+                Composing the 2,000-tile mosaic and writing to Walrus — this can
+                take a minute or two.
+              </p>
+              <div
+                aria-hidden="true"
+                className="op-indeterminate-bar"
+                role="presentation"
+              />
+              <p
+                aria-hidden="true"
+                className="font-mono-op text-[11px] uppercase tracking-[0.14em] tabular-nums text-[var(--ink-faint)]"
+              >
+                Elapsed {formatElapsed(elapsedMs)}
+              </p>
+            </div>
           )}
         </div>
       ) : null}

--- a/generator/src/server.ts
+++ b/generator/src/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import http from "node:http";
 import { pathToFileURL } from "node:url";
 
@@ -17,6 +18,30 @@ import {
 
 export const DISPATCH_SECRET_HEADER = "x-op-finalize-dispatch-secret";
 
+type LogLevel = "info" | "warn" | "error";
+
+function logLine(level: LogLevel, tag: string, message: string): void {
+  const prefix =
+    level === "info" ? "[INFO]" : level === "warn" ? "[WARN]" : "[ERR ]";
+  const raw = `${prefix} ${new Date().toISOString()} [${tag}] ${message}`;
+  const line = raw.replace(/[\r\n]+/g, " ");
+
+  if (level === "error") {
+    console.error(line);
+    return;
+  }
+
+  console.log(line);
+}
+
+function shortenObjectId(value: string): string {
+  if (value.length <= 14) {
+    return value;
+  }
+
+  return `${value.slice(0, 10)}..${value.slice(-4)}`;
+}
+
 class InvalidPayloadError extends Error {
   constructor(message: string) {
     super(message);
@@ -34,9 +59,18 @@ export async function handleRequest(
   request: http.IncomingMessage,
   response: http.ServerResponse,
 ): Promise<void> {
+  const reqId = randomUUID().slice(0, 8);
+  const reqTag = `req ${reqId}`;
+  const startedAt = Date.now();
+
   if (request.method === "GET" && request.url === "/health") {
     const readiness = getGeneratorReadiness(process.env);
     if (!readiness.ready) {
+      logLine(
+        "warn",
+        reqTag,
+        `health misconfigured missing=${readiness.missing.join(",")}`,
+      );
       writeJson(response, 503, {
         error: "server_misconfigured",
         message: `Missing required generator env variable(s): ${readiness.missing.join(", ")}.`,
@@ -54,8 +88,14 @@ export async function handleRequest(
   }
 
   if (request.method === "POST" && request.url === "/dispatch") {
+    logLine("info", reqTag, `POST /dispatch`);
     const authorizationError = validateDispatchAuthorization(request);
     if (authorizationError !== null) {
+      logLine(
+        "warn",
+        reqTag,
+        `dispatch unauthorized status=${authorizationError.status}`,
+      );
       writeJson(
         response,
         authorizationError.status,
@@ -66,6 +106,11 @@ export async function handleRequest(
 
     try {
       const input = parseDispatchInput(await readJsonBody(request));
+      logLine(
+        "info",
+        reqTag,
+        `dispatch start unitId=${shortenObjectId(input.unitId)}`,
+      );
       const env = loadGeneratorRuntimeEnv(process.env);
       const client = createSuiClient({
         network: env.suiNetwork,
@@ -83,13 +128,30 @@ export async function handleRequest(
         walrusPublisherBaseUrl: env.walrusPublisherBaseUrl,
       });
       const result = await runner.run(input.unitId);
+      const elapsedMs = Date.now() - startedAt;
+
+      if (result.status === "finalized") {
+        logLine(
+          "info",
+          reqTag,
+          `dispatch done status=${result.status} ms=${elapsedMs} mosaicBlobId=${result.mosaicBlobId} digest=${result.digest} placements=${result.placementCount}`,
+        );
+      } else {
+        logLine(
+          "info",
+          reqTag,
+          `dispatch done status=${result.status} ms=${elapsedMs}`,
+        );
+      }
 
       writeJson(response, 200, result);
       return;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logLine("error", reqTag, `dispatch failed message=${message}`);
       writeJson(response, 500, {
         error: "finalize_failed",
-        message: error instanceof Error ? error.message : String(error),
+        message,
       });
       return;
     }
@@ -98,6 +160,11 @@ export async function handleRequest(
   if (request.method === "GET" && request.url === "/dispatch-auth-probe") {
     const authorizationError = validateDispatchAuthorization(request);
     if (authorizationError !== null) {
+      logLine(
+        "warn",
+        reqTag,
+        `auth probe unauthorized status=${authorizationError.status}`,
+      );
       writeJson(
         response,
         authorizationError.status,
@@ -113,8 +180,14 @@ export async function handleRequest(
   }
 
   if (request.method === "POST" && request.url === "/admin/create-unit") {
+    logLine("info", reqTag, `POST /admin/create-unit`);
     const authorizationError = validateDispatchAuthorization(request);
     if (authorizationError !== null) {
+      logLine(
+        "warn",
+        reqTag,
+        `create-unit unauthorized status=${authorizationError.status}`,
+      );
       writeJson(
         response,
         authorizationError.status,
@@ -125,6 +198,11 @@ export async function handleRequest(
 
     try {
       const input = parseCreateUnitInput(await readJsonBody(request));
+      logLine(
+        "info",
+        reqTag,
+        `create-unit start displayName=${JSON.stringify(input.displayName)} maxSlots=${input.maxSlots} displayMaxSlots=${input.displayMaxSlots}`,
+      );
       const env = loadGeneratorRuntimeEnv(process.env);
       const client = createSuiClient({
         network: env.suiNetwork,
@@ -136,6 +214,12 @@ export async function handleRequest(
         privateKey: env.adminPrivateKey,
       });
       const result = await executeCreateUnit(input);
+      const elapsedMs = Date.now() - startedAt;
+      logLine(
+        "info",
+        reqTag,
+        `create-unit done unitId=${shortenObjectId(result.unitId)} digest=${result.digest} ms=${elapsedMs}`,
+      );
 
       writeJson(response, 200, {
         digest: result.digest,
@@ -144,22 +228,30 @@ export async function handleRequest(
       });
       return;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       if (error instanceof InvalidPayloadError) {
+        logLine("warn", reqTag, `create-unit invalid_args message=${message}`);
         writeJson(response, 400, {
           error: "invalid_args",
-          message: error.message,
+          message,
         });
         return;
       }
 
+      logLine("error", reqTag, `create-unit failed message=${message}`);
       writeJson(response, 500, {
         error: "create_unit_failed",
-        message: error instanceof Error ? error.message : String(error),
+        message,
       });
       return;
     }
   }
 
+  logLine(
+    "warn",
+    reqTag,
+    `not_found method=${request.method ?? "?"} url=${request.url ?? "?"}`,
+  );
   writeJson(response, 404, {
     error: "not_found",
     message: "Unknown route.",
@@ -432,5 +524,11 @@ function isMainModule() {
 if (isMainModule()) {
   const port = Number(process.env.PORT ?? "8080");
   const server = createGeneratorServer();
-  server.listen(port, "0.0.0.0");
+  server.listen(port, "0.0.0.0", () => {
+    logLine(
+      "info",
+      "boot",
+      `ONE Portrait generator listening port=${port} routes=/health,/dispatch,/dispatch-auth-probe,/admin/create-unit`,
+    );
+  });
 }

--- a/generator/test/server.test.ts
+++ b/generator/test/server.test.ts
@@ -177,6 +177,40 @@ describe("generator server", () => {
     }
   });
 
+  it("logs dispatch start and done lines for /dispatch", async () => {
+    setReadyGeneratorEnv();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const server = createGeneratorServer();
+    const baseUrl = await listen(server);
+
+    try {
+      const response = await fetch(`${baseUrl}/dispatch`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [DISPATCH_SECRET_HEADER]: "shared-secret",
+        },
+        body: JSON.stringify({ unitId: VALID_UNIT_ID }),
+      });
+      expect(response.status).toBe(200);
+      await response.json();
+
+      const logLines = logSpy.mock.calls.map((call) => String(call[0] ?? ""));
+      expect(
+        logLines.some((line) =>
+          /\[req [0-9a-f]{8}\] dispatch start/.test(line),
+        ),
+      ).toBe(true);
+      expect(
+        logLines.some((line) => /\[req [0-9a-f]{8}\] dispatch done/.test(line)),
+      ).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+      await close(server);
+    }
+  });
+
   it("accepts /admin/create-unit when the payload is valid", async () => {
     setReadyGeneratorEnv();
 


### PR DESCRIPTION
## 概要

`UnitFilledEvent` → `/api/finalize` → ジェネレーターコンテナ `/dispatch` → `MosaicReadyEvent` の finalize 経路は動作自体は通っているが、運用視点で分かりづらかった 2 点を改善する。機能面（状態機械、エラーハンドリング、API 契約、タイムアウト挙動）は現状を維持し、見た目とログの体裁だけを整える。

- ジェネレーターコンテナの stdout には sharp/libvips/tar の stderr ノイズしか流れず、リクエストが入ったかも分からない状態だった。
- フロントエンドの「生成中」表示は小さな英語一行だけで、ユーザーに処理中の実感がなかった。

## 変更内容

- \`generator/src/server.ts\`
    - 外部依存なしのインライン \`logLine()\` を追加。\`[INFO]/[WARN]/[ERR ]\` プレフィックス + ISO タイムスタンプ + タグ付きで、CR/LF は空白に畳んでログ偽造を防ぐ。
    - \`/dispatch\` と \`/admin/create-unit\` に \`[req <8桁ID>]\` 単位で start / done / failed のログを出力。\`dispatch done\` は \`status\` / \`ms\` / \`mosaicBlobId\` / \`digest\` / \`placements\` を含める。
    - 起動時に \`[boot]\` ログ、404 フォールバックに \`warn\` ログを追加。
    - \`/health\` と \`/dispatch-auth-probe\` は成功時はログを出さず（Cloudflare ヘルスチェックでログが溢れるのを防止）、失敗時のみ warn を出す。
- \`generator/test/server.test.ts\`
    - \`/dispatch\` 成功時に \`[req <id>] dispatch start\` / \`dispatch done\` が出力されることを spy で検証するケースを追加。
- \`apps/web/src/app/units/[unitId]/live-progress.tsx\`
    - 「generating」ブロックを差し替え、CSS スピナー + 「Finalizing your mosaic」見出し + 説明文 + 不確定プログレスバー + \`Elapsed mm:ss\` カウンタを描画。
    - \`startedAtMs\` / \`elapsedMs\` は UI 表示用の派生状態。running 以外の状態では毎回リセットしてゴーストを残さない。
    - \`aria-live="polite"\` は既存の \`finalize is running\` sr-only span にのみ付与。毎秒更新される Elapsed カウンタは \`aria-hidden=\"true\"\` でスクリーンリーダーの読み上げを抑止。
    - \`FinalizeState\`、\`startFinalize\`、\`defaultTriggerFinalize\`、failed UI、progressLabel、\`useUnitEvents\` の経路は無変更。
- \`apps/web/src/app/units/[unitId]/live-progress.test.tsx\`
    - 既存 11 ケースはそのまま通る。新規ケース「running 状態でスピナー/バー/\`Elapsed 00:00 → 00:05\`（fake timer）」を 1 件追加。
- \`apps/web/src/app/globals.css\`
    - \`op-finalize-spinner\`（回転）と \`op-indeterminate-bar\`（シマー）のキーフレーム / スタイルを追加。\`prefers-reduced-motion: reduce\` で両方のアニメーションを無効化。

## 動作確認

- \`pnpm run check\`（lint + typecheck + test）: exit 0
    - shared 23/23, web 426/426（live-progress 既存 11 + 新規 1 = 12）, generator 86/86（server 既存 8 + 新規 1 = 9）すべて pass
- \`pnpm --filter web test live-progress\`: 全 pass
- \`cd generator && pnpm test server\`: 全 pass

## 影響範囲

- Move / 契約層は一切触っていない。
- \`runtime.ts\`、\`FinalizeState\`、\`/api/finalize\` 契約、\`ParticipationAccess\` の投稿フロー、\`useUnitEvents\` の購読は変更なし。