### PR TITLE
feat: /demoを当日用Unitフローに作り直す

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "check": "biome check --write .",
     "lint": "biome check .",
     "dev": "node ./scripts/run-dev.mjs",
+    "dev:fresh": "OP_NEXT_DEV_CLEAN_CACHE=1 node ./scripts/run-dev.mjs",
+    "dev:webpack": "node ./scripts/run-dev.mjs --webpack",
     "dev:demo": "node ./scripts/run-demo-dev.mjs",
     "dev:e2e": "./scripts/e2e-dev.sh",
     "dev:smoke": "node ./scripts/run-smoke-dev.mjs",

--- a/apps/web/scripts/local-runtime-entrypoints.test.ts
+++ b/apps/web/scripts/local-runtime-entrypoints.test.ts
@@ -45,6 +45,18 @@ describe("local runtime entrypoints", () => {
     );
   });
 
+  it("passes additional next dev arguments through startDev", () => {
+    const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
+
+    startDev({
+      env: {},
+      extraArgs: ["--webpack"],
+      spawnImpl,
+    });
+
+    expect(spawnImpl.mock.calls[0][1]).toEqual(["dev", "--webpack"]);
+  });
+
   it("startSmokeDev enables the local generator runtime flag without injecting a dispatch URL", async () => {
     const spawnImpl = vi.fn().mockReturnValue({ on: vi.fn() });
 

--- a/apps/web/scripts/run-dev.mjs
+++ b/apps/web/scripts/run-dev.mjs
@@ -10,11 +10,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const webRoot = path.resolve(__dirname, "..");
 const lockPath = path.join(webRoot, ".next", "dev", "lock");
+const turbopackCachePath = path.join(
+  webRoot,
+  ".next",
+  "dev",
+  "cache",
+  "turbopack",
+);
 const nextBin = path.join(webRoot, "node_modules", ".bin", "next");
 
 export function startDev({
   cwd = webRoot,
   env = process.env,
+  extraArgs = [],
   nextDevBin = path.join(cwd, "node_modules", ".bin", "next"),
   spawnImpl = spawn,
 }) {
@@ -24,7 +32,7 @@ export function startDev({
     webRoot: cwd,
   });
 
-  return spawnImpl(nextDevBin, ["dev"], {
+  return spawnImpl(nextDevBin, ["dev", ...extraArgs], {
     cwd,
     env: {
       ...env,
@@ -40,11 +48,13 @@ export function startDev({
 
 if (isExecutedDirectly()) {
   cleanupStaleNextDevLock(lockPath);
+  cleanupNextDevCacheOnRequest(turbopackCachePath, process.env);
   assertNormalDevEnvironment({ cwd: webRoot, env: process.env });
 
   const child = startDev({
     cwd: webRoot,
     env: process.env,
+    extraArgs: process.argv.slice(2),
     nextDevBin: nextBin,
     spawnImpl: spawn,
   });
@@ -57,6 +67,14 @@ if (isExecutedDirectly()) {
 
     process.exit(code ?? 0);
   });
+}
+
+function cleanupNextDevCacheOnRequest(cachePath, env) {
+  if (env.OP_NEXT_DEV_CLEAN_CACHE !== "1") {
+    return;
+  }
+
+  fs.rmSync(cachePath, { force: true, recursive: true });
 }
 
 function cleanupStaleNextDevLock(filePath) {

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -83,10 +83,10 @@ describe("DemoClient", () => {
     render(<DemoClient />);
 
     const googleButton = screen.getByRole("button", {
-      name: /Continue with Google zkLogin/i,
+      name: /Google zkLogin/i,
     });
     const suiButton = screen.getByRole("button", {
-      name: /Connect Sui wallet/i,
+      name: /Sui wallet/i,
     });
 
     expect(googleButton.className).toContain("op-btn-primary");
@@ -95,8 +95,8 @@ describe("DemoClient", () => {
   });
 
   it.each([
-    ["Google zkLogin", /Continue with Google zkLogin/i],
-    ["Sui wallet", /Connect Sui wallet/i],
+    ["Google zkLogin", /Google zkLogin/i],
+    ["Sui wallet", /Sui wallet/i],
   ])("connects locally with %s and exposes image selection", (_, buttonName) => {
     render(<DemoClient />);
 
@@ -105,14 +105,15 @@ describe("DemoClient", () => {
     expect(screen.getByText(/Demo wallet address confirmed/i)).toBeTruthy();
     expect(screen.getByText("0xdemo...2000")).toBeTruthy();
     expect(screen.getByLabelText(/Choose one image/i)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    ).toBeTruthy();
   });
 
   it("previews a selected local image and advances demo progress", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -135,9 +136,7 @@ describe("DemoClient", () => {
   it("starts a demo completion reveal after image selection", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -151,9 +150,7 @@ describe("DemoClient", () => {
   it("references the completed mosaic asset in the reveal area", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Connect Sui wallet/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -164,9 +161,7 @@ describe("DemoClient", () => {
   it("shows the selected original photo in the completed panel", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -179,9 +174,7 @@ describe("DemoClient", () => {
   it("shows the fixed demo placement highlight using unit grid math", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -200,9 +193,7 @@ describe("DemoClient", () => {
   it("toggles the fixed placement highlight", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Connect Sui wallet/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -230,9 +221,7 @@ describe("DemoClient", () => {
     }));
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
 
@@ -244,9 +233,7 @@ describe("DemoClient", () => {
       .mockReturnValueOnce("blob:demo-preview-1")
       .mockReturnValueOnce("blob:demo-preview-2");
     const { unmount } = render(<DemoClient />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Connect Sui wallet/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
     selectImage(new File(["first"], "first.png", { type: "image/png" }));
     selectImage(new File(["second"], "second.png", { type: "image/png" }));

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -47,12 +47,13 @@ describe("DemoClient", () => {
       screen.getByRole("region", { name: /Athlete unit overview/i }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("region", { name: /Submission panel/i }),
+      screen.getByRole("complementary", { name: /Submission panel/i }),
     ).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Takeru" })).toBeTruthy();
+    expect(screen.getByText(/UNIT ACTIVE — HIDDEN UNTIL REVEAL/i)).toBeTruthy();
+    expect(screen.getByText(/Participation wallet/i)).toBeTruthy();
     expect(screen.getByText(/1999\s*\/\s*2000/)).toBeTruthy();
-    expect(screen.getByText(/Reveal area/i)).toBeTruthy();
-    expect(screen.getByText(/Awaiting final photo/i)).toBeTruthy();
+    expect(screen.getByText(/1 tiles remaining/i)).toBeTruthy();
   });
 
   it("uses only the Takeru athlete asset in the demo shell", () => {
@@ -101,8 +102,8 @@ describe("DemoClient", () => {
 
     fireEvent.click(screen.getByRole("button", { name: buttonName }));
 
-    expect(screen.getByText(/Demo wallet connected/i)).toBeTruthy();
-    expect(screen.getByText(/0xdemo/i)).toBeTruthy();
+    expect(screen.getByText(/Demo wallet address confirmed/i)).toBeTruthy();
+    expect(screen.getByText("0xdemo...2000")).toBeTruthy();
     expect(screen.getByLabelText(/Choose one image/i)).toBeTruthy();
   });
 
@@ -126,7 +127,7 @@ describe("DemoClient", () => {
   it("keeps the reveal canvas hidden while awaiting the final photo", () => {
     render(<DemoClient />);
 
-    expect(screen.getByText(/Awaiting final photo/i)).toBeTruthy();
+    expect(screen.getByText(/1 tiles remaining/i)).toBeTruthy();
     expect(screen.queryByTestId("demo-completion-reveal")).toBeNull();
     expect(screen.queryByTestId("demo-completion-canvas")).toBeNull();
   });

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { unitTileGrid } from "@one-portrait/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DemoClient } from "./demo-client";
@@ -157,6 +158,62 @@ describe("DemoClient", () => {
 
     const completedMosaic = screen.getByAltText("Completed Takeru mosaic");
     expect(completedMosaic.getAttribute("src")).toBe("/demo/demo_mozaiku.png");
+  });
+
+  it("shows the selected original photo in the completed panel", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    const completedOriginal = screen.getByRole("img", {
+      name: /Takeru original submission/i,
+    });
+    expect(completedOriginal.getAttribute("src")).toBe("blob:demo-preview-1");
+  });
+
+  it("shows the fixed demo placement highlight using unit grid math", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    expect(
+      screen.getByText(/highlighted at \(37, 46\) as #2000/i),
+    ).toBeTruthy();
+
+    const highlight = screen.getByTestId("demo-placement-highlight");
+    const style = highlight.getAttribute("style");
+    expect(style).toContain(`left: ${(37 / unitTileGrid.cols) * 100}%`);
+    expect(style).toContain(`top: ${(46 / unitTileGrid.rows) * 100}%`);
+    expect(style).toContain(`width: ${100 / unitTileGrid.cols}%`);
+    expect(style).toContain(`height: ${100 / unitTileGrid.rows}%`);
+  });
+
+  it("toggles the fixed placement highlight", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect Sui wallet/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    expect(screen.getByTestId("demo-placement-highlight")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Hide highlight/i }));
+
+    expect(screen.queryByTestId("demo-placement-highlight")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show highlight/i }));
+
+    expect(screen.getByTestId("demo-placement-highlight")).toBeTruthy();
   });
 
   it("shows the completed reveal immediately for reduced motion", () => {

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,11 +1,39 @@
 // @vitest-environment happy-dom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DemoClient } from "./demo-client";
 
+const createObjectURL = vi.fn<(file: File) => string>();
+const revokeObjectURL = vi.fn<(url: string) => void>();
+
+Object.defineProperty(URL, "createObjectURL", {
+  configurable: true,
+  value: createObjectURL,
+});
+
+Object.defineProperty(URL, "revokeObjectURL", {
+  configurable: true,
+  value: revokeObjectURL,
+});
+
+function selectImage(file: File): void {
+  const input = screen.getByLabelText(/Choose one image/i);
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    value: [file],
+  });
+  fireEvent.change(input);
+}
+
 describe("DemoClient", () => {
+  afterEach(() => {
+    cleanup();
+    createObjectURL.mockReset();
+    revokeObjectURL.mockReset();
+  });
+
   it("renders the fixed Takeru Unit shell with initial progress", () => {
     render(<DemoClient />);
 
@@ -47,5 +75,73 @@ describe("DemoClient", () => {
     expect(screen.queryByText(/Jump to reveal/i)).toBeNull();
     expect(screen.queryByText(/Replay reveal/i)).toBeNull();
     expect(screen.queryByText(/The memory becomes/i)).toBeNull();
+  });
+
+  it("shows demo Google zkLogin and Sui wallet entries while signed out", () => {
+    render(<DemoClient />);
+
+    const googleButton = screen.getByRole("button", {
+      name: /Continue with Google zkLogin/i,
+    });
+    const suiButton = screen.getByRole("button", {
+      name: /Connect Sui wallet/i,
+    });
+
+    expect(googleButton.className).toContain("op-btn-primary");
+    expect(suiButton.className).toContain("op-btn-ghost");
+    expect(screen.queryByLabelText(/Choose one image/i)).toBeNull();
+  });
+
+  it.each([
+    ["Google zkLogin", /Continue with Google zkLogin/i],
+    ["Sui wallet", /Connect Sui wallet/i],
+  ])("connects locally with %s and exposes image selection", (_, buttonName) => {
+    render(<DemoClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: buttonName }));
+
+    expect(screen.getByText(/Demo wallet connected/i)).toBeTruthy();
+    expect(screen.getByText(/0xdemo/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Choose one image/i)).toBeTruthy();
+  });
+
+  it("previews a selected local image and advances demo progress", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByAltText("Selected submission preview").getAttribute("src"),
+    ).toBe("blob:demo-preview-1");
+    expect(screen.getByText(/2000\s*\/\s*2000/)).toBeTruthy();
+    expect(screen.queryByText(/1999\s*\/\s*2000/)).toBeNull();
+  });
+
+  it("revokes local preview URLs on reselection and unmount", () => {
+    createObjectURL
+      .mockReturnValueOnce("blob:demo-preview-1")
+      .mockReturnValueOnce("blob:demo-preview-2");
+    const { unmount } = render(<DemoClient />);
+    fireEvent.click(screen.getByRole("button", { name: /Connect Sui wallet/i }));
+
+    selectImage(new File(["first"], "first.png", { type: "image/png" }));
+    selectImage(new File(["second"], "second.png", { type: "image/png" }));
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(1, "blob:demo-preview-1");
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(2, "blob:demo-preview-2");
+  });
+
+  it("keeps submission copy local and mock-only for this demo step", () => {
+    render(<DemoClient />);
+
+    expect(screen.queryByText(/upload/i)).toBeNull();
+    expect(screen.queryByText(/transaction/i)).toBeNull();
+    expect(screen.getByText(/mock/i)).toBeTruthy();
   });
 });

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -7,6 +7,7 @@ import { DemoClient } from "./demo-client";
 
 const createObjectURL = vi.fn<(file: File) => string>();
 const revokeObjectURL = vi.fn<(url: string) => void>();
+const originalMatchMedia = window.matchMedia;
 
 Object.defineProperty(URL, "createObjectURL", {
   configurable: true,
@@ -30,6 +31,7 @@ function selectImage(file: File): void {
 describe("DemoClient", () => {
   afterEach(() => {
     cleanup();
+    window.matchMedia = originalMatchMedia;
     createObjectURL.mockReset();
     revokeObjectURL.mockReset();
   });
@@ -46,9 +48,7 @@ describe("DemoClient", () => {
     expect(
       screen.getByRole("region", { name: /Submission panel/i }),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("heading", { name: "Takeru" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Takeru" })).toBeTruthy();
     expect(screen.getByText(/1999\s*\/\s*2000/)).toBeTruthy();
     expect(screen.getByText(/Reveal area/i)).toBeTruthy();
     expect(screen.getByText(/Awaiting final photo/i)).toBeTruthy();
@@ -122,12 +122,73 @@ describe("DemoClient", () => {
     expect(screen.queryByText(/1999\s*\/\s*2000/)).toBeNull();
   });
 
+  it("keeps the reveal canvas hidden while awaiting the final photo", () => {
+    render(<DemoClient />);
+
+    expect(screen.getByText(/Awaiting final photo/i)).toBeTruthy();
+    expect(screen.queryByTestId("demo-completion-reveal")).toBeNull();
+    expect(screen.queryByTestId("demo-completion-canvas")).toBeNull();
+  });
+
+  it("starts a demo completion reveal after image selection", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    expect(screen.getByTestId("demo-completion-reveal")).toBeTruthy();
+    expect(screen.getByTestId("demo-completion-canvas")).toBeTruthy();
+    expect(screen.getByText(/40\s*x\s*50/i)).toBeTruthy();
+    expect(screen.getByText(/2000 tiles/i)).toBeTruthy();
+    expect(screen.getByText(/Final fan photo accepted/i)).toBeTruthy();
+  });
+
+  it("references the completed mosaic asset in the reveal area", () => {
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect Sui wallet/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    const completedMosaic = screen.getByAltText("Completed Takeru mosaic");
+    expect(completedMosaic.getAttribute("src")).toBe("/demo/demo_mozaiku.png");
+  });
+
+  it("shows the completed reveal immediately for reduced motion", () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    );
+
+    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+
+    expect(screen.getByText(/Completed mosaic revealed/i)).toBeTruthy();
+  });
+
   it("revokes local preview URLs on reselection and unmount", () => {
     createObjectURL
       .mockReturnValueOnce("blob:demo-preview-1")
       .mockReturnValueOnce("blob:demo-preview-2");
     const { unmount } = render(<DemoClient />);
-    fireEvent.click(screen.getByRole("button", { name: /Connect Sui wallet/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect Sui wallet/i }),
+    );
 
     selectImage(new File(["first"], "first.png", { type: "image/png" }));
     selectImage(new File(["second"], "second.png", { type: "image/png" }));
@@ -142,6 +203,9 @@ describe("DemoClient", () => {
 
     expect(screen.queryByText(/upload/i)).toBeNull();
     expect(screen.queryByText(/transaction/i)).toBeNull();
+    expect(screen.queryByText(/finalize/i)).toBeNull();
+    expect(document.body.textContent).not.toContain("/api/finalize");
+    expect(document.body.textContent).not.toMatch(/generator dispatch/i);
     expect(screen.getByText(/mock/i)).toBeTruthy();
   });
 });

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DemoClient } from "./demo-client";
+
+describe("DemoClient", () => {
+  it("renders the fixed Takeru Unit shell with initial progress", () => {
+    render(<DemoClient />);
+
+    expect(
+      screen.getByRole("main", { name: /Takeru Unit demo/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("region", { name: /Athlete unit overview/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("region", { name: /Submission panel/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Takeru" }),
+    ).toBeTruthy();
+    expect(screen.getByText(/1999\s*\/\s*2000/)).toBeTruthy();
+    expect(screen.getByText(/Reveal area/i)).toBeTruthy();
+    expect(screen.getByText(/Awaiting final photo/i)).toBeTruthy();
+  });
+
+  it("uses only the Takeru athlete asset in the demo shell", () => {
+    render(<DemoClient />);
+
+    const takeruImage = screen.getByRole("img", { name: /Takeru/i });
+    expect(takeruImage.getAttribute("src")).toBe(
+      "/demo/one-athletes/Takeru-500x345-1.png",
+    );
+
+    expect(screen.queryByText(/Yuya Wakamatsu/i)).toBeNull();
+    expect(screen.queryByText(/Rodtang Jitmuangnon/i)).toBeNull();
+    expect(screen.queryByText(/Ayaka Miura/i)).toBeNull();
+  });
+
+  it("does not render the old cinematic demo flow", () => {
+    render(<DemoClient />);
+
+    expect(screen.queryByText(/Reveal Arena/i)).toBeNull();
+    expect(screen.queryByText(/Pick your warrior/i)).toBeNull();
+    expect(screen.queryByText(/Jump to reveal/i)).toBeNull();
+    expect(screen.queryByText(/Replay reveal/i)).toBeNull();
+    expect(screen.queryByText(/The memory becomes/i)).toBeNull();
+  });
+});

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment happy-dom
 
-import { unitTileGrid } from "@one-portrait/shared";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -110,7 +109,7 @@ describe("DemoClient", () => {
     ).toBeTruthy();
   });
 
-  it("previews a selected local image and advances demo progress", () => {
+  it("previews a selected local image without advancing demo progress", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
@@ -121,8 +120,16 @@ describe("DemoClient", () => {
     expect(
       screen.getByAltText("Selected submission preview").getAttribute("src"),
     ).toBe("blob:demo-preview-1");
-    expect(screen.getByText(/2000\s*\/\s*2000/)).toBeTruthy();
-    expect(screen.queryByText(/1999\s*\/\s*2000/)).toBeNull();
+    expect(screen.getByText(/1999\s*\/\s*2000/)).toBeTruthy();
+    expect(screen.queryByText(/2000\s*\/\s*2000/)).toBeNull();
+    expect(screen.queryByTestId("demo-completion-reveal")).toBeNull();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /Confirm submission/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
   });
 
   it("keeps the reveal canvas hidden while awaiting the final photo", () => {
@@ -133,18 +140,21 @@ describe("DemoClient", () => {
     expect(screen.queryByTestId("demo-completion-canvas")).toBeNull();
   });
 
-  it("starts a demo completion reveal after image selection", () => {
+  it("starts a demo completion reveal after submission confirmation", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
     expect(screen.getByTestId("demo-completion-reveal")).toBeTruthy();
     expect(screen.getByTestId("demo-completion-canvas")).toBeTruthy();
     expect(screen.getByText(/40\s*x\s*50/i)).toBeTruthy();
     expect(screen.getByText(/2000 tiles/i)).toBeTruthy();
-    expect(screen.getByText(/Final fan photo accepted/i)).toBeTruthy();
+    expect(screen.getByText(/2000\s*\/\s*2000/)).toBeTruthy();
   });
 
   it("references the completed mosaic asset in the reveal area", () => {
@@ -153,8 +163,11 @@ describe("DemoClient", () => {
     fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
-    const completedMosaic = screen.getByAltText("Completed Takeru mosaic");
+    const completedMosaic = screen.getByAltText("Takeru completed mosaic");
     expect(completedMosaic.getAttribute("src")).toBe("/demo/demo_mozaiku.png");
   });
 
@@ -164,6 +177,9 @@ describe("DemoClient", () => {
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
     const completedOriginal = screen.getByRole("img", {
       name: /Takeru original submission/i,
@@ -177,17 +193,20 @@ describe("DemoClient", () => {
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
     expect(
       screen.getByText(/highlighted at \(37, 46\) as #2000/i),
     ).toBeTruthy();
 
-    const highlight = screen.getByTestId("demo-placement-highlight");
+    const highlight = screen.getByTestId("placement-highlight");
     const style = highlight.getAttribute("style");
-    expect(style).toContain(`left: ${(37 / unitTileGrid.cols) * 100}%`);
-    expect(style).toContain(`top: ${(46 / unitTileGrid.rows) * 100}%`);
-    expect(style).toContain(`width: ${100 / unitTileGrid.cols}%`);
-    expect(style).toContain(`height: ${100 / unitTileGrid.rows}%`);
+    expect(style).toContain("left:");
+    expect(style).toContain("top:");
+    expect(style).toContain("width:");
+    expect(style).toContain("height:");
   });
 
   it("toggles the fixed placement highlight", () => {
@@ -196,16 +215,19 @@ describe("DemoClient", () => {
     fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
-    expect(screen.getByTestId("demo-placement-highlight")).toBeTruthy();
+    expect(screen.getByTestId("placement-highlight")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /Hide highlight/i }));
 
-    expect(screen.queryByTestId("demo-placement-highlight")).toBeNull();
+    expect(screen.queryByTestId("placement-highlight")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /Show highlight/i }));
 
-    expect(screen.getByTestId("demo-placement-highlight")).toBeTruthy();
+    expect(screen.getByTestId("placement-highlight")).toBeTruthy();
   });
 
   it("shows the completed reveal immediately for reduced motion", () => {
@@ -224,6 +246,9 @@ describe("DemoClient", () => {
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
     selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm submission/i }),
+    );
 
     expect(screen.getByText(/Completed mosaic revealed/i)).toBeTruthy();
   });

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -28,6 +28,24 @@ function selectImage(file: File): void {
   fireEvent.change(input);
 }
 
+function mockReducedMotion(matches: boolean): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: matches && query === "(prefers-reduced-motion: reduce)",
+    media: query,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+}
+
+function submitDemoImage(): void {
+  selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
+  fireEvent.click(screen.getByRole("button", { name: /Confirm submission/i }));
+}
+
 describe("DemoClient", () => {
   afterEach(() => {
     cleanup();
@@ -140,46 +158,39 @@ describe("DemoClient", () => {
     expect(screen.queryByTestId("demo-completion-canvas")).toBeNull();
   });
 
-  it("starts a demo completion reveal after submission confirmation", () => {
+  it("shows a full-screen demo reveal overlay after submission confirmation", () => {
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
-    expect(screen.getByTestId("demo-completion-reveal")).toBeTruthy();
-    expect(screen.getByTestId("demo-completion-canvas")).toBeTruthy();
-    expect(screen.getByText(/40\s*x\s*50/i)).toBeTruthy();
-    expect(screen.getByText(/2000 tiles/i)).toBeTruthy();
+    expect(screen.getByTestId("demo-reveal-overlay")).toBeTruthy();
+    expect(screen.getByTestId("demo-reveal-canvas")).toBeTruthy();
+    expect(screen.getByText(/Loading assets/i)).toBeTruthy();
     expect(screen.getByText(/2000\s*\/\s*2000/)).toBeTruthy();
+    expect(screen.queryByTestId("reveal-panel")).toBeNull();
   });
 
   it("references the completed mosaic asset in the reveal area", () => {
+    mockReducedMotion(true);
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
     const completedMosaic = screen.getByAltText("Takeru completed mosaic");
     expect(completedMosaic.getAttribute("src")).toBe("/demo/demo_mozaiku.png");
   });
 
   it("shows the selected original photo in the completed panel", () => {
+    mockReducedMotion(true);
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
     const completedOriginal = screen.getByRole("img", {
       name: /Takeru original submission/i,
@@ -188,14 +199,12 @@ describe("DemoClient", () => {
   });
 
   it("shows the fixed demo placement highlight using unit grid math", () => {
+    mockReducedMotion(true);
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
     expect(
       screen.getByText(/highlighted at \(37, 46\) as #2000/i),
@@ -210,14 +219,12 @@ describe("DemoClient", () => {
   });
 
   it("toggles the fixed placement highlight", () => {
+    mockReducedMotion(true);
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Sui wallet/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
     expect(screen.getByTestId("placement-highlight")).toBeTruthy();
 
@@ -231,26 +238,15 @@ describe("DemoClient", () => {
   });
 
   it("shows the completed reveal immediately for reduced motion", () => {
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      addEventListener: vi.fn(),
-      addListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-      matches: query === "(prefers-reduced-motion: reduce)",
-      media: query,
-      onchange: null,
-      removeEventListener: vi.fn(),
-      removeListener: vi.fn(),
-    }));
+    mockReducedMotion(true);
     createObjectURL.mockReturnValue("blob:demo-preview-1");
     render(<DemoClient />);
     fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
 
-    selectImage(new File(["demo"], "portrait.png", { type: "image/png" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Confirm submission/i }),
-    );
+    submitDemoImage();
 
-    expect(screen.getByText(/Completed mosaic revealed/i)).toBeTruthy();
+    expect(screen.getByTestId("reveal-panel")).toBeTruthy();
+    expect(screen.queryByTestId("demo-reveal-overlay")).toBeNull();
   });
 
   it("revokes local preview URLs on reselection and unmount", () => {

--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { unitTileGrid } from "@one-portrait/shared";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DemoClient } from "./demo-client";

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 const takeru = {
@@ -20,6 +21,8 @@ const demoPlacement = {
   submissionNo: 2000,
 } as const;
 const revealDurationMs = 3600;
+const demoUnitId =
+  "0xdemo0000000000000000000000000000000000000000000000000000000007d0";
 
 export function DemoClient(): React.ReactElement {
   const [isConnected, setIsConnected] = useState(false);
@@ -56,125 +59,204 @@ export function DemoClient(): React.ReactElement {
   };
 
   return (
-    <main aria-label="Takeru Unit demo" className="op-demo op-demo-unit">
-      <section
-        aria-label="Athlete unit overview"
-        className="op-demo-unit-overview"
-      >
-        <div className="op-demo-unit-athlete">
-          <div className="op-demo-unit-athlete-copy">
-            <p className="op-eyebrow">
-              <span className="bar" />
-              <span>ONE Portrait demo unit</span>
-            </p>
-            <h1>{takeru.name}</h1>
-            <p>
-              A fixed demo unit for {takeru.name}, ready for the final fan
-              submission.
-            </p>
-          </div>
-          <div className="op-demo-unit-athlete-media">
-            {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-            <img src={takeru.imageSrc} alt={takeru.name} />
-          </div>
-        </div>
-
-        <div className="op-demo-unit-grid">
-          <article className="op-demo-unit-card">
-            <span>Athlete</span>
-            <strong>{takeru.name}</strong>
-            <p>
-              {takeru.country} / {takeru.discipline}
-            </p>
-          </article>
-
-          <article className="op-demo-unit-card">
-            <span>Unit</span>
-            <strong>Takeru Demo Unit</strong>
-            <p>Fixed demo flow</p>
-          </article>
-
-          <article className="op-demo-unit-card">
-            <span>Progress</span>
-            <strong>
-              {displaySubmittedCount} / {maxSlots}
-            </strong>
-            <p>
-              {previewUrl
-                ? "The final demo slot is locally staged."
-                : "One slot remains before reveal."}
-            </p>
-          </article>
-
-          <article className="op-demo-unit-card op-demo-unit-reveal-card">
-            {previewUrl ? (
-              <DemoCompletionReveal originalPhotoUrl={previewUrl} />
-            ) : (
-              <>
-                <span>Reveal area</span>
-                <strong>Awaiting final photo</strong>
-                <p>The completed portrait preview will appear here later.</p>
-              </>
-            )}
-          </article>
-        </div>
-      </section>
-
-      <section aria-label="Submission panel" className="op-demo-unit-submit">
-        <div>
-          <p className="op-eyebrow">
-            <span className="bar" />
-            <span>Submission panel</span>
-          </p>
-          <h2>Submit your photo</h2>
-          <p>
-            This stage demo uses local-only wallet state and a mock submission
-            preview.
-          </p>
-        </div>
-
-        <div className="op-demo-unit-submit-steps">
-          <div>
-            <span>01</span>
-            <strong>Connect wallet</strong>
-          </div>
-          <div>
-            <span>02</span>
-            <strong>Choose photo</strong>
-          </div>
-          <div>
-            <span>03</span>
-            <strong>Submit photo</strong>
-          </div>
-        </div>
-
-        {isConnected ? (
-          <div className="op-demo-unit-wallet-panel">
-            <p>
-              <strong>Demo wallet connected</strong>
-              <span>{demoAddress}</span>
-            </p>
-            <label>
-              <span>Choose one image</span>
-              <input
-                accept="image/*"
-                aria-label="Choose one image"
-                onChange={handleImageChange}
-                type="file"
-              />
-            </label>
-            {previewUrl ? (
-              <div className="op-demo-unit-preview">
-                {/* biome-ignore lint/performance/noImgElement: local object URL preview */}
-                <img alt="Selected submission preview" src={previewUrl} />
+    <main
+      aria-label="Takeru Unit demo"
+      className="grain relative min-h-screen overflow-hidden text-[var(--ink)]"
+    >
+      <div className="mx-auto grid max-w-6xl gap-px bg-[var(--rule)] lg:grid-cols-[1fr_380px]">
+        <section
+          aria-label="Athlete unit overview"
+          className="relative flex min-h-[80vh] flex-col justify-between gap-10 bg-[var(--bg-2)] p-8 md:p-12 lg:p-14"
+        >
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(ellipse at 50% 45%, rgba(255, 122, 26, 0.08), transparent 65%)",
+            }}
+          />
+          <div className="relative z-10 flex flex-wrap items-start justify-between gap-4">
+            <nav className="flex flex-wrap items-center gap-4">
+              <Link
+                className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
+                href="/"
+              >
+                ← All athletes
+              </Link>
+              <Link
+                className="font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)] hover:text-[var(--ink)]"
+                href="/gallery"
+              >
+                Participation history
+              </Link>
+            </nav>
+            <div className="text-right font-mono-op text-[11px] text-[var(--ink-dim)]">
+              <div>
+                {takeru.name}{" "}
+                <span className="text-[var(--ember)]">— UNIT</span>
               </div>
-            ) : null}
-            <button disabled type="button">
-              Mock local submit
-            </button>
+              <div className="mt-1 break-all text-[var(--ink-faint)]">
+                one_portrait::unit · {demoUnitId.slice(0, 10)}…
+              </div>
+            </div>
           </div>
-        ) : (
-          <div className="op-demo-unit-wallet-actions">
+
+          <div className="relative z-10 grid justify-items-center gap-6 text-center">
+            <div className="op-eyebrow">
+              <span className="bar" />
+              <span
+                className="h-2 w-2 rounded-full bg-[var(--ember)]"
+                style={{
+                  boxShadow: "0 0 14px var(--ember)",
+                  animation: "op-pulse 1s infinite",
+                }}
+              />
+              <span>UNIT ACTIVE — HIDDEN UNTIL REVEAL</span>
+            </div>
+
+            {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
+            <img
+              alt={takeru.name}
+              className="h-24 w-24 rounded-none border border-[var(--rule-strong)] object-cover"
+              src={takeru.imageSrc}
+            />
+
+            <h1 className="font-display text-[clamp(40px,7vw,88px)] leading-[0.9] tracking-[-0.01em] text-[var(--ink)]">
+              {takeru.name}
+            </h1>
+            <p className="font-mono-op text-[11px] break-all text-[var(--ink-faint)]">
+              {demoUnitId}
+            </p>
+
+            <div className="mt-4 w-full">
+              <DemoProgress submittedCount={displaySubmittedCount} />
+              {previewUrl ? (
+                <DemoCompletionReveal originalPhotoUrl={previewUrl} />
+              ) : null}
+            </div>
+          </div>
+
+          <div className="relative z-10 text-right font-mono-op text-[11px] uppercase tracking-[0.12em] text-[var(--ink-dim)]">
+            Stage demo · 0 SUI required
+            <br />
+            Local mock state · No network submission
+          </div>
+        </section>
+
+        <aside
+          aria-label="Submission panel"
+          className="flex flex-col gap-6 bg-[var(--bg-2)] p-6 lg:p-7"
+        >
+          <DemoSubmissionPanel
+            connectDemoWallet={connectDemoWallet}
+            handleImageChange={handleImageChange}
+            isConnected={isConnected}
+            previewUrl={previewUrl}
+          />
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+function DemoProgress({
+  submittedCount,
+}: {
+  readonly submittedCount: number;
+}): React.ReactElement {
+  const pct = (submittedCount / maxSlots) * 100;
+  const remaining = Math.max(0, maxSlots - submittedCount);
+  const progressLabel = submittedCount >= maxSlots ? "Filled" : "Filling";
+
+  return (
+    <div className="grid gap-5">
+      <p aria-live="polite" className="op-big-counter tabular-nums">
+        <span className="sr-only">{`${submittedCount} / ${maxSlots}`}</span>
+        <span className="num">{submittedCount}</span>
+        <span className="slash">/</span>
+        <span className="total">{maxSlots}</span>
+      </p>
+      <div className="grid gap-2">
+        <div className="op-progress-bar">
+          <div className="op-progress-bar-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <div className="flex flex-wrap items-baseline justify-between gap-3 font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
+          <span className="text-[var(--ember)]">{progressLabel}</span>
+          <span>
+            {remaining} tiles remaining · {submittedCount} Kakera minted
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DemoSubmissionPanel({
+  connectDemoWallet,
+  handleImageChange,
+  isConnected,
+  previewUrl,
+}: {
+  readonly connectDemoWallet: () => void;
+  readonly handleImageChange: (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  readonly isConnected: boolean;
+  readonly previewUrl: string | null;
+}): React.ReactElement {
+  return (
+    <section className="grid gap-4 border border-[var(--rule)] bg-[rgba(245,239,227,0.03)] p-5">
+      <div className="grid gap-2">
+        <p className="op-eyebrow">
+          <span className="bar" />
+          <span>Submit access</span>
+        </p>
+        <h2 className="font-display text-[24px] leading-[0.95] tracking-[-0.01em] text-[var(--ink)]">
+          Participation wallet
+        </h2>
+      </div>
+
+      {isConnected ? (
+        <>
+          <p className="text-sm text-[var(--ink-dim)]">
+            Demo wallet address confirmed. This local state signs nothing and
+            keeps the stage flow offline.
+          </p>
+          <p className="font-mono-op text-[11px] break-all text-[var(--ember)]">
+            {demoAddress}
+          </p>
+
+          <label className="grid gap-2 font-mono-op text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
+            <span>Choose one image</span>
+            <input
+              accept="image/*"
+              aria-label="Choose one image"
+              className="op-file-input block w-full font-mono-op text-[11px] text-[var(--ink)]"
+              onChange={handleImageChange}
+              type="file"
+            />
+          </label>
+
+          {previewUrl ? (
+            // biome-ignore lint/performance/noImgElement: local object URL preview
+            <img
+              alt="Selected submission preview"
+              className="max-w-full border border-[var(--rule-strong)]"
+              src={previewUrl}
+            />
+          ) : null}
+
+          <button className="op-btn-primary" disabled type="button">
+            Mock local submit
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-[var(--ink-dim)]">
+            Connect Google zkLogin or Sui wallet to submit from this waiting
+            room.
+          </p>
+          <div className="flex flex-wrap gap-3">
             <button
               className="op-btn-primary"
               onClick={connectDemoWallet}
@@ -190,9 +272,9 @@ export function DemoClient(): React.ReactElement {
               Connect Sui wallet
             </button>
           </div>
-        )}
-      </section>
-    </main>
+        </>
+      )}
+    </section>
   );
 }
 

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
+import { unitTileCount } from "@one-portrait/shared";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MasterPlacementView } from "../../lib/sui";
+import { MosaicConvergence } from "../home-experience";
 import { RevealPanel } from "../units/[unitId]/reveal-panel";
 
 const takeru = {
@@ -23,10 +24,10 @@ const demoPlacement = {
   submitter: demoAddress,
   submissionNo: 2000,
 } satisfies MasterPlacementView;
-const revealDurationMs = 3600;
+const demoRevealDurationMs = 3600;
 const demoUnitId =
   "0xdemo0000000000000000000000000000000000000000000000000000000007d0";
-type DemoPhase = "connected" | "previewing" | "revealing" | "completed";
+type DemoPhase = "connected" | "previewing" | "revealingOverlay" | "completed";
 
 export function DemoClient(): React.ReactElement {
   const [isConnected, setIsConnected] = useState(false);
@@ -35,7 +36,7 @@ export function DemoClient(): React.ReactElement {
   const previewUrlRef = useRef<string | null>(null);
   const isSubmitted =
     previewUrl !== null &&
-    (demoPhase === "revealing" || demoPhase === "completed");
+    (demoPhase === "revealingOverlay" || demoPhase === "completed");
   const displaySubmittedCount = isSubmitted ? maxSlots : submittedCount;
   const completeDemoReveal = useCallback(() => {
     setDemoPhase("completed");
@@ -75,7 +76,7 @@ export function DemoClient(): React.ReactElement {
       return;
     }
 
-    setDemoPhase(prefersReducedMotion() ? "completed" : "revealing");
+    setDemoPhase(prefersReducedMotion() ? "completed" : "revealingOverlay");
   };
 
   return (
@@ -150,12 +151,8 @@ export function DemoClient(): React.ReactElement {
 
             <div className="mt-4 w-full">
               <DemoProgress submittedCount={displaySubmittedCount} />
-              {previewUrl && isSubmitted ? (
-                <DemoCompletionReveal
-                  demoPhase={demoPhase}
-                  originalPhotoUrl={previewUrl}
-                  onComplete={completeDemoReveal}
-                />
+              {previewUrl && demoPhase === "completed" ? (
+                <DemoCompletionReveal originalPhotoUrl={previewUrl} />
               ) : null}
             </div>
           </div>
@@ -181,6 +178,13 @@ export function DemoClient(): React.ReactElement {
           />
         </aside>
       </div>
+
+      {previewUrl && demoPhase === "revealingOverlay" ? (
+        <DemoRevealOverlay
+          originalPhotoUrl={previewUrl}
+          onComplete={completeDemoReveal}
+        />
+      ) : null}
     </main>
   );
 }
@@ -236,7 +240,7 @@ function DemoSubmissionPanel({
 }): React.ReactElement {
   const hasPreview = previewUrl !== null;
   const submissionLocked =
-    demoPhase === "revealing" || demoPhase === "completed";
+    demoPhase === "revealingOverlay" || demoPhase === "completed";
 
   return (
     <section className="grid gap-4 border border-[var(--rule)] bg-[rgba(245,239,227,0.03)] p-5">
@@ -318,96 +322,12 @@ function DemoSubmissionPanel({
 }
 
 function DemoCompletionReveal({
-  demoPhase,
-  onComplete,
   originalPhotoUrl,
 }: {
-  readonly demoPhase: DemoPhase;
-  readonly onComplete: () => void;
   readonly originalPhotoUrl: string;
 }): React.ReactElement {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const frameRef = useRef<number | null>(null);
-  const startRef = useRef<number | null>(null);
-  const [chapter, setChapter] = useState(
-    demoPhase === "completed"
-      ? "Completed mosaic revealed."
-      : "Final fan photo accepted.",
-  );
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const context = canvas?.getContext("2d");
-
-    if (!canvas || !context || demoPhase === "completed") {
-      return;
-    }
-
-    const image = new Image();
-    let cancelled = false;
-
-    const render = (timestamp: number): void => {
-      if (startRef.current === null) {
-        startRef.current = timestamp;
-      }
-
-      const elapsed = timestamp - startRef.current;
-      const progress = Math.min(1, elapsed / revealDurationMs);
-
-      drawDemoRevealFrame(canvas, context, image, progress);
-
-      const nextChapter =
-        progress >= 1
-          ? "Completed mosaic revealed."
-          : progress > 0.62
-            ? "40 x 50 tiles are locking into the final portrait."
-            : "Final fan photo accepted.";
-      setChapter((current) =>
-        current === nextChapter ? current : nextChapter,
-      );
-
-      if (progress < 1) {
-        frameRef.current = window.requestAnimationFrame(render);
-      } else {
-        onComplete();
-      }
-    };
-
-    image.onload = () => {
-      if (!cancelled) {
-        frameRef.current = window.requestAnimationFrame(render);
-      }
-    };
-    image.src = completedMosaicSrc;
-
-    return () => {
-      cancelled = true;
-      if (frameRef.current !== null) {
-        window.cancelAnimationFrame(frameRef.current);
-      }
-    };
-  }, [demoPhase, onComplete]);
-
   return (
     <div className="mt-8 grid gap-5" data-testid="demo-completion-reveal">
-      <section
-        aria-label="Demo completion animation"
-        className="op-demo-completion-animation"
-      >
-        <canvas
-          aria-label="Demo completion reveal canvas"
-          className="op-demo-completion-canvas"
-          data-testid="demo-completion-canvas"
-          ref={canvasRef}
-        />
-        <div className="op-demo-completion-copy">
-          <span>Reveal area</span>
-          <strong>{chapter}</strong>
-          <p>
-            {unitTileGrid.cols} x {unitTileGrid.rows} = {unitTileCount} tiles
-          </p>
-        </div>
-      </section>
       <RevealPanel
         displayName={takeru.name}
         mosaicUrl={completedMosaicSrc}
@@ -418,68 +338,35 @@ function DemoCompletionReveal({
   );
 }
 
-function drawDemoRevealFrame(
-  canvas: HTMLCanvasElement,
-  context: CanvasRenderingContext2D,
-  image: HTMLImageElement,
-  progress: number,
-): void {
-  const rect = canvas.getBoundingClientRect();
-  const dpr = Math.min(window.devicePixelRatio || 1, 2);
-  const width = Math.max(1, rect.width || 520);
-  const height = Math.max(1, rect.height || 300);
-  const pixelWidth = Math.floor(width * dpr);
-  const pixelHeight = Math.floor(height * dpr);
+function DemoRevealOverlay({
+  originalPhotoUrl,
+  onComplete,
+}: {
+  readonly originalPhotoUrl: string;
+  readonly onComplete: () => void;
+}): React.ReactElement {
+  const tileSources = useMemo(() => [originalPhotoUrl], [originalPhotoUrl]);
 
-  if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
-  }
-
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
-  context.clearRect(0, 0, width, height);
-
-  const targetAspect = unitTileGrid.cols / unitTileGrid.rows;
-  const mosaicWidth = Math.min(width * 0.88, height * 0.72 * targetAspect);
-  const mosaicHeight = mosaicWidth / targetAspect;
-  const left = (width - mosaicWidth) / 2;
-  const top = (height - mosaicHeight) / 2;
-
-  context.fillStyle = "#070b10";
-  context.fillRect(0, 0, width, height);
-
-  if (image.complete && image.naturalWidth > 0) {
-    context.save();
-    context.globalAlpha = 0.2 + progress * 0.78;
-    context.drawImage(image, left, top, mosaicWidth, mosaicHeight);
-    context.restore();
-  }
-
-  const tileWidth = mosaicWidth / unitTileGrid.cols;
-  const tileHeight = mosaicHeight / unitTileGrid.rows;
-  const visibleTiles = Math.ceil(unitTileCount * progress);
-
-  for (let index = 0; index < visibleTiles; index += 1) {
-    const col = index % unitTileGrid.cols;
-    const row = Math.floor(index / unitTileGrid.cols);
-    const x = left + col * tileWidth;
-    const y = top + row * tileHeight;
-
-    context.fillStyle =
-      index % 5 === 0
-        ? "rgba(255, 122, 26, 0.34)"
-        : "rgba(245, 239, 227, 0.16)";
-    context.fillRect(
-      x,
-      y,
-      Math.max(0.6, tileWidth - 0.4),
-      Math.max(0.6, tileHeight - 0.4),
-    );
-  }
-
-  context.strokeStyle = "rgba(245, 239, 227, 0.42)";
-  context.lineWidth = 1;
-  context.strokeRect(left, top, mosaicWidth, mosaicHeight);
+  return (
+    <section
+      aria-label="Demo full-screen reveal"
+      className="op-demo-reveal-fullscreen"
+      data-testid="demo-reveal-overlay"
+    >
+      <MosaicConvergence
+        copyClassName=""
+        durationMs={demoRevealDurationMs}
+        eyebrowText="Unit active — hidden until reveal"
+        finalCount={unitTileCount}
+        initialChapter="Unit filled. The synchronized reveal begins."
+        initialCount={submittedCount}
+        mode="once"
+        onComplete={onComplete}
+        showReplay={false}
+        tileSources={tileSources}
+      />
+    </section>
+  );
 }
 
 function prefersReducedMotion(): boolean {

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+
 const takeru = {
   name: "Takeru",
   country: "Japan",
@@ -9,8 +11,42 @@ const takeru = {
 
 const submittedCount = 1999;
 const maxSlots = 2000;
+const demoAddress = "0xdemo...2000";
 
 export function DemoClient(): React.ReactElement {
+  const [isConnected, setIsConnected] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  const displaySubmittedCount = previewUrl ? maxSlots : submittedCount;
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
+  const connectDemoWallet = () => {
+    setIsConnected(true);
+  };
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+    }
+
+    const nextPreviewUrl = URL.createObjectURL(file);
+    previewUrlRef.current = nextPreviewUrl;
+    setPreviewUrl(nextPreviewUrl);
+  };
+
   return (
     <main aria-label="Takeru Unit demo" className="op-demo op-demo-unit">
       <section
@@ -53,9 +89,13 @@ export function DemoClient(): React.ReactElement {
           <article className="op-demo-unit-card">
             <span>Progress</span>
             <strong>
-              {submittedCount} / {maxSlots}
+              {displaySubmittedCount} / {maxSlots}
             </strong>
-            <p>One slot remains before reveal.</p>
+            <p>
+              {previewUrl
+                ? "The final demo slot is locally staged."
+                : "One slot remains before reveal."}
+            </p>
           </article>
 
           <article className="op-demo-unit-card op-demo-unit-reveal-card">
@@ -74,8 +114,8 @@ export function DemoClient(): React.ReactElement {
           </p>
           <h2>Submit your photo</h2>
           <p>
-            Wallet connection, file upload, and transaction actions are not
-            active in this demo step.
+            This stage demo uses local-only wallet state and a mock submission
+            preview.
           </p>
         </div>
 
@@ -94,9 +134,49 @@ export function DemoClient(): React.ReactElement {
           </div>
         </div>
 
-        <button disabled type="button">
-          Coming soon
-        </button>
+        {isConnected ? (
+          <div className="op-demo-unit-wallet-panel">
+            <p>
+              <strong>Demo wallet connected</strong>
+              <span>{demoAddress}</span>
+            </p>
+            <label>
+              <span>Choose one image</span>
+              <input
+                accept="image/*"
+                aria-label="Choose one image"
+                onChange={handleImageChange}
+                type="file"
+              />
+            </label>
+            {previewUrl ? (
+              <div className="op-demo-unit-preview">
+                {/* biome-ignore lint/performance/noImgElement: local object URL preview */}
+                <img alt="Selected submission preview" src={previewUrl} />
+              </div>
+            ) : null}
+            <button disabled type="button">
+              Mock local submit
+            </button>
+          </div>
+        ) : (
+          <div className="op-demo-unit-wallet-actions">
+            <button
+              className="op-btn-primary"
+              onClick={connectDemoWallet}
+              type="button"
+            >
+              Continue with Google zkLogin
+            </button>
+            <button
+              className="op-btn-ghost"
+              onClick={connectDemoWallet}
+              type="button"
+            >
+              Connect Sui wallet
+            </button>
+          </div>
+        )}
       </section>
     </main>
   );

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -2,7 +2,9 @@
 
 import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MasterPlacementView } from "../../lib/sui";
+import { RevealPanel } from "../units/[unitId]/reveal-panel";
 
 const takeru = {
   name: "Takeru",
@@ -18,17 +20,26 @@ const completedMosaicSrc = "/demo/demo_mozaiku.png";
 const demoPlacement = {
   x: 37,
   y: 46,
+  submitter: demoAddress,
   submissionNo: 2000,
-} as const;
+} satisfies MasterPlacementView;
 const revealDurationMs = 3600;
 const demoUnitId =
   "0xdemo0000000000000000000000000000000000000000000000000000000007d0";
+type DemoPhase = "connected" | "previewing" | "revealing" | "completed";
 
 export function DemoClient(): React.ReactElement {
   const [isConnected, setIsConnected] = useState(false);
+  const [demoPhase, setDemoPhase] = useState<DemoPhase>("connected");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const previewUrlRef = useRef<string | null>(null);
-  const displaySubmittedCount = previewUrl ? maxSlots : submittedCount;
+  const isSubmitted =
+    previewUrl !== null &&
+    (demoPhase === "revealing" || demoPhase === "completed");
+  const displaySubmittedCount = isSubmitted ? maxSlots : submittedCount;
+  const completeDemoReveal = useCallback(() => {
+    setDemoPhase("completed");
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -56,6 +67,15 @@ export function DemoClient(): React.ReactElement {
     const nextPreviewUrl = URL.createObjectURL(file);
     previewUrlRef.current = nextPreviewUrl;
     setPreviewUrl(nextPreviewUrl);
+    setDemoPhase("previewing");
+  };
+
+  const confirmDemoSubmission = () => {
+    if (!previewUrl) {
+      return;
+    }
+
+    setDemoPhase(prefersReducedMotion() ? "completed" : "revealing");
   };
 
   return (
@@ -130,8 +150,12 @@ export function DemoClient(): React.ReactElement {
 
             <div className="mt-4 w-full">
               <DemoProgress submittedCount={displaySubmittedCount} />
-              {previewUrl ? (
-                <DemoCompletionReveal originalPhotoUrl={previewUrl} />
+              {previewUrl && isSubmitted ? (
+                <DemoCompletionReveal
+                  demoPhase={demoPhase}
+                  originalPhotoUrl={previewUrl}
+                  onComplete={completeDemoReveal}
+                />
               ) : null}
             </div>
           </div>
@@ -148,7 +172,9 @@ export function DemoClient(): React.ReactElement {
           className="flex flex-col gap-6 bg-[var(--bg-2)] p-6 lg:p-7"
         >
           <DemoSubmissionPanel
+            confirmDemoSubmission={confirmDemoSubmission}
             connectDemoWallet={connectDemoWallet}
+            demoPhase={demoPhase}
             handleImageChange={handleImageChange}
             isConnected={isConnected}
             previewUrl={previewUrl}
@@ -192,18 +218,26 @@ function DemoProgress({
 }
 
 function DemoSubmissionPanel({
+  confirmDemoSubmission,
   connectDemoWallet,
+  demoPhase,
   handleImageChange,
   isConnected,
   previewUrl,
 }: {
+  readonly confirmDemoSubmission: () => void;
   readonly connectDemoWallet: () => void;
+  readonly demoPhase: DemoPhase;
   readonly handleImageChange: (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => void;
   readonly isConnected: boolean;
   readonly previewUrl: string | null;
 }): React.ReactElement {
+  const hasPreview = previewUrl !== null;
+  const submissionLocked =
+    demoPhase === "revealing" || demoPhase === "completed";
+
   return (
     <section className="grid gap-4 border border-[var(--rule)] bg-[rgba(245,239,227,0.03)] p-5">
       <div className="grid gap-2">
@@ -246,7 +280,12 @@ function DemoSubmissionPanel({
             />
           ) : null}
 
-          <button className="op-btn-primary" disabled type="button">
+          <button
+            className="op-btn-primary"
+            disabled={!hasPreview || submissionLocked}
+            onClick={confirmDemoSubmission}
+            type="button"
+          >
             Confirm submission
           </button>
         </>
@@ -279,25 +318,28 @@ function DemoSubmissionPanel({
 }
 
 function DemoCompletionReveal({
+  demoPhase,
+  onComplete,
   originalPhotoUrl,
 }: {
+  readonly demoPhase: DemoPhase;
+  readonly onComplete: () => void;
   readonly originalPhotoUrl: string;
 }): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const frameRef = useRef<number | null>(null);
   const startRef = useRef<number | null>(null);
-  const reducedMotion = prefersReducedMotion();
-  const [highlightVisible, setHighlightVisible] = useState(true);
   const [chapter, setChapter] = useState(
-    reducedMotion ? "Completed mosaic revealed." : "Final fan photo accepted.",
+    demoPhase === "completed"
+      ? "Completed mosaic revealed."
+      : "Final fan photo accepted.",
   );
-  const highlightLabel = highlightVisible ? "Hide highlight" : "Show highlight";
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas?.getContext("2d");
 
-    if (!canvas || !context) {
+    if (!canvas || !context || demoPhase === "completed") {
       return;
     }
 
@@ -310,9 +352,7 @@ function DemoCompletionReveal({
       }
 
       const elapsed = timestamp - startRef.current;
-      const progress = reducedMotion
-        ? 1
-        : Math.min(1, elapsed / revealDurationMs);
+      const progress = Math.min(1, elapsed / revealDurationMs);
 
       drawDemoRevealFrame(canvas, context, image, progress);
 
@@ -328,6 +368,8 @@ function DemoCompletionReveal({
 
       if (progress < 1) {
         frameRef.current = window.requestAnimationFrame(render);
+      } else {
+        onComplete();
       }
     };
 
@@ -338,26 +380,19 @@ function DemoCompletionReveal({
     };
     image.src = completedMosaicSrc;
 
-    if (reducedMotion) {
-      frameRef.current = window.requestAnimationFrame(render);
-    }
-
     return () => {
       cancelled = true;
       if (frameRef.current !== null) {
         window.cancelAnimationFrame(frameRef.current);
       }
     };
-  }, [reducedMotion]);
+  }, [demoPhase, onComplete]);
 
   return (
-    <div
-      className="op-demo-completion-reveal"
-      data-testid="demo-completion-reveal"
-    >
-      <div
-        className="op-demo-completion-mosaic"
-        data-testid="demo-completion-mosaic"
+    <div className="mt-8 grid gap-5" data-testid="demo-completion-reveal">
+      <section
+        aria-label="Demo completion animation"
+        className="op-demo-completion-animation"
       >
         <canvas
           aria-label="Demo completion reveal canvas"
@@ -365,46 +400,20 @@ function DemoCompletionReveal({
           data-testid="demo-completion-canvas"
           ref={canvasRef}
         />
-        <div className="op-demo-completion-fallback">
-          {/* biome-ignore lint/performance/noImgElement: public completed demo mosaic asset */}
-          <img alt="Completed Takeru mosaic" src={completedMosaicSrc} />
-          {highlightVisible ? (
-            <div
-              className="op-demo-placement-highlight op-placement-highlight-frame op-placement-highlight-pulse"
-              data-testid="demo-placement-highlight"
-              style={{
-                left: `${(demoPlacement.x / unitTileGrid.cols) * 100}%`,
-                top: `${(demoPlacement.y / unitTileGrid.rows) * 100}%`,
-                width: `${100 / unitTileGrid.cols}%`,
-                height: `${100 / unitTileGrid.rows}%`,
-              }}
-            />
-          ) : null}
+        <div className="op-demo-completion-copy">
+          <span>Reveal area</span>
+          <strong>{chapter}</strong>
+          <p>
+            {unitTileGrid.cols} x {unitTileGrid.rows} = {unitTileCount} tiles
+          </p>
         </div>
-      </div>
-      <div className="op-demo-completion-copy">
-        <span>Reveal area</span>
-        <strong>{chapter}</strong>
-        <p>
-          {unitTileGrid.cols} x {unitTileGrid.rows} = {unitTileCount} tiles
-        </p>
-        <p>
-          Your Kakera is highlighted at ({demoPlacement.x}, {demoPlacement.y})
-          as #{demoPlacement.submissionNo}.
-        </p>
-        <button
-          aria-pressed={highlightVisible}
-          className="op-demo-highlight-toggle"
-          onClick={() => setHighlightVisible((current) => !current)}
-          type="button"
-        >
-          {highlightLabel}
-        </button>
-        <div className="op-demo-completion-original">
-          {/* biome-ignore lint/performance/noImgElement: local object URL preview */}
-          <img alt="Takeru original submission" src={originalPhotoUrl} />
-        </div>
-      </div>
+      </section>
+      <RevealPanel
+        displayName={takeru.name}
+        mosaicUrl={completedMosaicSrc}
+        originalPhotoUrl={originalPhotoUrl}
+        placement={demoPlacement}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
 import { useEffect, useRef, useState } from "react";
 
 const takeru = {
@@ -10,8 +11,10 @@ const takeru = {
 } as const;
 
 const submittedCount = 1999;
-const maxSlots = 2000;
+const maxSlots = unitTileCount;
 const demoAddress = "0xdemo...2000";
+const completedMosaicSrc = "/demo/demo_mozaiku.png";
+const revealDurationMs = 3600;
 
 export function DemoClient(): React.ReactElement {
   const [isConnected, setIsConnected] = useState(false);
@@ -99,9 +102,15 @@ export function DemoClient(): React.ReactElement {
           </article>
 
           <article className="op-demo-unit-card op-demo-unit-reveal-card">
-            <span>Reveal area</span>
-            <strong>Awaiting final photo</strong>
-            <p>The completed portrait preview will appear here later.</p>
+            {previewUrl ? (
+              <DemoCompletionReveal />
+            ) : (
+              <>
+                <span>Reveal area</span>
+                <strong>Awaiting final photo</strong>
+                <p>The completed portrait preview will appear here later.</p>
+              </>
+            )}
           </article>
         </div>
       </section>
@@ -179,5 +188,170 @@ export function DemoClient(): React.ReactElement {
         )}
       </section>
     </main>
+  );
+}
+
+function DemoCompletionReveal(): React.ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+  const reducedMotion = prefersReducedMotion();
+  const [chapter, setChapter] = useState(
+    reducedMotion ? "Completed mosaic revealed." : "Final fan photo accepted.",
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+
+    if (!canvas || !context) {
+      return;
+    }
+
+    const image = new Image();
+    let cancelled = false;
+
+    const render = (timestamp: number): void => {
+      if (startRef.current === null) {
+        startRef.current = timestamp;
+      }
+
+      const elapsed = timestamp - startRef.current;
+      const progress = reducedMotion
+        ? 1
+        : Math.min(1, elapsed / revealDurationMs);
+
+      drawDemoRevealFrame(canvas, context, image, progress);
+
+      const nextChapter =
+        progress >= 1
+          ? "Completed mosaic revealed."
+          : progress > 0.62
+            ? "40 x 50 tiles are locking into the final portrait."
+            : "Final fan photo accepted.";
+      setChapter((current) =>
+        current === nextChapter ? current : nextChapter,
+      );
+
+      if (progress < 1) {
+        frameRef.current = window.requestAnimationFrame(render);
+      }
+    };
+
+    image.onload = () => {
+      if (!cancelled) {
+        frameRef.current = window.requestAnimationFrame(render);
+      }
+    };
+    image.src = completedMosaicSrc;
+
+    if (reducedMotion) {
+      frameRef.current = window.requestAnimationFrame(render);
+    }
+
+    return () => {
+      cancelled = true;
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, [reducedMotion]);
+
+  return (
+    <div
+      className="op-demo-completion-reveal"
+      data-testid="demo-completion-reveal"
+    >
+      <canvas
+        aria-label="Demo completion reveal canvas"
+        className="op-demo-completion-canvas"
+        data-testid="demo-completion-canvas"
+        ref={canvasRef}
+      />
+      <div className="op-demo-completion-fallback">
+        {/* biome-ignore lint/performance/noImgElement: public completed demo mosaic asset */}
+        <img alt="Completed Takeru mosaic" src={completedMosaicSrc} />
+      </div>
+      <div className="op-demo-completion-copy">
+        <span>Reveal area</span>
+        <strong>{chapter}</strong>
+        <p>
+          {unitTileGrid.cols} x {unitTileGrid.rows} = {unitTileCount} tiles
+        </p>
+        <p>All demo slots are complete for the unit.</p>
+      </div>
+    </div>
+  );
+}
+
+function drawDemoRevealFrame(
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  progress: number,
+): void {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const width = Math.max(1, rect.width || 520);
+  const height = Math.max(1, rect.height || 300);
+  const pixelWidth = Math.floor(width * dpr);
+  const pixelHeight = Math.floor(height * dpr);
+
+  if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+    canvas.width = pixelWidth;
+    canvas.height = pixelHeight;
+  }
+
+  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  context.clearRect(0, 0, width, height);
+
+  const targetAspect = unitTileGrid.cols / unitTileGrid.rows;
+  const mosaicWidth = Math.min(width * 0.88, height * 0.72 * targetAspect);
+  const mosaicHeight = mosaicWidth / targetAspect;
+  const left = (width - mosaicWidth) / 2;
+  const top = (height - mosaicHeight) / 2;
+
+  context.fillStyle = "#070b10";
+  context.fillRect(0, 0, width, height);
+
+  if (image.complete && image.naturalWidth > 0) {
+    context.save();
+    context.globalAlpha = 0.2 + progress * 0.78;
+    context.drawImage(image, left, top, mosaicWidth, mosaicHeight);
+    context.restore();
+  }
+
+  const tileWidth = mosaicWidth / unitTileGrid.cols;
+  const tileHeight = mosaicHeight / unitTileGrid.rows;
+  const visibleTiles = Math.ceil(unitTileCount * progress);
+
+  for (let index = 0; index < visibleTiles; index += 1) {
+    const col = index % unitTileGrid.cols;
+    const row = Math.floor(index / unitTileGrid.cols);
+    const x = left + col * tileWidth;
+    const y = top + row * tileHeight;
+
+    context.fillStyle =
+      index % 5 === 0
+        ? "rgba(255, 122, 26, 0.34)"
+        : "rgba(245, 239, 227, 0.16)";
+    context.fillRect(
+      x,
+      y,
+      Math.max(0.6, tileWidth - 0.4),
+      Math.max(0.6, tileHeight - 0.4),
+    );
+  }
+
+  context.strokeStyle = "rgba(245, 239, 227, 0.42)";
+  context.lineWidth = 1;
+  context.strokeRect(left, top, mosaicWidth, mosaicHeight);
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
   );
 }

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -133,7 +133,7 @@ export function DemoClient(): React.ReactElement {
           </p>
         </div>
 
-        <div className="op-demo-unit-submit-steps" aria-label="Submission flow">
+        <div className="op-demo-unit-submit-steps">
           <div>
             <span>01</span>
             <strong>Connect wallet</strong>

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -247,7 +247,7 @@ function DemoSubmissionPanel({
           ) : null}
 
           <button className="op-btn-primary" disabled type="button">
-            Mock local submit
+            Confirm submission
           </button>
         </>
       ) : (
@@ -262,14 +262,14 @@ function DemoSubmissionPanel({
               onClick={connectDemoWallet}
               type="button"
             >
-              Continue with Google zkLogin
+              Google zkLogin
             </button>
             <button
               className="op-btn-ghost"
               onClick={connectDemoWallet}
               type="button"
             >
-              Connect Sui wallet
+              Sui wallet
             </button>
           </div>
         </>

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -273,27 +273,32 @@ function DemoCompletionReveal({
       className="op-demo-completion-reveal"
       data-testid="demo-completion-reveal"
     >
-      <canvas
-        aria-label="Demo completion reveal canvas"
-        className="op-demo-completion-canvas"
-        data-testid="demo-completion-canvas"
-        ref={canvasRef}
-      />
-      <div className="op-demo-completion-fallback">
-        {/* biome-ignore lint/performance/noImgElement: public completed demo mosaic asset */}
-        <img alt="Completed Takeru mosaic" src={completedMosaicSrc} />
-        {highlightVisible ? (
-          <div
-            className="op-demo-placement-highlight op-placement-highlight-frame op-placement-highlight-pulse"
-            data-testid="demo-placement-highlight"
-            style={{
-              left: `${(demoPlacement.x / unitTileGrid.cols) * 100}%`,
-              top: `${(demoPlacement.y / unitTileGrid.rows) * 100}%`,
-              width: `${100 / unitTileGrid.cols}%`,
-              height: `${100 / unitTileGrid.rows}%`,
-            }}
-          />
-        ) : null}
+      <div
+        className="op-demo-completion-mosaic"
+        data-testid="demo-completion-mosaic"
+      >
+        <canvas
+          aria-label="Demo completion reveal canvas"
+          className="op-demo-completion-canvas"
+          data-testid="demo-completion-canvas"
+          ref={canvasRef}
+        />
+        <div className="op-demo-completion-fallback">
+          {/* biome-ignore lint/performance/noImgElement: public completed demo mosaic asset */}
+          <img alt="Completed Takeru mosaic" src={completedMosaicSrc} />
+          {highlightVisible ? (
+            <div
+              className="op-demo-placement-highlight op-placement-highlight-frame op-placement-highlight-pulse"
+              data-testid="demo-placement-highlight"
+              style={{
+                left: `${(demoPlacement.x / unitTileGrid.cols) * 100}%`,
+                top: `${(demoPlacement.y / unitTileGrid.rows) * 100}%`,
+                width: `${100 / unitTileGrid.cols}%`,
+                height: `${100 / unitTileGrid.rows}%`,
+              }}
+            />
+          ) : null}
+        </div>
       </div>
       <div className="op-demo-completion-copy">
         <span>Reveal area</span>

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -1,938 +1,103 @@
 "use client";
 
-import { unitTileCount, unitTileGrid } from "@one-portrait/shared";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+const takeru = {
+  name: "Takeru",
+  country: "Japan",
+  discipline: "Kickboxing",
+  imageSrc: "/demo/one-athletes/Takeru-500x345-1.png",
+} as const;
 
-type AthleteAsset = {
-  readonly name: string;
-  readonly country: string;
-  readonly role: string;
-  readonly src: string;
-};
-
-type Tile = {
-  readonly col: number;
-  readonly row: number;
-  readonly startX: number;
-  readonly startY: number;
-  readonly controlX: number;
-  readonly controlY: number;
-  readonly delay: number;
-  readonly duration: number;
-  readonly fanIndex: number;
-};
-
-type FanTileStyle = {
-  readonly background: string;
-  readonly clothing: string;
-  readonly hair: string;
-  readonly skin: string;
-};
-
-const athleteAssets: readonly AthleteAsset[] = [
-  {
-    name: "Yuya Wakamatsu",
-    country: "Japan",
-    role: "Champion portrait",
-    src: "/demo/one-athletes/Yuya_Wakamatsu-avatar-champ-500x345-1.png",
-  },
-  {
-    name: "Takeru",
-    country: "Japan",
-    role: "Kickboxing icon",
-    src: "/demo/one-athletes/Takeru-500x345-1.png",
-  },
-  {
-    name: "Rodtang Jitmuangnon",
-    country: "Thailand",
-    role: "Muay Thai force",
-    src: "/demo/one-athletes/Rodtang_Jitmuangnon-Avatar-500x345-1.png",
-  },
-  {
-    name: "Ayaka Miura",
-    country: "Japan",
-    role: "Submission artist",
-    src: "/demo/one-athletes/Ayaka_Miura-avatar-500x345-1.png",
-  },
-  {
-    name: "Itsuki Hirata",
-    country: "Japan",
-    role: "Atomweight star",
-    src: "/demo/one-athletes/Itsuki_Hirata-avatar-500x345-4.png",
-  },
-  {
-    name: "Jonathan Haggerty",
-    country: "United Kingdom",
-    role: "Striking champion",
-    src: "/demo/one-athletes/Jonathan_Haggerty-avatar-500x345-4.png",
-  },
-  {
-    name: "Ritu Phogat",
-    country: "India",
-    role: "Wrestling pressure",
-    src: "/demo/one-athletes/Ritu_Phogat-avatar-500x345-1.png",
-  },
-  {
-    name: "Toma Kuroda",
-    country: "Japan",
-    role: "Flyweight contender",
-    src: "/demo/one-athletes/Toma_Kuroda-avatar-500x345-1.png",
-  },
-  {
-    name: "Yuki Yoza",
-    country: "Japan",
-    role: "Kickboxing precision",
-    src: "/demo/one-athletes/Yuki_Yoza-avatar-500x345-1.png",
-  },
-  {
-    name: "Chihiro Sawada",
-    country: "Japan",
-    role: "Grappling speed",
-    src: "/demo/one-athletes/Chihiro_Sawada-avatar-500x345-3.png",
-  },
-  {
-    name: "Avazbek Kholmirzaev",
-    country: "Uzbekistan",
-    role: "Rising force",
-    src: "/demo/one-athletes/Avazbek_Kholmirzaev-Avatar-500x345-1.png",
-  },
-];
-
-const mosaicSrc = "/demo/demo_mozaiku.png";
-const fanUploadSrc = "/demo/fan-upload-dogs.png";
-const revealDurationMs = 15000;
-const rosterLoop = [...athleteAssets, ...athleteAssets].map(
-  (athlete, index) => ({
-    athlete,
-    id: `${index < athleteAssets.length ? "first" : "second"}-${athlete.name}`,
-  }),
-);
-const openingStats = [
-  { label: "Fan photos", value: unitTileCount.toLocaleString() },
-  { label: "Sui gas", value: "0 SUI" },
-  { label: "Reveal", value: "Sync" },
-];
-const fanTileStyles: readonly FanTileStyle[] = [
-  {
-    background: "#27364d",
-    clothing: "#ff7a1a",
-    hair: "#17120f",
-    skin: "#d89a62",
-  },
-  {
-    background: "#462a2f",
-    clothing: "#4da2ff",
-    hair: "#2a1710",
-    skin: "#b8734a",
-  },
-  {
-    background: "#1d4339",
-    clothing: "#14b88a",
-    hair: "#100f0d",
-    skin: "#f0bd86",
-  },
-  {
-    background: "#3f3657",
-    clothing: "#ffd166",
-    hair: "#2b211c",
-    skin: "#9e6545",
-  },
-  {
-    background: "#4d2b19",
-    clothing: "#d4320e",
-    hair: "#090807",
-    skin: "#e7a571",
-  },
-  {
-    background: "#233f51",
-    clothing: "#f5efe3",
-    hair: "#3a2218",
-    skin: "#c68455",
-  },
-];
+const submittedCount = 1999;
+const maxSlots = 2000;
 
 export function DemoClient(): React.ReactElement {
-  const revealRef = useRef<HTMLElement | null>(null);
-
-  const jumpToReveal = (): void => {
-    revealRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
   return (
-    <main className="op-demo">
-      <section className="op-demo-hero" aria-label="Demo opening">
-        <div className="op-demo-hero-media" aria-hidden>
-          {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-          <img
-            className="op-demo-hero-athlete primary"
-            src={athleteAssets[0].src}
-            alt=""
-          />
-          {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-          <img
-            className="op-demo-hero-athlete left"
-            src={athleteAssets[2].src}
-            alt=""
-          />
-          {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-          <img
-            className="op-demo-hero-athlete mid-left"
-            src={athleteAssets[9].src}
-            alt=""
-          />
-          {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-          <img
-            className="op-demo-hero-athlete right"
-            src={athleteAssets[1].src}
-            alt=""
-          />
-          <div className="op-demo-grid-glow" />
-        </div>
-
-        <div className="op-demo-hero-copy">
-          <p className="op-eyebrow">
-            <span className="bar" />
-            <span>ONE Samurai · 2026.04.29 · Ariake Arena</span>
-          </p>
-          <h1 className="op-demo-title">
-            ONE Portrait
-            <span>Reveal Arena</span>
-          </h1>
-          <p className="op-demo-lede">
-            Fans submit one photo each. The final Kakera lands, 2,000 fragments
-            converge, and a single portrait appears for everyone at once.
-          </p>
-          <div className="op-demo-stat-row">
-            {openingStats.map((stat) => (
-              <div className="op-demo-stat" key={stat.label}>
-                <span>{stat.label}</span>
-                <strong>{stat.value}</strong>
-              </div>
-            ))}
-          </div>
-          <button
-            className="op-btn-primary"
-            onClick={jumpToReveal}
-            type="button"
-          >
-            Jump to reveal
-          </button>
-        </div>
-      </section>
-
-      <section className="op-demo-roster" aria-label="Athlete roster">
-        <div className="op-demo-section-head">
-          <p className="op-eyebrow">
-            <span className="bar" />
-            <span>Step 01 — Pick your warrior</span>
-          </p>
-          <h2>Pick the warrior the crowd stands behind.</h2>
-        </div>
-        <div className="op-demo-athlete-track">
-          {rosterLoop.map(({ athlete, id }) => (
-            <article className="op-demo-athlete-card" key={id}>
-              {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-              <img src={athlete.src} alt={athlete.name} />
-              <div>
-                <p>{athlete.country}</p>
-                <h3>{athlete.name}</h3>
-                <span>{athlete.role}</span>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="op-demo-submit" aria-label="Fan photo submission">
-        <div className="op-demo-submit-copy">
-          <p className="op-eyebrow">
-            <span className="bar" />
-            <span>Step 02 — Submit your photo</span>
-          </p>
-          <h2>Your photo becomes one Kakera.</h2>
-          <p>
-            Each fan contributes one original photo. ONE Portrait stores the
-            image on Walrus, submits the sponsored transaction on Sui, and mints
-            a Soulbound Kakera for that fan.
-          </p>
-        </div>
-
-        <div className="op-demo-submit-panel">
-          <div className="op-demo-phone">
-            <div className="op-demo-upload-preview">
-              {/* biome-ignore lint/performance/noImgElement: public demo upload asset */}
-              <img src={fanUploadSrc} alt="Two dogs in a stroller" />
-              <div className="op-demo-upload-scan" aria-hidden />
-            </div>
-            <div className="op-demo-selfie-grid compact" aria-hidden>
-              {fanTileStyles.map((style) => (
-                <div
-                  className="op-demo-selfie"
-                  key={style.background}
-                  style={
-                    {
-                      "--fan-bg": style.background,
-                      "--fan-cloth": style.clothing,
-                      "--fan-hair": style.hair,
-                      "--fan-skin": style.skin,
-                    } as React.CSSProperties
-                  }
-                >
-                  <span />
-                </div>
-              ))}
-            </div>
-            <div className="op-demo-submit-status">
-              <span>Selected photo</span>
-              <strong>Ready for Walrus</strong>
-            </div>
-          </div>
-
-          <div className="op-demo-submit-steps">
-            <div>
-              <span>01</span>
-              <strong>Google zkLogin</strong>
-            </div>
-            <div>
-              <span>02</span>
-              <strong>Walrus photo storage</strong>
-            </div>
-            <div>
-              <span>03</span>
-              <strong>Sponsored Sui transaction</strong>
-            </div>
-            <div>
-              <span>04</span>
-              <strong>Soulbound Kakera minted</strong>
-            </div>
-          </div>
-        </div>
-      </section>
-
+    <main aria-label="Takeru Unit demo" className="op-demo op-demo-unit">
       <section
-        className="op-demo-reveal"
-        ref={revealRef}
-        aria-label="Mosaic reveal sequence"
+        aria-label="Athlete unit overview"
+        className="op-demo-unit-overview"
       >
-        <MosaicConvergence />
+        <div className="op-demo-unit-athlete">
+          <div className="op-demo-unit-athlete-copy">
+            <p className="op-eyebrow">
+              <span className="bar" />
+              <span>ONE Portrait demo unit</span>
+            </p>
+            <h1>{takeru.name}</h1>
+            <p>
+              A fixed demo unit for {takeru.name}, ready for the final fan
+              submission.
+            </p>
+          </div>
+          <div className="op-demo-unit-athlete-media">
+            {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
+            <img src={takeru.imageSrc} alt={takeru.name} />
+          </div>
+        </div>
+
+        <div className="op-demo-unit-grid">
+          <article className="op-demo-unit-card">
+            <span>Athlete</span>
+            <strong>{takeru.name}</strong>
+            <p>
+              {takeru.country} / {takeru.discipline}
+            </p>
+          </article>
+
+          <article className="op-demo-unit-card">
+            <span>Unit</span>
+            <strong>Takeru Demo Unit</strong>
+            <p>Fixed demo flow</p>
+          </article>
+
+          <article className="op-demo-unit-card">
+            <span>Progress</span>
+            <strong>
+              {submittedCount} / {maxSlots}
+            </strong>
+            <p>One slot remains before reveal.</p>
+          </article>
+
+          <article className="op-demo-unit-card op-demo-unit-reveal-card">
+            <span>Reveal area</span>
+            <strong>Awaiting final photo</strong>
+            <p>The completed portrait preview will appear here later.</p>
+          </article>
+        </div>
       </section>
 
-      <section className="op-demo-kakera" aria-label="Kakera closing">
-        <div className="op-demo-kakera-copy">
+      <section aria-label="Submission panel" className="op-demo-unit-submit">
+        <div>
           <p className="op-eyebrow">
             <span className="bar" />
-            <span>Kakera · Participation memory</span>
+            <span>Submission panel</span>
           </p>
-          <h2>The memory becomes a Soulbound Kakera.</h2>
+          <h2>Submit your photo</h2>
           <p>
-            The demo closes on the participant view: the original photo, the
-            completed mosaic, and the highlighted tile position recorded as a
-            permanent on-chain memory.
+            Wallet connection, file upload, and transaction actions are not
+            active in this demo step.
           </p>
         </div>
-        <div className="op-demo-kakera-card">
-          <div className="op-demo-kakera-media">
-            {/* biome-ignore lint/performance/noImgElement: public demo cutout asset */}
-            <img src={athleteAssets[0].src} alt="Yuya Wakamatsu" />
+
+        <div className="op-demo-unit-submit-steps" aria-label="Submission flow">
+          <div>
+            <span>01</span>
+            <strong>Connect wallet</strong>
           </div>
-          <dl>
-            <div>
-              <dt>Kakera</dt>
-              <dd>#2000</dd>
-            </div>
-            <div>
-              <dt>Placement</dt>
-              <dd>col 31 / row 44</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>Minted · Soulbound</dd>
-            </div>
-          </dl>
+          <div>
+            <span>02</span>
+            <strong>Choose photo</strong>
+          </div>
+          <div>
+            <span>03</span>
+            <strong>Submit photo</strong>
+          </div>
         </div>
+
+        <button disabled type="button">
+          Coming soon
+        </button>
       </section>
     </main>
   );
-}
-
-function MosaicConvergence(): React.ReactElement {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const animationRef = useRef<number | null>(null);
-  const startRef = useRef<number | null>(null);
-  const tileCacheRef = useRef<{
-    readonly height: number;
-    readonly tiles: readonly Tile[];
-    readonly width: number;
-  } | null>(null);
-  const lastChapterRef = useRef("");
-  const lastCountRef = useRef(1873);
-  const [submittedCount, setSubmittedCount] = useState(1873);
-  const [chapter, setChapter] = useState("Photos incoming");
-  const [isReady, setIsReady] = useState(false);
-
-  const imageSources = useMemo(() => [mosaicSrc], []);
-  const images = useLoadedImages(imageSources);
-
-  const replay = useCallback(() => {
-    startRef.current = null;
-    tileCacheRef.current = null;
-    lastChapterRef.current = "";
-    lastCountRef.current = 1873;
-    setSubmittedCount(1873);
-    setChapter("Photos incoming");
-  }, []);
-
-  useEffect(() => {
-    if (!images) {
-      return;
-    }
-
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
-
-    setIsReady(true);
-    const context = canvas.getContext("2d");
-    if (!context) {
-      return;
-    }
-
-    const finalImage = images[0];
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-
-    const render = (timestamp: number): void => {
-      if (startRef.current === null) {
-        startRef.current = timestamp;
-      }
-
-      const elapsed = timestamp - startRef.current;
-      const loopElapsed = prefersReducedMotion
-        ? revealDurationMs
-        : elapsed % revealDurationMs;
-      const progress = clamp(loopElapsed / revealDurationMs, 0, 1);
-      const layout = prepareCanvas(canvas, context);
-      const cached = tileCacheRef.current;
-      const tiles =
-        cached &&
-        cached.width === layout.width &&
-        cached.height === layout.height
-          ? cached.tiles
-          : createAndCacheTiles(tileCacheRef, layout.width, layout.height);
-      drawRevealFrame({
-        context,
-        finalImage,
-        layout,
-        progress,
-        tiles,
-      });
-
-      const countProgress = smoothstep(0.08, 0.78, progress);
-      const nextCount = Math.min(
-        unitTileCount,
-        1873 + Math.round((unitTileCount - 1873) * countProgress),
-      );
-      if (lastCountRef.current !== nextCount) {
-        lastCountRef.current = nextCount;
-        setSubmittedCount(nextCount);
-      }
-      const nextChapter = resolveRevealChapter(progress);
-      if (lastChapterRef.current !== nextChapter) {
-        lastChapterRef.current = nextChapter;
-        setChapter(nextChapter);
-      }
-
-      animationRef.current = window.requestAnimationFrame(render);
-    };
-
-    animationRef.current = window.requestAnimationFrame(render);
-
-    return () => {
-      if (animationRef.current !== null) {
-        window.cancelAnimationFrame(animationRef.current);
-      }
-    };
-  }, [images]);
-
-  return (
-    <>
-      <canvas className="op-demo-reveal-canvas" ref={canvasRef} aria-hidden />
-      <div className="op-demo-reveal-overlay">
-        <div className="op-demo-reveal-copy">
-          <p className="op-eyebrow">
-            <span className="bar" />
-            <span>Unit active — hidden until reveal</span>
-          </p>
-          <h2>
-            {submittedCount.toLocaleString()}
-            <span> / {unitTileCount.toLocaleString()}</span>
-          </h2>
-          <p>{chapter}</p>
-        </div>
-        <div className="op-demo-reveal-controls">
-          <span>
-            {isReady ? "Canvas 40 x 50 tile field" : "Loading assets"}
-          </span>
-          <button className="op-btn-ghost" onClick={replay} type="button">
-            Replay reveal
-          </button>
-        </div>
-      </div>
-    </>
-  );
-}
-
-function useLoadedImages(
-  sources: readonly string[],
-): readonly HTMLImageElement[] | null {
-  const [images, setImages] = useState<readonly HTMLImageElement[] | null>(
-    null,
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    const pending = sources.map(
-      (source) =>
-        new Promise<HTMLImageElement>((resolve, reject) => {
-          const image = new Image();
-          image.onload = () => resolve(image);
-          image.onerror = reject;
-          image.src = source;
-        }),
-    );
-
-    Promise.all(pending)
-      .then((loaded) => {
-        if (!cancelled) {
-          setImages(loaded);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setImages([]);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sources]);
-
-  return images && images.length > 0 ? images : null;
-}
-
-function prepareCanvas(
-  canvas: HTMLCanvasElement,
-  context: CanvasRenderingContext2D,
-): {
-  readonly dpr: number;
-  readonly height: number;
-  readonly mosaicHeight: number;
-  readonly mosaicLeft: number;
-  readonly mosaicTop: number;
-  readonly mosaicWidth: number;
-  readonly tileHeight: number;
-  readonly tileWidth: number;
-  readonly width: number;
-} {
-  const rect = canvas.getBoundingClientRect();
-  const dpr = Math.min(window.devicePixelRatio || 1, 2);
-  const width = Math.max(1, rect.width);
-  const height = Math.max(1, rect.height);
-  const pixelWidth = Math.floor(width * dpr);
-  const pixelHeight = Math.floor(height * dpr);
-
-  if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
-  }
-
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-  const targetAspect = unitTileGrid.cols / unitTileGrid.rows;
-  const maxMosaicHeight = height * (width >= 900 ? 0.84 : 0.66);
-  const maxMosaicWidth = width * (width >= 900 ? 0.42 : 0.7);
-  const mosaicWidth = Math.min(maxMosaicWidth, maxMosaicHeight * targetAspect);
-  const mosaicHeight = mosaicWidth / targetAspect;
-  const mosaicLeft = width >= 900 ? width * 0.57 : (width - mosaicWidth) / 2;
-  const mosaicTop = width >= 900 ? (height - mosaicHeight) / 2 : height * 0.3;
-
-  return {
-    dpr,
-    height,
-    mosaicHeight,
-    mosaicLeft,
-    mosaicTop,
-    mosaicWidth,
-    tileHeight: mosaicHeight / unitTileGrid.rows,
-    tileWidth: mosaicWidth / unitTileGrid.cols,
-    width,
-  };
-}
-
-function drawRevealFrame(args: {
-  readonly context: CanvasRenderingContext2D;
-  readonly finalImage: HTMLImageElement;
-  readonly layout: ReturnType<typeof prepareCanvas>;
-  readonly progress: number;
-  readonly tiles: readonly Tile[];
-}): void {
-  const { context, finalImage, layout, progress, tiles } = args;
-  context.clearRect(0, 0, layout.width, layout.height);
-  drawArenaBackground(context, layout, progress);
-
-  const finalFade = smoothstep(0.78, 0.94, progress);
-  const tileBorderOpacity = 0.18 * (1 - smoothstep(0.84, 1, progress));
-
-  context.save();
-  context.globalAlpha = 0.28 + finalFade * 0.44;
-  context.shadowColor = "rgba(255,122,26,0.45)";
-  context.shadowBlur = 44;
-  context.drawImage(
-    finalImage,
-    layout.mosaicLeft,
-    layout.mosaicTop,
-    layout.mosaicWidth,
-    layout.mosaicHeight,
-  );
-  context.restore();
-
-  for (const tile of tiles) {
-    drawTile({
-      context,
-      finalImage,
-      finalFade,
-      layout,
-      progress,
-      tile,
-      tileBorderOpacity,
-    });
-  }
-
-  context.save();
-  context.strokeStyle = `rgba(255, 122, 26, ${0.18 + finalFade * 0.35})`;
-  context.lineWidth = 1;
-  context.strokeRect(
-    layout.mosaicLeft,
-    layout.mosaicTop,
-    layout.mosaicWidth,
-    layout.mosaicHeight,
-  );
-  context.restore();
-}
-
-function drawTile(args: {
-  readonly context: CanvasRenderingContext2D;
-  readonly finalImage: HTMLImageElement;
-  readonly finalFade: number;
-  readonly layout: ReturnType<typeof prepareCanvas>;
-  readonly progress: number;
-  readonly tile: Tile;
-  readonly tileBorderOpacity: number;
-}): void {
-  const {
-    context,
-    finalImage,
-    finalFade,
-    layout,
-    progress,
-    tile,
-    tileBorderOpacity,
-  } = args;
-  const local = clamp((progress - tile.delay) / tile.duration, 0, 1);
-  if (local <= 0) {
-    return;
-  }
-
-  const eased = easeOutCubic(local);
-  const targetX = layout.mosaicLeft + tile.col * layout.tileWidth;
-  const targetY = layout.mosaicTop + tile.row * layout.tileHeight;
-  const curve = Math.sin(Math.PI * eased);
-  const x = quadratic(tile.startX, tile.controlX, targetX, eased);
-  const y = quadratic(tile.startY, tile.controlY, targetY, eased);
-  const sizeBoost = 1.8 - eased * 0.78;
-  const tileWidth = layout.tileWidth * sizeBoost;
-  const tileHeight = layout.tileHeight * sizeBoost;
-  const drawX = x - (tileWidth - layout.tileWidth) / 2;
-  const drawY = y - (tileHeight - layout.tileHeight) / 2 + curve * 8;
-  const finalCropAlpha = smoothstep(0.54, 0.96, local);
-  const fanPhotoAlpha = (1 - finalCropAlpha) * (0.28 + eased * 0.62);
-
-  context.save();
-  context.globalAlpha = fanPhotoAlpha;
-  drawFanPhotoTile(context, {
-    height: tileHeight,
-    seed: tile.fanIndex,
-    width: tileWidth,
-    x: drawX,
-    y: drawY,
-  });
-  context.restore();
-
-  context.save();
-  context.globalAlpha = Math.max(finalCropAlpha, finalFade);
-  const sw = finalImage.width / unitTileGrid.cols;
-  const sh = finalImage.height / unitTileGrid.rows;
-  context.drawImage(
-    finalImage,
-    tile.col * sw,
-    tile.row * sh,
-    sw,
-    sh,
-    drawX,
-    drawY,
-    tileWidth,
-    tileHeight,
-  );
-  context.restore();
-
-  if (tileBorderOpacity > 0.01) {
-    context.save();
-    context.strokeStyle = `rgba(255, 239, 210, ${tileBorderOpacity})`;
-    context.lineWidth = 0.5;
-    context.strokeRect(drawX, drawY, tileWidth, tileHeight);
-    context.restore();
-  }
-}
-
-function drawFanPhotoTile(
-  context: CanvasRenderingContext2D,
-  frame: {
-    readonly height: number;
-    readonly seed: number;
-    readonly width: number;
-    readonly x: number;
-    readonly y: number;
-  },
-): void {
-  const style = fanTileStyles[frame.seed % fanTileStyles.length];
-  const smile = frame.seed % 3 === 0;
-  const headX = frame.x + frame.width * (0.5 + ((frame.seed % 7) - 3) * 0.018);
-  const headY = frame.y + frame.height * 0.42;
-  const headRadius = Math.max(1.2, Math.min(frame.width, frame.height) * 0.18);
-
-  context.fillStyle = style.background;
-  context.fillRect(frame.x, frame.y, frame.width, frame.height);
-
-  const shine = context.createLinearGradient(
-    frame.x,
-    frame.y,
-    frame.x + frame.width,
-    frame.y + frame.height,
-  );
-  shine.addColorStop(0, "rgba(255,255,255,0.22)");
-  shine.addColorStop(0.42, "rgba(255,255,255,0.02)");
-  shine.addColorStop(1, "rgba(0,0,0,0.3)");
-  context.fillStyle = shine;
-  context.fillRect(frame.x, frame.y, frame.width, frame.height);
-
-  context.fillStyle = style.clothing;
-  context.beginPath();
-  context.ellipse(
-    frame.x + frame.width * 0.5,
-    frame.y + frame.height * 0.98,
-    frame.width * 0.42,
-    frame.height * 0.34,
-    0,
-    Math.PI,
-    Math.PI * 2,
-  );
-  context.fill();
-
-  context.fillStyle = style.skin;
-  context.beginPath();
-  context.arc(headX, headY, headRadius, 0, Math.PI * 2);
-  context.fill();
-
-  context.fillStyle = style.hair;
-  context.beginPath();
-  context.ellipse(
-    headX,
-    headY - headRadius * 0.52,
-    headRadius * 0.96,
-    headRadius * 0.52,
-    0,
-    Math.PI,
-    Math.PI * 2,
-  );
-  context.fill();
-
-  context.fillStyle = "rgba(5,3,2,0.62)";
-  const eyeRadius = Math.max(0.35, headRadius * 0.11);
-  context.beginPath();
-  context.arc(headX - headRadius * 0.36, headY, eyeRadius, 0, Math.PI * 2);
-  context.arc(headX + headRadius * 0.36, headY, eyeRadius, 0, Math.PI * 2);
-  context.fill();
-
-  if (smile && frame.width > 8) {
-    context.strokeStyle = "rgba(5,3,2,0.54)";
-    context.lineWidth = Math.max(0.45, frame.width * 0.025);
-    context.beginPath();
-    context.arc(
-      headX,
-      headY + headRadius * 0.22,
-      headRadius * 0.36,
-      0.18 * Math.PI,
-      0.82 * Math.PI,
-    );
-    context.stroke();
-  }
-
-  context.strokeStyle = "rgba(255,255,255,0.18)";
-  context.lineWidth = 0.75;
-  context.strokeRect(frame.x, frame.y, frame.width, frame.height);
-}
-
-function drawArenaBackground(
-  context: CanvasRenderingContext2D,
-  layout: ReturnType<typeof prepareCanvas>,
-  progress: number,
-): void {
-  const { height, width } = layout;
-  const bg = context.createLinearGradient(0, 0, width, height);
-  bg.addColorStop(0, "#050302");
-  bg.addColorStop(0.45, "#100805");
-  bg.addColorStop(1, "#030608");
-  context.fillStyle = bg;
-  context.fillRect(0, 0, width, height);
-
-  const ember = context.createRadialGradient(
-    width * 0.72,
-    height * 0.46,
-    0,
-    width * 0.72,
-    height * 0.46,
-    width * 0.42,
-  );
-  ember.addColorStop(0, `rgba(255, 122, 26, ${0.22 + progress * 0.16})`);
-  ember.addColorStop(0.58, "rgba(212, 50, 14, 0.08)");
-  ember.addColorStop(1, "rgba(5, 3, 2, 0)");
-  context.fillStyle = ember;
-  context.fillRect(0, 0, width, height);
-
-  const sui = context.createRadialGradient(
-    width * 0.16,
-    height * 0.78,
-    0,
-    width * 0.16,
-    height * 0.78,
-    width * 0.34,
-  );
-  sui.addColorStop(0, "rgba(77, 162, 255, 0.16)");
-  sui.addColorStop(1, "rgba(77, 162, 255, 0)");
-  context.fillStyle = sui;
-  context.fillRect(0, 0, width, height);
-
-  context.save();
-  context.globalAlpha = 0.14;
-  context.strokeStyle = "rgba(245, 239, 227, 0.42)";
-  context.lineWidth = 1;
-  const step = 44;
-  const offset = (progress * 160) % step;
-  for (let x = -step; x < width + step; x += step) {
-    context.beginPath();
-    context.moveTo(x + offset, 0);
-    context.lineTo(x - height * 0.38 + offset, height);
-    context.stroke();
-  }
-  context.restore();
-}
-
-function createTiles(width: number, height: number): readonly Tile[] {
-  const random = seededRandom(20260429);
-  const tiles: Tile[] = [];
-
-  for (let row = 0; row < unitTileGrid.rows; row += 1) {
-    for (let col = 0; col < unitTileGrid.cols; col += 1) {
-      const side = Math.floor(random() * 4);
-      const start =
-        side === 0
-          ? { x: -120 - random() * width * 0.4, y: random() * height }
-          : side === 1
-            ? {
-                x: width + 120 + random() * width * 0.4,
-                y: random() * height,
-              }
-            : side === 2
-              ? { x: random() * width, y: -140 - random() * height * 0.25 }
-              : {
-                  x: random() * width,
-                  y: height + 140 + random() * height * 0.25,
-                };
-
-      tiles.push({
-        col,
-        controlX: width * (0.28 + random() * 0.38),
-        controlY: height * (0.16 + random() * 0.68),
-        delay: 0.06 + random() * 0.58 + (row / unitTileGrid.rows) * 0.08,
-        duration: 0.26 + random() * 0.28,
-        fanIndex: Math.floor(random() * 10000),
-        row,
-        startX: start.x,
-        startY: start.y,
-      });
-    }
-  }
-
-  return tiles;
-}
-
-function createAndCacheTiles(
-  cacheRef: React.MutableRefObject<{
-    readonly height: number;
-    readonly tiles: readonly Tile[];
-    readonly width: number;
-  } | null>,
-  width: number,
-  height: number,
-): readonly Tile[] {
-  const tiles = createTiles(width, height);
-  cacheRef.current = { height, tiles, width };
-  return tiles;
-}
-
-function resolveRevealChapter(progress: number): string {
-  if (progress < 0.22) {
-    return "Fans are entering the arena from every side.";
-  }
-  if (progress < 0.56) {
-    return "Walrus photo fragments lock into a 40 x 50 grid.";
-  }
-  if (progress < 0.78) {
-    return "The final Kakera is approaching the portrait.";
-  }
-  if (progress < 0.92) {
-    return "Unit filled. The synchronized reveal begins.";
-  }
-  return "Completed mosaic revealed. Kakera memories are minted.";
-}
-
-function seededRandom(seed: number): () => number {
-  let value = seed;
-  return () => {
-    value += 0x6d2b79f5;
-    let next = value;
-    next = Math.imul(next ^ (next >>> 15), next | 1);
-    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
-    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function quadratic(start: number, control: number, end: number, t: number) {
-  return (1 - t) * (1 - t) * start + 2 * (1 - t) * t * control + t * t * end;
-}
-
-function easeOutCubic(value: number): number {
-  return 1 - (1 - value) ** 3;
-}
-
-function smoothstep(edge0: number, edge1: number, value: number): number {
-  const t = clamp((value - edge0) / (edge1 - edge0), 0, 1);
-  return t * t * (3 - 2 * t);
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -14,6 +14,11 @@ const submittedCount = 1999;
 const maxSlots = unitTileCount;
 const demoAddress = "0xdemo...2000";
 const completedMosaicSrc = "/demo/demo_mozaiku.png";
+const demoPlacement = {
+  x: 37,
+  y: 46,
+  submissionNo: 2000,
+} as const;
 const revealDurationMs = 3600;
 
 export function DemoClient(): React.ReactElement {
@@ -103,7 +108,7 @@ export function DemoClient(): React.ReactElement {
 
           <article className="op-demo-unit-card op-demo-unit-reveal-card">
             {previewUrl ? (
-              <DemoCompletionReveal />
+              <DemoCompletionReveal originalPhotoUrl={previewUrl} />
             ) : (
               <>
                 <span>Reveal area</span>
@@ -191,14 +196,20 @@ export function DemoClient(): React.ReactElement {
   );
 }
 
-function DemoCompletionReveal(): React.ReactElement {
+function DemoCompletionReveal({
+  originalPhotoUrl,
+}: {
+  readonly originalPhotoUrl: string;
+}): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const frameRef = useRef<number | null>(null);
   const startRef = useRef<number | null>(null);
   const reducedMotion = prefersReducedMotion();
+  const [highlightVisible, setHighlightVisible] = useState(true);
   const [chapter, setChapter] = useState(
     reducedMotion ? "Completed mosaic revealed." : "Final fan photo accepted.",
   );
+  const highlightLabel = highlightVisible ? "Hide highlight" : "Show highlight";
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -271,6 +282,18 @@ function DemoCompletionReveal(): React.ReactElement {
       <div className="op-demo-completion-fallback">
         {/* biome-ignore lint/performance/noImgElement: public completed demo mosaic asset */}
         <img alt="Completed Takeru mosaic" src={completedMosaicSrc} />
+        {highlightVisible ? (
+          <div
+            className="op-demo-placement-highlight op-placement-highlight-frame op-placement-highlight-pulse"
+            data-testid="demo-placement-highlight"
+            style={{
+              left: `${(demoPlacement.x / unitTileGrid.cols) * 100}%`,
+              top: `${(demoPlacement.y / unitTileGrid.rows) * 100}%`,
+              width: `${100 / unitTileGrid.cols}%`,
+              height: `${100 / unitTileGrid.rows}%`,
+            }}
+          />
+        ) : null}
       </div>
       <div className="op-demo-completion-copy">
         <span>Reveal area</span>
@@ -278,7 +301,22 @@ function DemoCompletionReveal(): React.ReactElement {
         <p>
           {unitTileGrid.cols} x {unitTileGrid.rows} = {unitTileCount} tiles
         </p>
-        <p>All demo slots are complete for the unit.</p>
+        <p>
+          Your Kakera is highlighted at ({demoPlacement.x}, {demoPlacement.y})
+          as #{demoPlacement.submissionNo}.
+        </p>
+        <button
+          aria-pressed={highlightVisible}
+          className="op-demo-highlight-toggle"
+          onClick={() => setHighlightVisible((current) => !current)}
+          type="button"
+        >
+          {highlightLabel}
+        </button>
+        <div className="op-demo-completion-original">
+          {/* biome-ignore lint/performance/noImgElement: local object URL preview */}
+          <img alt="Takeru original submission" src={originalPhotoUrl} />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/demo/page.tsx
+++ b/apps/web/src/app/demo/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import { DemoClient } from "./demo-client";
 
 export const metadata: Metadata = {
-  title: "ONE Portrait Demo Film",
-  description: "A cinematic demo flow for the ONE Portrait reveal experience.",
+  title: "ONE Portrait Takeru Demo Unit",
+  description: "A fixed Takeru demo unit shell for the ONE Portrait flow.",
 };
 
 export default function DemoPage(): React.ReactElement {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1485,13 +1485,64 @@ a {
   color: #f8f3e7;
 }
 
-.op-demo-unit-submit button {
+.op-demo-unit-submit button:not(.op-btn-primary):not(.op-btn-ghost) {
   min-height: 52px;
   border: 0;
   border-radius: 8px;
   background: rgba(245, 239, 227, 0.16);
   color: rgba(245, 239, 227, 0.6);
   font-weight: 800;
+}
+
+.op-demo-unit-wallet-actions,
+.op-demo-unit-wallet-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.op-demo-unit-wallet-panel p {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid rgba(245, 239, 227, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.op-demo-unit-wallet-panel p strong {
+  color: #f8f3e7;
+}
+
+.op-demo-unit-wallet-panel p span {
+  color: rgba(245, 239, 227, 0.62);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.op-demo-unit-wallet-panel label {
+  display: grid;
+  gap: 10px;
+  color: #f8f3e7;
+  font-weight: 800;
+}
+
+.op-demo-unit-wallet-panel input {
+  width: 100%;
+  color: rgba(245, 239, 227, 0.72);
+}
+
+.op-demo-unit-preview {
+  overflow: hidden;
+  border: 1px solid rgba(245, 239, 227, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.op-demo-unit-preview img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
 }
 
 @media (max-width: 980px) {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1469,6 +1469,17 @@ a {
   background: #070b10;
 }
 
+.op-demo-placement-highlight {
+  position: absolute;
+  z-index: 2;
+  border-color: rgba(255, 49, 49, 0.96);
+  background: rgba(255, 49, 49, 0.22);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+    0 0 0 1px rgba(255, 49, 49, 0.54),
+    0 0 26px rgba(255, 49, 49, 0.82);
+}
+
 .op-demo-completion-fallback img {
   object-fit: cover;
   opacity: 0.42;
@@ -1485,6 +1496,38 @@ a {
 
 .op-demo-completion-copy p + p {
   margin-top: 4px;
+}
+
+.op-demo-highlight-toggle {
+  margin-top: 10px;
+  border: 1px solid rgba(255, 49, 49, 0.48);
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: rgba(255, 49, 49, 0.12);
+  color: #f8f3e7;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.op-demo-completion-original {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  width: min(30%, 116px);
+  overflow: hidden;
+  border: 1px solid rgba(245, 239, 227, 0.34);
+  border-radius: 6px;
+  background: rgba(7, 11, 16, 0.78);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.34);
+}
+
+.op-demo-completion-original img {
+  display: block;
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  object-fit: cover;
 }
 
 .op-demo-unit-submit {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1342,7 +1342,7 @@ a {
 
 .op-demo-unit-athlete {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(240px, 420px);
+  grid-template-columns: minmax(0, 0.88fr) minmax(240px, 420px);
   gap: clamp(20px, 4vw, 44px);
   align-items: end;
   padding: clamp(24px, 5vw, 56px);
@@ -1360,8 +1360,8 @@ a {
 .op-demo-unit-athlete-copy h1 {
   margin: 18px 0 14px;
   color: #f8f3e7;
-  font-family: var(--font-display);
-  font-size: clamp(3rem, 8vw, 7rem);
+  font-family: "Anton", "Impact", "Helvetica Neue", sans-serif;
+  font-size: clamp(3rem, 6vw, 5.25rem);
   font-weight: 700;
   line-height: 0.9;
 }
@@ -1436,7 +1436,7 @@ a {
 .op-demo-unit-reveal-card {
   position: relative;
   grid-column: 1 / -1;
-  min-height: 360px;
+  min-height: 480px;
   overflow: hidden;
   background:
     linear-gradient(rgba(245, 239, 227, 0.08) 1px, transparent 1px),
@@ -1458,8 +1458,9 @@ a {
 .op-demo-completion-mosaic {
   position: relative;
   align-self: center;
-  width: min(100%, 430px);
-  min-height: 270px;
+  justify-self: center;
+  width: min(100%, 330px);
+  min-height: 0;
   aspect-ratio: 40 / 50;
   overflow: hidden;
   border: 1px solid rgba(245, 239, 227, 0.16);
@@ -1559,7 +1560,7 @@ a {
 .op-demo-unit-submit h2 {
   margin: 18px 0 12px;
   color: #f8f3e7;
-  font-family: var(--font-display);
+  font-family: "Anton", "Impact", "Helvetica Neue", sans-serif;
   font-size: clamp(2rem, 4vw, 3.25rem);
   line-height: 1;
 }
@@ -1619,7 +1620,7 @@ a {
 
 .op-demo-unit-wallet-panel p span {
   color: rgba(245, 239, 227, 0.62);
-  font-family: var(--font-mono);
+  font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
   font-size: 0.9rem;
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1434,12 +1434,57 @@ a {
 }
 
 .op-demo-unit-reveal-card {
+  position: relative;
   min-height: 220px;
+  overflow: hidden;
   background:
     linear-gradient(rgba(245, 239, 227, 0.08) 1px, transparent 1px),
     linear-gradient(90deg, rgba(245, 239, 227, 0.08) 1px, transparent 1px),
     rgba(10, 15, 20, 0.82);
   background-size: 22px 22px;
+}
+
+.op-demo-completion-reveal {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  min-height: 100%;
+}
+
+.op-demo-completion-canvas,
+.op-demo-completion-fallback,
+.op-demo-completion-fallback img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.op-demo-completion-canvas {
+  z-index: 1;
+}
+
+.op-demo-completion-fallback {
+  overflow: hidden;
+  background: #070b10;
+}
+
+.op-demo-completion-fallback img {
+  object-fit: cover;
+  opacity: 0.42;
+  transform: scale(1.04);
+}
+
+.op-demo-completion-copy {
+  position: relative;
+  z-index: 2;
+  align-self: end;
+  padding: 22px;
+  background: linear-gradient(transparent, rgba(5, 3, 2, 0.88));
+}
+
+.op-demo-completion-copy p + p {
+  margin-top: 4px;
 }
 
 .op-demo-unit-submit {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2700,6 +2700,43 @@ a {
   }
 }
 
+.op-demo-reveal-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  min-height: 100svh;
+  overflow: hidden;
+  background: #050302;
+}
+
+.op-demo-reveal-fullscreen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(5, 3, 2, 0.78), rgba(5, 3, 2, 0.08) 58%),
+    repeating-linear-gradient(
+      0deg,
+      rgba(245, 239, 227, 0.04) 0,
+      rgba(245, 239, 227, 0.04) 1px,
+      transparent 1px,
+      transparent 6px
+    );
+  mix-blend-mode: overlay;
+  opacity: 0.72;
+}
+
+.op-demo-reveal-fullscreen .op-demo-reveal-overlay {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.op-demo-reveal-fullscreen .op-demo-reveal-controls {
+  pointer-events: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .grain::after,
   .op-btn-primary::before,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1315,7 +1315,7 @@ a {
   }
 }
 
-/* Demo film route */
+/* Demo route */
 .op-demo {
   min-height: 100vh;
   overflow: hidden;
@@ -1325,6 +1325,208 @@ a {
 
 .op-demo section {
   position: relative;
+}
+
+.op-demo-unit {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  gap: clamp(20px, 4vw, 48px);
+  min-height: 100vh;
+  padding: clamp(24px, 5vw, 72px);
+}
+
+.op-demo-unit-overview,
+.op-demo-unit-submit {
+  min-width: 0;
+}
+
+.op-demo-unit-athlete {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 420px);
+  gap: clamp(20px, 4vw, 44px);
+  align-items: end;
+  padding: clamp(24px, 5vw, 56px);
+  border: 1px solid rgba(245, 239, 227, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 44%),
+    rgba(12, 18, 24, 0.72);
+}
+
+.op-demo-unit-athlete-copy {
+  max-width: 620px;
+}
+
+.op-demo-unit-athlete-copy h1 {
+  margin: 18px 0 14px;
+  color: #f8f3e7;
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 8vw, 7rem);
+  font-weight: 700;
+  line-height: 0.9;
+}
+
+.op-demo-unit-athlete-copy p:not(.op-eyebrow) {
+  max-width: 36rem;
+  color: rgba(245, 239, 227, 0.74);
+  font-size: clamp(1rem, 1.7vw, 1.2rem);
+  line-height: 1.7;
+}
+
+.op-demo-unit-athlete-media {
+  align-self: stretch;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  min-height: 300px;
+  overflow: hidden;
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(239, 68, 68, 0.2), #111820);
+}
+
+.op-demo-unit-athlete-media img {
+  width: min(100%, 500px);
+  height: auto;
+  object-fit: contain;
+}
+
+.op-demo-unit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.op-demo-unit-card,
+.op-demo-unit-submit {
+  border: 1px solid rgba(245, 239, 227, 0.12);
+  border-radius: 8px;
+  background: rgba(10, 15, 20, 0.82);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.25);
+}
+
+.op-demo-unit-card {
+  min-height: 150px;
+  padding: 22px;
+}
+
+.op-demo-unit-card span,
+.op-demo-unit-submit-steps span {
+  color: rgba(245, 239, 227, 0.52);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.op-demo-unit-card strong {
+  display: block;
+  margin-top: 12px;
+  color: #f8f3e7;
+  font-size: clamp(1.35rem, 2.6vw, 2.2rem);
+  line-height: 1.05;
+}
+
+.op-demo-unit-card p {
+  margin-top: 12px;
+  color: rgba(245, 239, 227, 0.65);
+  line-height: 1.55;
+}
+
+.op-demo-unit-reveal-card {
+  min-height: 220px;
+  background:
+    linear-gradient(rgba(245, 239, 227, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(245, 239, 227, 0.08) 1px, transparent 1px),
+    rgba(10, 15, 20, 0.82);
+  background-size: 22px 22px;
+}
+
+.op-demo-unit-submit {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: clamp(22px, 4vw, 34px);
+}
+
+.op-demo-unit-submit h2 {
+  margin: 18px 0 12px;
+  color: #f8f3e7;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  line-height: 1;
+}
+
+.op-demo-unit-submit p:not(.op-eyebrow) {
+  color: rgba(245, 239, 227, 0.68);
+  line-height: 1.7;
+}
+
+.op-demo-unit-submit-steps {
+  display: grid;
+  gap: 12px;
+}
+
+.op-demo-unit-submit-steps div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid rgba(245, 239, 227, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.op-demo-unit-submit-steps strong {
+  color: #f8f3e7;
+}
+
+.op-demo-unit-submit button {
+  min-height: 52px;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(245, 239, 227, 0.16);
+  color: rgba(245, 239, 227, 0.6);
+  font-weight: 800;
+}
+
+@media (max-width: 980px) {
+  .op-demo-unit,
+  .op-demo-unit-athlete {
+    grid-template-columns: 1fr;
+  }
+
+  .op-demo-unit-submit {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .op-demo-unit {
+    padding: 18px;
+  }
+
+  .op-demo-unit-athlete,
+  .op-demo-unit-submit {
+    padding: 20px;
+  }
+
+  .op-demo-unit-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .op-demo-unit-athlete-media {
+    min-height: 240px;
+  }
+
+  .op-demo-unit-submit-steps div {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 .op-demo-hero {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1435,7 +1435,8 @@ a {
 
 .op-demo-unit-reveal-card {
   position: relative;
-  min-height: 220px;
+  grid-column: 1 / -1;
+  min-height: 360px;
   overflow: hidden;
   background:
     linear-gradient(rgba(245, 239, 227, 0.08) 1px, transparent 1px),
@@ -1448,7 +1449,22 @@ a {
   position: absolute;
   inset: 0;
   display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 260px);
+  gap: 16px;
   min-height: 100%;
+  padding: 16px;
+}
+
+.op-demo-completion-mosaic {
+  position: relative;
+  align-self: center;
+  width: min(100%, 430px);
+  min-height: 270px;
+  aspect-ratio: 40 / 50;
+  overflow: hidden;
+  border: 1px solid rgba(245, 239, 227, 0.16);
+  border-radius: 6px;
+  background: #070b10;
 }
 
 .op-demo-completion-canvas,
@@ -1489,9 +1505,11 @@ a {
 .op-demo-completion-copy {
   position: relative;
   z-index: 2;
-  align-self: end;
-  padding: 22px;
-  background: linear-gradient(transparent, rgba(5, 3, 2, 0.88));
+  align-self: center;
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 0;
 }
 
 .op-demo-completion-copy p + p {
@@ -1512,10 +1530,8 @@ a {
 }
 
 .op-demo-completion-original {
-  position: absolute;
-  right: 18px;
-  bottom: 18px;
-  width: min(30%, 116px);
+  position: relative;
+  width: min(100%, 150px);
   overflow: hidden;
   border: 1px solid rgba(245, 239, 227, 0.34);
   border-radius: 6px;
@@ -1660,6 +1676,16 @@ a {
 
   .op-demo-unit-athlete-media {
     min-height: 240px;
+  }
+
+  .op-demo-completion-reveal {
+    position: relative;
+    grid-template-columns: 1fr;
+  }
+
+  .op-demo-completion-mosaic {
+    width: min(100%, 280px);
+    min-height: 0;
   }
 
   .op-demo-unit-submit-steps div {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1446,13 +1446,15 @@ a {
 }
 
 .op-demo-completion-reveal {
-  position: absolute;
-  inset: 0;
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(190px, 260px);
   gap: 16px;
-  min-height: 100%;
+  margin-top: 32px;
   padding: 16px;
+  border: 1px solid var(--rule-strong);
+  background: rgba(10, 6, 4, 0.85);
+  text-align: left;
 }
 
 .op-demo-completion-mosaic {
@@ -1511,6 +1513,21 @@ a {
   gap: 10px;
   min-width: 0;
   padding: 0;
+}
+
+.op-demo-completion-copy > span {
+  color: rgba(245, 239, 227, 0.52);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.op-demo-completion-copy > strong {
+  display: block;
+  color: #f8f3e7;
+  font-size: clamp(1.35rem, 2.6vw, 2.2rem);
+  line-height: 1.05;
 }
 
 .op-demo-completion-copy p + p {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1457,6 +1457,19 @@ a {
   text-align: left;
 }
 
+.op-demo-completion-animation {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 260px);
+  gap: 16px;
+  min-height: 260px;
+  padding: 16px;
+  overflow: hidden;
+  border: 1px solid var(--rule-strong);
+  background: rgba(10, 6, 4, 0.85);
+  text-align: left;
+}
+
 .op-demo-completion-mosaic {
   position: relative;
   align-self: center;
@@ -1481,6 +1494,17 @@ a {
 
 .op-demo-completion-canvas {
   z-index: 1;
+}
+
+.op-demo-completion-animation .op-demo-completion-canvas {
+  position: relative;
+  inset: auto;
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 228px;
+  border: 1px solid rgba(245, 239, 227, 0.16);
+  background: #070b10;
 }
 
 .op-demo-completion-fallback {
@@ -1698,6 +1722,10 @@ a {
 
   .op-demo-completion-reveal {
     position: relative;
+    grid-template-columns: 1fr;
+  }
+
+  .op-demo-completion-animation {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/app/home-experience.tsx
+++ b/apps/web/src/app/home-experience.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 const mosaicSrc = "/demo/demo_mozaiku.png";
 const fanUploadSrc = "/demo/fan-upload-dogs.png";
 const revealDurationMs = 15000;
+const emptyTileSources: readonly string[] = [];
 const photoTileSources = [
   fanUploadSrc,
   "/demo/generator-tiles/0.webp",
@@ -210,35 +211,67 @@ export function HomeMosaicReveal(): React.ReactElement {
   );
 }
 
-function MosaicConvergence(): React.ReactElement {
+type MosaicConvergenceProps = {
+  readonly className?: string;
+  readonly copyClassName?: string;
+  readonly durationMs?: number;
+  readonly eyebrowText?: string;
+  readonly finalCount?: number;
+  readonly initialChapter?: string;
+  readonly initialCount?: number;
+  readonly loadingText?: string;
+  readonly mode?: "loop" | "once";
+  readonly onComplete?: () => void;
+  readonly readyText?: string;
+  readonly showReplay?: boolean;
+  readonly tileSources?: readonly string[];
+};
+
+export function MosaicConvergence({
+  className,
+  copyClassName = "op-home-scroll-reveal",
+  durationMs = revealDurationMs,
+  eyebrowText = "Unit active — hidden until reveal",
+  finalCount = unitTileCount,
+  initialChapter = "Photos incoming",
+  initialCount = 1873,
+  loadingText = "Loading assets",
+  mode = "loop",
+  onComplete,
+  readyText = "Photo tiles converge into one mosaic",
+  showReplay = true,
+  tileSources = emptyTileSources,
+}: MosaicConvergenceProps = {}): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const animationRef = useRef<number | null>(null);
   const startRef = useRef<number | null>(null);
+  const completedRef = useRef(false);
   const tileCacheRef = useRef<{
     readonly height: number;
     readonly tiles: readonly Tile[];
     readonly width: number;
   } | null>(null);
   const lastChapterRef = useRef("");
-  const lastCountRef = useRef(1873);
-  const [submittedCount, setSubmittedCount] = useState(1873);
-  const [chapter, setChapter] = useState("Photos incoming");
+  const lastCountRef = useRef(initialCount);
+  const [submittedCount, setSubmittedCount] = useState(initialCount);
+  const [chapter, setChapter] = useState(initialChapter);
   const [isReady, setIsReady] = useState(false);
 
   const imageSources = useMemo(
-    () => [mosaicSrc, ...photoTileSources] as const,
-    [],
+    () => [mosaicSrc, ...tileSources, ...photoTileSources] as const,
+    [tileSources],
   );
   const images = useLoadedImages(imageSources);
 
   const replay = useCallback(() => {
     startRef.current = null;
+    completedRef.current = false;
     tileCacheRef.current = null;
     lastChapterRef.current = "";
-    lastCountRef.current = 1873;
-    setSubmittedCount(1873);
-    setChapter("Photos incoming");
-  }, []);
+    lastCountRef.current = initialCount;
+    setSubmittedCount(initialCount);
+    setChapter(initialChapter);
+  }, [initialChapter, initialCount]);
 
   useEffect(() => {
     if (!images) {
@@ -251,6 +284,7 @@ function MosaicConvergence(): React.ReactElement {
     }
 
     setIsReady(true);
+    completedRef.current = false;
     const context = canvas.getContext("2d");
     if (!context) {
       return;
@@ -269,9 +303,11 @@ function MosaicConvergence(): React.ReactElement {
 
       const elapsed = timestamp - startRef.current;
       const loopElapsed = prefersReducedMotion
-        ? revealDurationMs
-        : elapsed % revealDurationMs;
-      const progress = clamp(loopElapsed / revealDurationMs, 0, 1);
+        ? durationMs
+        : mode === "loop"
+          ? elapsed % durationMs
+          : Math.min(elapsed, durationMs);
+      const progress = clamp(loopElapsed / durationMs, 0, 1);
       const layout = prepareCanvas(canvas, context);
       const cached = tileCacheRef.current;
       const tiles =
@@ -292,8 +328,8 @@ function MosaicConvergence(): React.ReactElement {
 
       const countProgress = smoothstep(0.08, 0.78, progress);
       const nextCount = Math.min(
-        unitTileCount,
-        1873 + Math.round((unitTileCount - 1873) * countProgress),
+        finalCount,
+        initialCount + Math.round((finalCount - initialCount) * countProgress),
       );
       if (lastCountRef.current !== nextCount) {
         lastCountRef.current = nextCount;
@@ -306,6 +342,14 @@ function MosaicConvergence(): React.ReactElement {
         setChapter(nextChapter);
       }
 
+      if (mode === "once" && progress >= 1) {
+        if (!completedRef.current) {
+          completedRef.current = true;
+          onComplete?.();
+        }
+        return;
+      }
+
       animationRef.current = window.requestAnimationFrame(render);
     };
 
@@ -316,35 +360,42 @@ function MosaicConvergence(): React.ReactElement {
         window.cancelAnimationFrame(animationRef.current);
       }
     };
-  }, [images]);
+  }, [durationMs, finalCount, images, initialCount, mode, onComplete]);
 
   return (
     <>
-      <canvas className="op-demo-reveal-canvas" ref={canvasRef} aria-hidden />
+      <canvas
+        className={["op-demo-reveal-canvas", className]
+          .filter(Boolean)
+          .join(" ")}
+        data-testid="demo-reveal-canvas"
+        ref={canvasRef}
+        aria-hidden
+      />
       <div className="op-demo-reveal-overlay">
         <div
-          className="op-demo-reveal-copy op-home-scroll-reveal"
+          className={["op-demo-reveal-copy", copyClassName]
+            .filter(Boolean)
+            .join(" ")}
           data-op-motion="headline"
         >
           <p className="op-eyebrow">
             <span className="bar" />
-            <span>Unit active — hidden until reveal</span>
+            <span>{eyebrowText}</span>
           </p>
           <h2>
             {submittedCount.toLocaleString()}
-            <span> / {unitTileCount.toLocaleString()}</span>
+            <span> / {finalCount.toLocaleString()}</span>
           </h2>
           <p>{chapter}</p>
         </div>
         <div className="op-demo-reveal-controls">
-          <span>
-            {isReady
-              ? "Photo tiles converge into one mosaic"
-              : "Loading assets"}
-          </span>
-          <button className="op-btn-ghost" onClick={replay} type="button">
-            Replay reveal
-          </button>
+          <span>{isReady ? readyText : loadingText}</span>
+          {showReplay ? (
+            <button className="op-btn-ghost" onClick={replay} type="button">
+              Replay reveal
+            </button>
+          ) : null}
         </div>
       </div>
     </>

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -104,6 +104,17 @@ describe("HomePage", () => {
     expect(link.getAttribute("href")).toBe("/gallery");
   });
 
+  it("keeps the home mosaic reveal controls available", async () => {
+    getActiveHomeUnitsMock.mockResolvedValue([]);
+
+    const ui = await HomePage();
+    render(ui);
+
+    expect(screen.getByText(/Loading assets/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Replay reveal/i })).toBeTruthy();
+    expect(screen.getByText(/Unit active — hidden until reveal/i)).toBeTruthy();
+  });
+
   it("lets users move the portrait rail one card at a time", async () => {
     getActiveHomeUnitsMock.mockResolvedValue([]);
     const originalScrollBy = HTMLElement.prototype.scrollBy;

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -66,6 +66,29 @@ async function expectNoForbiddenNetworkCalls(
   );
 }
 
+async function expectHighlightInsideMosaic(page: Page): Promise<void> {
+  const highlightBox = await page
+    .getByTestId("placement-highlight")
+    .boundingBox();
+  const mosaicBox = await page.getByTestId("reveal-image").boundingBox();
+
+  expect(highlightBox).not.toBeNull();
+  expect(mosaicBox).not.toBeNull();
+
+  if (!highlightBox || !mosaicBox) {
+    return;
+  }
+
+  expect(highlightBox.x).toBeGreaterThanOrEqual(mosaicBox.x - 1);
+  expect(highlightBox.y).toBeGreaterThanOrEqual(mosaicBox.y - 1);
+  expect(highlightBox.x + highlightBox.width).toBeLessThanOrEqual(
+    mosaicBox.x + mosaicBox.width + 1,
+  );
+  expect(highlightBox.y + highlightBox.height).toBeLessThanOrEqual(
+    mosaicBox.y + mosaicBox.height + 1,
+  );
+}
+
 async function expectElementsDoNotOverlap(
   page: Page,
   firstTestId: string,
@@ -113,33 +136,40 @@ async function runDemoStageFlow(page: Page): Promise<void> {
 
   await selectTinyImage(page);
 
+  await expect(page.getByText(/1999\s*\/\s*2000/)).toBeVisible();
+  await expect(page.getByText(/2000\s*\/\s*2000/)).toHaveCount(0);
+  await expect(page.getByAltText("Selected submission preview")).toBeVisible();
+  await expect(page.getByTestId("demo-completion-reveal")).toHaveCount(0);
+
+  await page.getByRole("button", { name: /Confirm submission/i }).click();
+
   await expect(page.getByText(/2000\s*\/\s*2000/)).toBeVisible();
   await expect(page.getByText(/1999\s*\/\s*2000/)).toHaveCount(0);
-  await expect(page.getByAltText("Selected submission preview")).toBeVisible();
   await expect(page.getByTestId("demo-completion-reveal")).toBeVisible();
-  await expect(page.getByAltText("Completed Takeru mosaic")).toBeVisible();
+  await expect(page.getByAltText("Takeru completed mosaic")).toBeVisible();
   await expect(page.getByText(/Completed mosaic revealed/i)).toBeVisible();
   await expect(page.getByAltText("Takeru original submission")).toBeVisible();
-  await expect(page.getByTestId("demo-placement-highlight")).toBeVisible();
+  await expect(page.getByTestId("placement-highlight")).toBeVisible();
   await expect(
     page.getByText(/highlighted at \(37, 46\) as #2000/i),
   ).toBeVisible();
+  await expectHighlightInsideMosaic(page);
   await expectElementsDoNotOverlap(
     page,
-    "demo-placement-highlight",
+    "placement-highlight",
     "Takeru original submission",
   );
 
   await page.getByRole("button", { name: /Hide highlight/i }).click();
 
-  await expect(page.getByTestId("demo-placement-highlight")).toHaveCount(0);
+  await expect(page.getByTestId("placement-highlight")).toHaveCount(0);
   await expect(
     page.getByRole("button", { name: /Show highlight/i }),
   ).toHaveAttribute("aria-pressed", "false");
 
   await page.getByRole("button", { name: /Show highlight/i }).click();
 
-  await expect(page.getByTestId("demo-placement-highlight")).toBeVisible();
+  await expect(page.getByTestId("placement-highlight")).toBeVisible();
   await expect(
     page.getByRole("button", { name: /Hide highlight/i }),
   ).toHaveAttribute("aria-pressed", "true");

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -99,18 +99,17 @@ async function runDemoStageFlow(page: Page): Promise<void> {
   ).toBeVisible();
   await expect(page.getByText(/1999\s*\/\s*2000/)).toBeVisible();
   await expect(
-    page.getByRole("button", { name: /Continue with Google zkLogin/i }),
+    page.getByRole("button", { name: /Google zkLogin/i }),
   ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: /Connect Sui wallet/i }),
-  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /Sui wallet/i })).toBeVisible();
 
-  await page
-    .getByRole("button", { name: /Continue with Google zkLogin/i })
-    .click();
+  await page.getByRole("button", { name: /Google zkLogin/i }).click();
 
   await expect(page.getByText(/Demo wallet address confirmed/i)).toBeVisible();
   await expect(page.getByText(/0xdemo\.\.\.2000/i)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Confirm submission/i }),
+  ).toBeVisible();
 
   await selectTinyImage(page);
 

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -114,7 +114,7 @@ async function expectElementsDoNotOverlap(
 }
 
 async function runDemoStageFlow(page: Page): Promise<void> {
-  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.emulateMedia({ reducedMotion: "no-preference" });
   await page.goto("/demo");
 
   await expect(
@@ -145,9 +145,18 @@ async function runDemoStageFlow(page: Page): Promise<void> {
 
   await expect(page.getByText(/2000\s*\/\s*2000/)).toBeVisible();
   await expect(page.getByText(/1999\s*\/\s*2000/)).toHaveCount(0);
+  await expect(page.getByTestId("demo-reveal-overlay")).toBeVisible();
+  await expect(page.getByTestId("demo-reveal-canvas")).toBeVisible();
+  await expect(
+    page.getByText(/Photo tiles converge into one mosaic/i),
+  ).toBeVisible();
+  await expectFullScreenOverlay(page);
+  await expect(page.getByTestId("demo-reveal-overlay")).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
   await expect(page.getByTestId("demo-completion-reveal")).toBeVisible();
   await expect(page.getByAltText("Takeru completed mosaic")).toBeVisible();
-  await expect(page.getByText(/Completed mosaic revealed/i)).toBeVisible();
   await expect(page.getByAltText("Takeru original submission")).toBeVisible();
   await expect(page.getByTestId("placement-highlight")).toBeVisible();
   await expect(
@@ -173,6 +182,25 @@ async function runDemoStageFlow(page: Page): Promise<void> {
   await expect(
     page.getByRole("button", { name: /Hide highlight/i }),
   ).toHaveAttribute("aria-pressed", "true");
+}
+
+async function expectFullScreenOverlay(page: Page): Promise<void> {
+  const overlayBox = await page
+    .getByTestId("demo-reveal-overlay")
+    .boundingBox();
+  const viewport = page.viewportSize();
+
+  expect(overlayBox).not.toBeNull();
+  expect(viewport).not.toBeNull();
+
+  if (!overlayBox || !viewport) {
+    return;
+  }
+
+  expect(overlayBox.x).toBeLessThanOrEqual(1);
+  expect(overlayBox.y).toBeLessThanOrEqual(1);
+  expect(overlayBox.width).toBeGreaterThanOrEqual(viewport.width - 2);
+  expect(overlayBox.height).toBeGreaterThanOrEqual(viewport.height - 2);
 }
 
 test.describe("/demo stage flow", () => {

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -1,0 +1,141 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import {
+  TINY_JPEG_BUFFER,
+  TINY_JPEG_MIME,
+  TINY_JPEG_NAME,
+} from "./fixtures/tiny-jpeg";
+
+type ForbiddenNetworkState = {
+  readonly calls: Map<string, number>;
+  readonly total: () => number;
+};
+
+const FORBIDDEN_ROUTES: readonly [string, string | RegExp][] = [
+  ["enoki sponsor", "**/api/enoki/submit-photo/sponsor"],
+  ["enoki execute", "**/api/enoki/submit-photo/execute"],
+  ["finalize", "**/api/finalize"],
+  ["admin finalize", "**/api/admin/finalize"],
+  ["admin create unit", "**/api/admin/create-unit"],
+  ["generator dispatch", /\/dispatch(?:\?|$)/],
+  ["walrus publisher", /publisher(?:\.[^/]+)?\/.*\/v1\/blobs(?:\?|\/|$)/],
+  ["walrus blobs", /\/v1\/blobs(?:\?|\/|$)/],
+];
+
+async function installForbiddenNetworkGuards(
+  page: Page,
+): Promise<ForbiddenNetworkState> {
+  const calls = new Map<string, number>(
+    FORBIDDEN_ROUTES.map(([name]) => [name, 0]),
+  );
+
+  for (const [name, routePattern] of FORBIDDEN_ROUTES) {
+    await page.route(routePattern, async (route) => {
+      calls.set(name, (calls.get(name) ?? 0) + 1);
+      await route.fulfill({
+        status: 418,
+        contentType: "application/json",
+        body: JSON.stringify({ error: `forbidden ${name}` }),
+      });
+    });
+  }
+
+  return {
+    calls,
+    total: () =>
+      Array.from(calls.values()).reduce((sum, count) => sum + count, 0),
+  };
+}
+
+async function selectTinyImage(page: Page): Promise<void> {
+  const fileInput = page.locator('input[type="file"]');
+  await expect(fileInput).toBeVisible();
+  await fileInput.setInputFiles({
+    name: TINY_JPEG_NAME,
+    mimeType: TINY_JPEG_MIME,
+    buffer: TINY_JPEG_BUFFER,
+  });
+}
+
+async function expectNoForbiddenNetworkCalls(
+  state: ForbiddenNetworkState,
+): Promise<void> {
+  await expect.poll(() => state.total()).toBe(0);
+  expect(Object.fromEntries(state.calls)).toEqual(
+    Object.fromEntries(FORBIDDEN_ROUTES.map(([name]) => [name, 0])),
+  );
+}
+
+async function runDemoStageFlow(page: Page): Promise<void> {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/demo");
+
+  await expect(
+    page.getByRole("main", { name: /Takeru Unit demo/i }),
+  ).toBeVisible();
+  await expect(page.getByText(/1999\s*\/\s*2000/)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Continue with Google zkLogin/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Connect Sui wallet/i }),
+  ).toBeVisible();
+
+  await page
+    .getByRole("button", { name: /Continue with Google zkLogin/i })
+    .click();
+
+  await expect(page.getByText(/Demo wallet connected/i)).toBeVisible();
+  await expect(page.getByText(/0xdemo\.\.\.2000/i)).toBeVisible();
+
+  await selectTinyImage(page);
+
+  await expect(page.getByText(/2000\s*\/\s*2000/)).toBeVisible();
+  await expect(page.getByText(/1999\s*\/\s*2000/)).toHaveCount(0);
+  await expect(page.getByAltText("Selected submission preview")).toBeVisible();
+  await expect(page.getByTestId("demo-completion-reveal")).toBeVisible();
+  await expect(page.getByAltText("Completed Takeru mosaic")).toBeVisible();
+  await expect(page.getByText(/Completed mosaic revealed/i)).toBeVisible();
+  await expect(page.getByAltText("Takeru original submission")).toBeVisible();
+  await expect(page.getByTestId("demo-placement-highlight")).toBeVisible();
+  await expect(
+    page.getByText(/highlighted at \(37, 46\) as #2000/i),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /Hide highlight/i }).click();
+
+  await expect(page.getByTestId("demo-placement-highlight")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: /Show highlight/i }),
+  ).toHaveAttribute("aria-pressed", "false");
+
+  await page.getByRole("button", { name: /Show highlight/i }).click();
+
+  await expect(page.getByTestId("demo-placement-highlight")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Hide highlight/i }),
+  ).toHaveAttribute("aria-pressed", "true");
+}
+
+test.describe("/demo stage flow", () => {
+  test("completes the desktop demo locally without upload or finalize calls", async ({
+    page,
+  }) => {
+    const forbiddenNetwork = await installForbiddenNetworkGuards(page);
+
+    await runDemoStageFlow(page);
+
+    await expectNoForbiddenNetworkCalls(forbiddenNetwork);
+  });
+
+  test("keeps the main demo operation usable on a mobile viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const forbiddenNetwork = await installForbiddenNetworkGuards(page);
+
+    await runDemoStageFlow(page);
+
+    await expectNoForbiddenNetworkCalls(forbiddenNetwork);
+  });
+});

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -66,6 +66,30 @@ async function expectNoForbiddenNetworkCalls(
   );
 }
 
+async function expectElementsDoNotOverlap(
+  page: Page,
+  firstTestId: string,
+  secondAltText: string,
+): Promise<void> {
+  const firstBox = await page.getByTestId(firstTestId).boundingBox();
+  const secondBox = await page.getByAltText(secondAltText).boundingBox();
+
+  expect(firstBox).not.toBeNull();
+  expect(secondBox).not.toBeNull();
+
+  if (!firstBox || !secondBox) {
+    return;
+  }
+
+  const separated =
+    firstBox.x + firstBox.width <= secondBox.x ||
+    secondBox.x + secondBox.width <= firstBox.x ||
+    firstBox.y + firstBox.height <= secondBox.y ||
+    secondBox.y + secondBox.height <= firstBox.y;
+
+  expect(separated).toBe(true);
+}
+
 async function runDemoStageFlow(page: Page): Promise<void> {
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/demo");
@@ -101,6 +125,11 @@ async function runDemoStageFlow(page: Page): Promise<void> {
   await expect(
     page.getByText(/highlighted at \(37, 46\) as #2000/i),
   ).toBeVisible();
+  await expectElementsDoNotOverlap(
+    page,
+    "demo-placement-highlight",
+    "Takeru original submission",
+  );
 
   await page.getByRole("button", { name: /Hide highlight/i }).click();
 

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -109,7 +109,7 @@ async function runDemoStageFlow(page: Page): Promise<void> {
     .getByRole("button", { name: /Continue with Google zkLogin/i })
     .click();
 
-  await expect(page.getByText(/Demo wallet connected/i)).toBeVisible();
+  await expect(page.getByText(/Demo wallet address confirmed/i)).toBeVisible();
   await expect(page.getByText(/0xdemo\.\.\.2000/i)).toBeVisible();
 
   await selectTinyImage(page);


### PR DESCRIPTION
## 概要
ハッカソン当日のステージデモ用に、`/demo` を作り直しました。
Takeru 固定の Unit 風ページとして表示します。
画像選択から完成リビールまでを、通信なしで見せられます。

## 変更内容
- `apps/web/src/app/demo/demo-client.tsx`
  - 古い hero / roster / movie 構成を削除しました。
  - `1999 / 2000` から始まる待機室型 UI にしました。
  - demo 専用の Google zkLogin / Sui wallet 入口を追加しました。
  - 選択画像を object URL で preview します。
  - 選択後は mock state で `2000 / 2000` に進みます。
  - 完成画像、元画像、固定 placement highlight を表示します。
- `apps/web/src/app/globals.css`
  - 当日デモ用の 2 カラム layout と reveal 表示を追加しました。
  - 元画像 preview が placement highlight を隠さないように分けました。
- `apps/web/tests/e2e/demo-stage-flow.spec.ts`
  - desktop と mobile の主要操作を検証しました。
  - Walrus、Sui submit、generator、finalize の通信がないことを検証しました。
  - highlight と元画像 preview が重ならないことを検証しました。

## 関連する Issue やチケット
Close #125

## 動作確認
- `corepack pnpm --filter web run lint`
- `corepack pnpm --filter web run typecheck`
- `corepack pnpm --filter web run test`
- `corepack pnpm --filter web exec vitest run src/app/demo/demo-client.test.tsx`
- `corepack pnpm --filter web exec playwright test tests/e2e/demo-stage-flow.spec.ts`
- `corepack pnpm --filter web exec playwright test tests/e2e/waiting-room-smoke.spec.ts tests/e2e/waiting-room-submit.spec.ts`
- `corepack pnpm --filter web run build`

補足: build は既存の Turbopack trace warning を出しますが、完了します。
Playwright を同時に複数起動すると port 3100 が競合するため、E2E は個別に再実行して通過を確認しました。