### PR TITLE
fix: handle quick tunnel DNS fallback

### DIFF
--- a/apps/web/scripts/generator-stack-health.mjs
+++ b/apps/web/scripts/generator-stack-health.mjs
@@ -183,11 +183,7 @@ async function defaultResolveHostname(hostname) {
   return addresses[0] ?? null;
 }
 
-async function defaultRequestWithResolvedHostname({
-  ipAddress,
-  signal,
-  url,
-}) {
+async function defaultRequestWithResolvedHostname({ ipAddress, signal, url }) {
   return new Promise((resolve, reject) => {
     const family = ipAddress.includes(":") ? 6 : 4;
     const request = https.request(

--- a/apps/web/scripts/generator-stack-health.mjs
+++ b/apps/web/scripts/generator-stack-health.mjs
@@ -1,5 +1,9 @@
+import dns from "node:dns";
+import https from "node:https";
+
 const GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS = 1000;
 const GENERATOR_STACK_HEALTH_TIMEOUT_MS = 30000;
+const QUICK_TUNNEL_HOST_SUFFIX = ".trycloudflare.com";
 
 export {
   GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS,
@@ -14,6 +18,8 @@ export async function waitForGeneratorStackHealth({
   sleep = defaultSleep,
   now = defaultNow,
   logger = console,
+  requestWithResolvedHostname = defaultRequestWithResolvedHostname,
+  resolveHostname = defaultResolveHostname,
   retryIntervalMs = GENERATOR_STACK_HEALTH_RETRY_INTERVAL_MS,
   timeoutMs = GENERATOR_STACK_HEALTH_TIMEOUT_MS,
   waitForAttemptTimeout = defaultWaitForAttemptTimeout,
@@ -46,6 +52,8 @@ export async function waitForGeneratorStackHealth({
     const attemptResult = await raceHealthAttempt({
       abortController,
       fetchImpl,
+      requestWithResolvedHostname,
+      resolveHostname,
       url,
       waitForAttemptTimeout,
       waitMs: attemptTimeoutMs,
@@ -67,7 +75,13 @@ export async function waitForGeneratorStackHealth({
   }
 }
 
-async function isHealthReady(fetchImpl, url, signal) {
+async function isHealthReady({
+  fetchImpl,
+  requestWithResolvedHostname,
+  resolveHostname,
+  signal,
+  url,
+}) {
   try {
     const response = await fetchImpl(url, {
       method: "GET",
@@ -77,19 +91,32 @@ async function isHealthReady(fetchImpl, url, signal) {
 
     return response?.status === 200;
   } catch {
-    return false;
+    return isHealthReadyWithResolvedHostname({
+      requestWithResolvedHostname,
+      resolveHostname,
+      signal,
+      url,
+    });
   }
 }
 
 async function raceHealthAttempt({
   abortController,
   fetchImpl,
+  requestWithResolvedHostname,
+  resolveHostname,
   url,
   waitForAttemptTimeout,
   waitMs,
 }) {
   const timeoutResult = await Promise.race([
-    isHealthReady(fetchImpl, url, abortController.signal),
+    isHealthReady({
+      fetchImpl,
+      requestWithResolvedHostname,
+      resolveHostname,
+      signal: abortController.signal,
+      url,
+    }),
     waitForAttemptTimeout({
       milliseconds: waitMs,
       signal: abortController.signal,
@@ -99,6 +126,92 @@ async function raceHealthAttempt({
   abortController.abort();
 
   return timeoutResult === true ? "ready" : "retry";
+}
+
+async function isHealthReadyWithResolvedHostname({
+  requestWithResolvedHostname,
+  resolveHostname,
+  signal,
+  url,
+}) {
+  const parsed = parseQuickTunnelUrl(url);
+  if (parsed === null) {
+    return false;
+  }
+
+  try {
+    const ipAddress = await resolveHostname(parsed.hostname);
+    if (!ipAddress) {
+      return false;
+    }
+
+    const response = await requestWithResolvedHostname({
+      hostname: parsed.hostname,
+      ipAddress,
+      signal,
+      url,
+    });
+
+    return response?.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+function parseQuickTunnelUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== "https:" ||
+      !parsed.hostname.endsWith(QUICK_TUNNEL_HOST_SUFFIX)
+    ) {
+      return null;
+    }
+
+    return {
+      hostname: parsed.hostname,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function defaultResolveHostname(hostname) {
+  const resolver = new dns.promises.Resolver();
+  resolver.setServers(["1.1.1.1", "1.0.0.1"]);
+  const addresses = await resolver.resolve4(hostname);
+  return addresses[0] ?? null;
+}
+
+async function defaultRequestWithResolvedHostname({
+  ipAddress,
+  signal,
+  url,
+}) {
+  return new Promise((resolve, reject) => {
+    const family = ipAddress.includes(":") ? 6 : 4;
+    const request = https.request(
+      new URL(url),
+      {
+        method: "GET",
+        signal,
+        lookup: (_hostname, _options, callback) => {
+          callback(null, ipAddress, family);
+        },
+      },
+      (response) => {
+        response.resume();
+        response.once("end", () => {
+          resolve({
+            status: response.statusCode ?? null,
+          });
+        });
+      },
+    );
+
+    request.once("error", reject);
+    request.end();
+  });
 }
 
 async function defaultSleep(milliseconds) {

--- a/apps/web/scripts/generator-stack-health.test.ts
+++ b/apps/web/scripts/generator-stack-health.test.ts
@@ -274,7 +274,9 @@ it("falls back to Cloudflare DNS for Quick Tunnel external health", async () => 
   const clock = createClock();
   const fetchImpl = vi.fn().mockRejectedValue(new Error("fetch failed"));
   const resolveHostname = vi.fn().mockResolvedValue("104.16.230.132");
-  const requestWithResolvedHostname = vi.fn().mockResolvedValue({ status: 200 });
+  const requestWithResolvedHostname = vi
+    .fn()
+    .mockResolvedValue({ status: 200 });
 
   const result = await waitForGeneratorStackHealth({
     fetchImpl,
@@ -293,7 +295,9 @@ it("falls back to Cloudflare DNS for Quick Tunnel external health", async () => 
     marker: "[generator-stack][health][external][ready]",
   });
   expect(fetchImpl).toHaveBeenCalledTimes(1);
-  expect(resolveHostname).toHaveBeenCalledWith("fresh-runtime.trycloudflare.com");
+  expect(resolveHostname).toHaveBeenCalledWith(
+    "fresh-runtime.trycloudflare.com",
+  );
   expect(requestWithResolvedHostname).toHaveBeenCalledWith(
     expect.objectContaining({
       hostname: "fresh-runtime.trycloudflare.com",

--- a/apps/web/scripts/generator-stack-health.test.ts
+++ b/apps/web/scripts/generator-stack-health.test.ts
@@ -269,6 +269,41 @@ describe.each(labels)("waitForGeneratorStackHealth: %s", (label) => {
   });
 });
 
+it("falls back to Cloudflare DNS for Quick Tunnel external health", async () => {
+  const logger = createLogger();
+  const clock = createClock();
+  const fetchImpl = vi.fn().mockRejectedValue(new Error("fetch failed"));
+  const resolveHostname = vi.fn().mockResolvedValue("104.16.230.132");
+  const requestWithResolvedHostname = vi.fn().mockResolvedValue({ status: 200 });
+
+  const result = await waitForGeneratorStackHealth({
+    fetchImpl,
+    label: "external",
+    logger,
+    now: clock.now,
+    requestWithResolvedHostname,
+    resolveHostname,
+    sleep: clock.sleep,
+    url: "https://fresh-runtime.trycloudflare.com/health",
+  });
+
+  expect(result).toEqual({
+    ok: true,
+    exitCode: 0,
+    marker: "[generator-stack][health][external][ready]",
+  });
+  expect(fetchImpl).toHaveBeenCalledTimes(1);
+  expect(resolveHostname).toHaveBeenCalledWith("fresh-runtime.trycloudflare.com");
+  expect(requestWithResolvedHostname).toHaveBeenCalledWith(
+    expect.objectContaining({
+      hostname: "fresh-runtime.trycloudflare.com",
+      ipAddress: "104.16.230.132",
+      url: "https://fresh-runtime.trycloudflare.com/health",
+    }),
+  );
+  expect(clock.sleep).not.toHaveBeenCalled();
+});
+
 function createClock() {
   let currentTime = 0;
 


### PR DESCRIPTION
## 概要
Quick Tunnel のランダム URL を Ubuntu 側の通常 DNS で解決できない場合でも、`generator:tunnel` の外部 health check が進めるようにします。

## 変更内容
- `apps/web/scripts/generator-stack-health.mjs`
  - 通常 `fetch` が失敗した場合、`*.trycloudflare.com` に限って Cloudflare DNS (`1.1.1.1`, `1.0.0.1`) で IPv4 を解決し、同じ hostname/SNI のまま `/health` を再試行
  - Quick Tunnel 以外の URL では従来通り失敗として retry
- `apps/web/scripts/generator-stack-health.test.ts`
  - 通常 fetch が失敗しても Cloudflare DNS fallback で external health が ready になるケースを追加

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm --filter web exec vitest run scripts/generator-stack-health.test.ts`
- `corepack pnpm --filter web typecheck`
- 常駐起動済みの `generator:tunnel` で `[generator-stack][ready]` を確認
- 本番 `/api/admin/health` が `source: worker_kv`, `resolutionStatus: ok`, `generator: ok`, `dispatch: ok` を返すことを確認
