### PR TITLE
fix: demoの完成トランジションを整える

### DIFF
--- a/apps/web/src/app/demo/demo-client.test.tsx
+++ b/apps/web/src/app/demo/demo-client.test.tsx
@@ -1,7 +1,31 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../home-experience", () => ({
+  MosaicConvergence: ({
+    loadingText = "Loading assets",
+    onComplete,
+  }: {
+    readonly loadingText?: string;
+    readonly onComplete?: () => void;
+  }) => (
+    <>
+      <canvas data-testid="demo-reveal-canvas" />
+      <div>{loadingText}</div>
+      <button onClick={onComplete} type="button">
+        Finish reveal animation
+      </button>
+    </>
+  ),
+}));
 
 import { DemoClient } from "./demo-client";
 
@@ -49,6 +73,7 @@ function submitDemoImage(): void {
 describe("DemoClient", () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     window.matchMedia = originalMatchMedia;
     createObjectURL.mockReset();
     revokeObjectURL.mockReset();
@@ -170,6 +195,61 @@ describe("DemoClient", () => {
     expect(screen.getByText(/Loading assets/i)).toBeTruthy();
     expect(screen.getByText(/2000\s*\/\s*2000/)).toBeTruthy();
     expect(screen.queryByTestId("reveal-panel")).toBeNull();
+  });
+
+  it("holds the completed reveal briefly before easing into the completed panel", () => {
+    vi.useFakeTimers();
+    createObjectURL.mockReturnValue("blob:demo-preview-1");
+    render(<DemoClient />);
+    fireEvent.click(screen.getByRole("button", { name: /Google zkLogin/i }));
+
+    submitDemoImage();
+
+    const overlay = screen.getByTestId("demo-reveal-overlay");
+    expect(overlay.getAttribute("data-state")).toBe("revealing");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Finish reveal animation/i }),
+    );
+
+    expect(screen.getByTestId("demo-reveal-overlay")).toBeTruthy();
+    expect(
+      screen.getByTestId("demo-reveal-overlay").getAttribute("data-state"),
+    ).toBe("hold");
+    expect(screen.queryByTestId("demo-reveal-handoff")).toBeNull();
+    expect(screen.queryByTestId("demo-completion-reveal")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+
+    expect(
+      screen.getByTestId("demo-reveal-overlay").getAttribute("data-state"),
+    ).toBe("hold");
+    expect(screen.queryByTestId("demo-completion-reveal")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(
+      screen.getByTestId("demo-reveal-overlay").getAttribute("data-state"),
+    ).toBe("handoff");
+    expect(screen.getByTestId("demo-reveal-handoff")).toBeTruthy();
+    expect(screen.getByTestId("demo-completion-reveal")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1599);
+    });
+
+    expect(screen.getByTestId("demo-reveal-overlay")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.queryByTestId("demo-reveal-overlay")).toBeNull();
+    expect(screen.getByTestId("demo-completion-reveal")).toBeTruthy();
   });
 
   it("references the completed mosaic asset in the reveal area", () => {

--- a/apps/web/src/app/demo/demo-client.tsx
+++ b/apps/web/src/app/demo/demo-client.tsx
@@ -25,25 +25,64 @@ const demoPlacement = {
   submissionNo: 2000,
 } satisfies MasterPlacementView;
 const demoRevealDurationMs = 3600;
+const demoRevealHoldDurationMs = 1000;
+const demoRevealHandoffDurationMs = 1600;
 const demoUnitId =
   "0xdemo0000000000000000000000000000000000000000000000000000000007d0";
-type DemoPhase = "connected" | "previewing" | "revealingOverlay" | "completed";
+type DemoPhase =
+  | "connected"
+  | "previewing"
+  | "revealingOverlay"
+  | "revealHold"
+  | "revealHandoff"
+  | "completed";
 
 export function DemoClient(): React.ReactElement {
   const [isConnected, setIsConnected] = useState(false);
   const [demoPhase, setDemoPhase] = useState<DemoPhase>("connected");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const previewUrlRef = useRef<string | null>(null);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSubmitted =
     previewUrl !== null &&
-    (demoPhase === "revealingOverlay" || demoPhase === "completed");
+    (demoPhase === "revealingOverlay" ||
+      demoPhase === "revealHold" ||
+      demoPhase === "revealHandoff" ||
+      demoPhase === "completed");
   const displaySubmittedCount = isSubmitted ? maxSlots : submittedCount;
   const completeDemoReveal = useCallback(() => {
-    setDemoPhase("completed");
+    setDemoPhase("revealHold");
+
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+    }
+
+    if (handoffTimerRef.current) {
+      clearTimeout(handoffTimerRef.current);
+    }
+
+    holdTimerRef.current = setTimeout(() => {
+      holdTimerRef.current = null;
+      setDemoPhase("revealHandoff");
+
+      handoffTimerRef.current = setTimeout(() => {
+        handoffTimerRef.current = null;
+        setDemoPhase("completed");
+      }, demoRevealHandoffDurationMs);
+    }, demoRevealHoldDurationMs);
   }, []);
 
   useEffect(() => {
     return () => {
+      if (holdTimerRef.current) {
+        clearTimeout(holdTimerRef.current);
+      }
+
+      if (handoffTimerRef.current) {
+        clearTimeout(handoffTimerRef.current);
+      }
+
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
       }
@@ -59,6 +98,16 @@ export function DemoClient(): React.ReactElement {
 
     if (!file) {
       return;
+    }
+
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+
+    if (handoffTimerRef.current) {
+      clearTimeout(handoffTimerRef.current);
+      handoffTimerRef.current = null;
     }
 
     if (previewUrlRef.current) {
@@ -151,7 +200,8 @@ export function DemoClient(): React.ReactElement {
 
             <div className="mt-4 w-full">
               <DemoProgress submittedCount={displaySubmittedCount} />
-              {previewUrl && demoPhase === "completed" ? (
+              {previewUrl &&
+              (demoPhase === "revealHandoff" || demoPhase === "completed") ? (
                 <DemoCompletionReveal originalPhotoUrl={previewUrl} />
               ) : null}
             </div>
@@ -179,8 +229,18 @@ export function DemoClient(): React.ReactElement {
         </aside>
       </div>
 
-      {previewUrl && demoPhase === "revealingOverlay" ? (
+      {previewUrl &&
+      (demoPhase === "revealingOverlay" ||
+        demoPhase === "revealHold" ||
+        demoPhase === "revealHandoff") ? (
         <DemoRevealOverlay
+          overlayState={
+            demoPhase === "revealHandoff"
+              ? "handoff"
+              : demoPhase === "revealHold"
+                ? "hold"
+                : "revealing"
+          }
           originalPhotoUrl={previewUrl}
           onComplete={completeDemoReveal}
         />
@@ -327,7 +387,10 @@ function DemoCompletionReveal({
   readonly originalPhotoUrl: string;
 }): React.ReactElement {
   return (
-    <div className="mt-8 grid gap-5" data-testid="demo-completion-reveal">
+    <div
+      className="op-demo-completion-arrival mt-8 grid gap-5"
+      data-testid="demo-completion-reveal"
+    >
       <RevealPanel
         displayName={takeru.name}
         mosaicUrl={completedMosaicSrc}
@@ -339,18 +402,24 @@ function DemoCompletionReveal({
 }
 
 function DemoRevealOverlay({
+  overlayState,
   originalPhotoUrl,
   onComplete,
 }: {
+  readonly overlayState: "revealing" | "hold" | "handoff";
   readonly originalPhotoUrl: string;
   readonly onComplete: () => void;
 }): React.ReactElement {
   const tileSources = useMemo(() => [originalPhotoUrl], [originalPhotoUrl]);
+  const isHandoff = overlayState === "handoff";
 
   return (
     <section
       aria-label="Demo full-screen reveal"
-      className="op-demo-reveal-fullscreen"
+      className={["op-demo-reveal-fullscreen", isHandoff ? "is-handoff" : ""]
+        .filter(Boolean)
+        .join(" ")}
+      data-state={overlayState}
       data-testid="demo-reveal-overlay"
     >
       <MosaicConvergence
@@ -365,6 +434,13 @@ function DemoRevealOverlay({
         showReplay={false}
         tileSources={tileSources}
       />
+      {isHandoff ? (
+        <div
+          aria-hidden="true"
+          className="op-demo-reveal-handoff"
+          data-testid="demo-reveal-handoff"
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2707,6 +2707,22 @@ a {
   min-height: 100svh;
   overflow: hidden;
   background: #050302;
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: center;
+  transition:
+    opacity 1500ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 1500ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 1500ms cubic-bezier(0.22, 1, 0.36, 1);
+  filter: blur(0) saturate(1) brightness(1);
+  will-change: opacity, filter, transform;
+}
+
+.op-demo-reveal-fullscreen.is-handoff {
+  opacity: 0;
+  transform: scale(1.018);
+  filter: blur(10px) saturate(1.18) brightness(1.12);
+  pointer-events: none;
 }
 
 .op-demo-reveal-fullscreen::after {
@@ -2737,6 +2753,71 @@ a {
   pointer-events: none;
 }
 
+.op-demo-reveal-handoff {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      115deg,
+      transparent 0%,
+      transparent 35%,
+      rgba(245, 239, 227, 0.2) 45%,
+      rgba(255, 122, 26, 0.26) 50%,
+      rgba(160, 238, 211, 0.14) 55%,
+      transparent 66%,
+      transparent 100%
+    ),
+    radial-gradient(circle at 50% 48%, rgba(255, 122, 26, 0.2), transparent 42%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transform: translateX(-18%) scale(1.04);
+  animation: op-demo-reveal-handoff-sweep 1500ms cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+.op-demo-completion-arrival {
+  animation: op-demo-completion-arrival 1100ms cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+@keyframes op-demo-reveal-handoff-sweep {
+  0% {
+    opacity: 0;
+    transform: translateX(-18%) scale(1.04);
+  }
+
+  34% {
+    opacity: 0.78;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateX(18%) scale(1.02);
+  }
+}
+
+@keyframes op-demo-completion-arrival {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.985);
+    filter: blur(10px);
+  }
+
+  58% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.005);
+    filter: blur(0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .grain::after,
   .op-btn-primary::before,
@@ -2748,12 +2829,18 @@ a {
   .op-home-teaser-image,
   .op-home-teaser-panel,
   .op-home-teaser-scan,
+  .op-demo-completion-arrival,
   .op-demo-hero-athlete.primary,
   .op-demo-grid-glow,
   .op-demo-athlete-track,
+  .op-demo-reveal-handoff,
   .op-finalize-spinner,
   .op-indeterminate-bar::after {
     animation: none;
+  }
+
+  .op-demo-reveal-fullscreen {
+    transition: none;
   }
 
   .op-hero-title .line {

--- a/apps/web/tests/e2e/demo-stage-flow.spec.ts
+++ b/apps/web/tests/e2e/demo-stage-flow.spec.ts
@@ -151,6 +151,22 @@ async function runDemoStageFlow(page: Page): Promise<void> {
     page.getByText(/Photo tiles converge into one mosaic/i),
   ).toBeVisible();
   await expectFullScreenOverlay(page);
+  await expect(page.getByTestId("demo-reveal-overlay")).toHaveAttribute(
+    "data-state",
+    "hold",
+    {
+      timeout: 10_000,
+    },
+  );
+  await expect(page.getByTestId("demo-reveal-overlay")).toHaveAttribute(
+    "data-state",
+    "handoff",
+    {
+      timeout: 10_000,
+    },
+  );
+  await expect(page.getByTestId("demo-reveal-handoff")).toBeVisible();
+  await expect(page.getByTestId("demo-completion-reveal")).toBeVisible();
   await expect(page.getByTestId("demo-reveal-overlay")).toHaveCount(0, {
     timeout: 10_000,
   });


### PR DESCRIPTION
## 概要
`/demo` の完成リビール後に画面が急に切り替わっていたため、完了後に短い静止時間を置いてから、完成パネルへゆっくりフェードするトランジションを追加しました。

## 変更内容
- `apps/web/src/app/demo/demo-client.tsx`
  - リビール完了後の状態遷移を `revealing -> hold -> handoff -> completed` に分割
  - 完了直後に1秒静止し、その後1.6秒のhandoffで完成パネルへ遷移
  - タイマーのクリーンアップを追加
- `apps/web/src/app/globals.css`
  - overlayのfade / blur / sweep演出と完成パネルのarrival animationを追加
  - reduced motionでは追加アニメーションを無効化
- `apps/web/src/app/demo/demo-client.test.tsx`
  - holdとhandoffの状態遷移をテスト
- `apps/web/tests/e2e/demo-stage-flow.spec.ts`
  - desktop/mobileのdemo flowでholdからhandoffへ進むことを確認

## 関連する Issue やチケット
なし

## 動作確認
- `corepack pnpm --filter web exec vitest run src/app/demo/demo-client.test.tsx`
- `corepack pnpm --filter web exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm --filter web exec biome check src/app/demo/demo-client.tsx src/app/demo/demo-client.test.tsx src/app/globals.css tests/e2e/demo-stage-flow.spec.ts`
- `corepack pnpm --filter web exec playwright test tests/e2e/demo-stage-flow.spec.ts --project=chromium`
